### PR TITLE
Remove translation footnotes

### DIFF
--- a/encoder/Cargo.lock
+++ b/encoder/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "lambda",
  "lambda_http",
  "mongodb",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/encoder/Cargo.toml
+++ b/encoder/Cargo.toml
@@ -29,3 +29,4 @@ mongodb = "*"
 lambda = {git = "https://github.com/awslabs/aws-lambda-rust-runtime"}
 lambda_http = {git = "https://github.com/awslabs/aws-lambda-rust-runtime"}
 dotenv = "0.15"
+regex = "1.3"


### PR DESCRIPTION
- Clears out footnote brackets (i.e `[4]`) from translations.
- Throttles requests to the Drive API to prevent exceeding our per-second request quota. (Should fix inconsistent errors on some translation documents)