### PR TITLE
Encode mid-word line/page breaks

### DIFF
--- a/encoder/macros.xml
+++ b/encoder/macros.xml
@@ -2,6 +2,8 @@
 {% macro any_segment(segment) %}
   {% if segment.type == "LineBreak" %}
     <lb n="{{segment.index + 1}}"/>
+  {% elif segment.type == "PageBreak" %}
+    <pb facs="drs:page{{segment.index + 1}}"/>
   {% elif segment.type == "Phrase" %}
     {{ self::phrase(segment=segment) }}
   {% elif segment.type == "Block" %}

--- a/encoder/template.tera.xml
+++ b/encoder/template.tera.xml
@@ -40,10 +40,9 @@
     <group>
       <text type="source" xml:lang="chr">
         <body>
-          <pb facs="drs:page01"/>
-            {% for segment in segments %}
-              {{ macros::any_segment(segment=segment) }}
-            {% endfor %}
+          {% for segment in segments %}
+            {{ macros::any_segment(segment=segment) }}
+          {% endfor %}
         </body>
       </text>
 


### PR DESCRIPTION
These commits make sure that mid-word line breaks and both kinds of page breaks are encoded as `lb` and `pb` tags respectively.