### PR TITLE
Remove phonemic layer

### DIFF
--- a/xml/stylesheets/xhtml.xsl
+++ b/xml/stylesheets/xhtml.xsl
@@ -89,7 +89,11 @@
             <xsl:apply-templates/>
         </div>
     </xsl:template>
-    <xsl:template match="choice/seg">
+    
+    <xsl:template match="choice/seg[@type='phonemic_form']"/>
+    
+    
+    <xsl:template match="choice/seg[@type!='phonemic_form']">
         <div class="{@type}">
             <xsl:apply-templates/>
         </div>


### PR DESCRIPTION
Removed the phonemic layer from HTML output.

As mentioned in our last meeting, we want to hide the phonemic layer in the web display.

Next Steps:
Create view options to allow this sort of adjustment on-the-fly