### PR TITLE
Scope all morpheme glosses to the document level

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,14 +55,9 @@ jobs:
         run: |
           cd migration
           cargo run
-      - name: Build GraphQL layer
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --target x86_64-unknown-linux-musl
       - name: Deploy GraphQL to AWS via Serverless
         run: |
+          cargo install cross
           yarn install
           yarn deploy-graphql
       - name: Publish website to Netlify

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "dailp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,13 +71,14 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f8328f0a1831cf5b3aee6f8d4376173d95541458af5ca484db180be0914dc6"
+checksum = "894f383c74764a0f8a660fb8ed20e755713d42f182b75dd768ad668a6e842c30"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
  "async-graphql-value",
+ "async-mutex",
  "async-stream 0.3.0",
  "async-trait",
  "blocking",
@@ -86,9 +87,8 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "fnv",
- "futures",
+ "futures-util",
  "indexmap",
- "itertools",
  "log",
  "lru",
  "multer",
@@ -98,7 +98,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "spin",
+ "sha2 0.9.2",
+ "spin 0.6.0",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -109,14 +110,13 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "2.0.3"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a781b93674fa6aef77f7f37c03489a320420b55a8785974cab94be3af582db8"
+checksum = "a0cef705420097c98c542dab0029306e52b14b3c8f1452113c6891869f2d6640"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
  "darling",
- "itertools",
  "proc-macro-crate",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "2.0.3"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08113484ce92f4324a0d9e64dfad2bb306ece538201ab42c5f1bd12422ad93b0"
+checksum = "ca660e5dea2757fefec931f34c7babb01ff7eb01756494f66929cbb8411cf98a"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -139,12 +139,21 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "2.0.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db49f7d7838091f7b4fe10d8632d3e5969d558045ce9167662271b7c34bbfacf"
+checksum = "57d3aa3cd3696ffd8decb10f5053affc78cb33ecfc545e480072bbc600e6723d"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
 ]
 
 [[package]]
@@ -269,7 +278,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -427,6 +445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,7 +503,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
  "subtle",
 ]
 
@@ -611,7 +635,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -867,6 +900,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,7 +1009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.8.1",
 ]
 
 [[package]]
@@ -1329,9 +1372,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18af3dcaf2b0219366cdb4e2af65a6101457b415c3d1a5c71dd9c2b7c77b9c8"
 dependencies = [
- "block-buffer",
- "digest",
- "opaque-debug",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -1468,7 +1511,7 @@ dependencies = [
  "serde_bytes",
  "serde_with",
  "sha-1",
- "sha2",
+ "sha2 0.8.2",
  "socket2",
  "stringprep",
  "strsim 0.10.0",
@@ -1590,6 +1633,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -2021,7 +2070,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
@@ -2136,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
@@ -2154,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2215,10 +2264,10 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -2227,10 +2276,23 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2290,6 +2352,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef7b840d5ef62f81f50649ade37112748461256c64a70bccefeabb4d02c515c5"
 
 [[package]]
 name = "static_assertions"

--- a/graphql/Cargo.toml
+++ b/graphql/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["full", "time"] }
 anyhow = "*"
-async-graphql = "2.0"
+async-graphql = "2.1"
 mongodb = "*"
 lambda = {git = "https://github.com/awslabs/aws-lambda-rust-runtime"}
 lambda_http = {git = "https://github.com/awslabs/aws-lambda-rust-runtime"}

--- a/graphql/src/main.rs
+++ b/graphql/src/main.rs
@@ -49,7 +49,7 @@ impl Query {
     ) -> FieldResult<Vec<AnnotatedDoc>> {
         Ok(context
             .data::<Database>()?
-            .all_documents(collection)
+            .all_documents(collection.as_ref().map(|x| &**x))
             .await?)
     }
 

--- a/migration/src/lexical.rs
+++ b/migration/src/lexical.rs
@@ -1,5 +1,9 @@
+use crate::spreadsheets::LexicalEntryWithForms;
 use crate::spreadsheets::SheetResult;
 use anyhow::Result;
+use dailp::convert_udb;
+use dailp::seg_verb_surface_forms;
+use dailp::LexicalEntry;
 use dailp::MorphemeSegment;
 use dailp::{AnnotatedForm, Database, DateTime, PositionInDocument, UniqueAnnotatedForm};
 use futures::future::join_all;
@@ -17,7 +21,7 @@ pub async fn migrate_dictionaries(db: &Database) -> Result<()> {
         SheetResult::from_sheet("1feuNOuzm0-TpotKyjebKwuXV4MYv-jnU5zLamczqu5U", None),
     );
 
-    let df1975 = df1975?.into_df1975("DF1975", 1975, 3, true, false, 2, 5, 3)?;
+    let df1975 = parse_new_df1975(df1975?, "DF1975", 1975, 3, true, false, 3, 3);
     let root_nouns = root_nouns?.into_nouns("DF1975", 1975, 1, 2)?;
     let irreg_nouns = irreg_nouns?.into_nouns("DF1975", 1975, 1, 2)?;
     let ptcp_nouns = ptcp_nouns?.into_nouns("DF1975", 1975, 1, 1)?;
@@ -65,6 +69,83 @@ pub async fn migrate_dictionaries(db: &Database) -> Result<()> {
     .await;
 
     Ok(())
+}
+
+fn parse_new_df1975(
+    sheet: SheetResult,
+    doc_id: &str,
+    year: i32,
+    translation_count: usize,
+    has_numeric: bool,
+    has_comment: bool,
+    after_root: usize,
+    translations: usize,
+) -> impl Iterator<Item = LexicalEntryWithForms> {
+    use chrono::TimeZone as _;
+    let doc_id = doc_id.to_owned();
+    sheet
+        .values
+        .into_iter()
+        // The first two rows are simply headers.
+        .skip(2)
+        .enumerate()
+        // The rest are relevant to the verb itself.
+        .filter_map(move |(index, columns)| {
+            // The columns are as follows: key, page number, root, root gloss,
+            // translations 1, 2, 3, transitivity, UDB class, blank, surface forms.
+            if columns.len() > 7 && !columns[2].is_empty() {
+                // Skip reference numbers for now.
+                let mut root_values = columns.into_iter();
+                let _key = root_values.next()?;
+                let page_number = root_values.next()?;
+                let root = root_values.next()?;
+                let root_gloss = root_values.next()?;
+                let root_id = LexicalEntry::make_id(&doc_id, &root_gloss);
+                let mut form_values = root_values.clone().skip(after_root + translations);
+                let date = DateTime::new(chrono::Utc.ymd(year, 1, 1).and_hms(0, 0, 0));
+                Some(LexicalEntryWithForms {
+                    forms: seg_verb_surface_forms(
+                        &doc_id,
+                        &date,
+                        &mut form_values,
+                        translation_count,
+                        has_numeric,
+                        has_comment,
+                        true,
+                    ),
+                    entry: UniqueAnnotatedForm {
+                        id: root_id.clone(),
+                        form: AnnotatedForm {
+                            simple_phonetics: None,
+                            normalized_source: None,
+                            phonemic: None,
+                            commentary: None,
+                            line_break: None,
+                            page_break: None,
+                            english_gloss: root_values
+                                .take(translations)
+                                .map(|s| s.trim().to_owned())
+                                .filter(|s| !s.is_empty())
+                                .collect(),
+                            segments: Some(vec![MorphemeSegment::new(
+                                convert_udb(&root).to_dailp(),
+                                root_id,
+                                None,
+                            )]),
+                            date_recorded: Some(date),
+                            source: root,
+                            position: Some(PositionInDocument {
+                                document_id: doc_id.clone(),
+                                page_number,
+                                index: index as i32 + 1,
+                            }),
+                        },
+                    },
+                })
+            } else {
+                None
+            }
+        })
 }
 
 pub async fn migrate_old_lexical(db: &Database) -> Result<()> {

--- a/migration/src/spreadsheets.rs
+++ b/migration/src/spreadsheets.rs
@@ -102,7 +102,7 @@ impl SheetResult {
                     RetryPolicy::<anyhow::Error>::ForwardError(e)
                 } else {
                     tries += 1;
-                    RetryPolicy::<anyhow::Error>::WaitRetry(Duration::from_millis(350))
+                    RetryPolicy::<anyhow::Error>::WaitRetry(Duration::from_millis(400))
                 }
             },
         )

--- a/migration/src/spreadsheets.rs
+++ b/migration/src/spreadsheets.rs
@@ -7,11 +7,12 @@ use anyhow::Result;
 use dailp::PositionInDocument;
 use dailp::{
     convert_udb, root_noun_surface_form, root_verb_surface_forms, AnnotatedDoc, AnnotatedForm,
-    AnnotatedPhrase, AnnotatedSeg, BlockType, Database, DateTime, DocumentMetadata, LexicalEntry,
-    LineBreak, MorphemeSegment, PageBreak, PersonAssociation, UniqueAnnotatedForm,
+    AnnotatedPhrase, AnnotatedSeg, BlockType, Database, DateTime, DocumentMetadata,
+    LexicalConnection, LexicalEntry, LineBreak, MorphemeSegment, PageBreak, PersonAssociation,
+    UniqueAnnotatedForm,
 };
 use futures_retry::{FutureRetry, RetryPolicy};
-use mongodb::bson::{self, Bson};
+use mongodb::bson;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fs::File, io::Write, time::Duration};
 
@@ -34,31 +35,33 @@ pub struct LexicalEntryWithForms {
 /// pushes that data into the underlying database.
 /// Existing versions of these documents are overwritten with the new data.
 pub async fn migrate_documents_to_db(
-    inputs: Vec<(DocumentMetadata, Vec<SemanticLine>)>,
+    docs: Vec<(AnnotatedDoc, Vec<LexicalConnection>)>,
     db: &Database,
 ) -> Result<()> {
-    // Combine the documents into one object.
-    let docs = inputs.into_iter().map(|(meta, lines)| {
-        let annotated = AnnotatedLine::many_from_semantic(&lines);
-        let segments = AnnotatedLine::to_segments(annotated, &meta.id, &meta.date);
-        AnnotatedDoc::new(meta, segments)
-    });
-
     // Write the contents of each document to our database.
+    let ref_db = db.connections_collection();
     let db = db.documents_collection();
-    for doc in docs {
-        if let Bson::Document(bson_doc) = bson::to_bson(&doc)? {
-            db.update_one(
-                bson::doc! {"_id": doc.meta.id},
-                bson_doc,
-                mongodb::options::UpdateOptions::builder()
-                    .upsert(true)
-                    .build(),
-            )
-            .await?;
-        } else {
-            eprintln!("Failed to make document!");
+    let upsert = mongodb::options::UpdateOptions::builder()
+        .upsert(true)
+        .build();
+
+    for (doc, refs) in docs {
+        for r in refs {
+            ref_db
+                .update_one(
+                    bson::doc! { "_id": &r.id },
+                    bson::to_document(&r)?,
+                    upsert.clone(),
+                )
+                .await?;
         }
+
+        db.update_one(
+            bson::doc! {"_id": &doc.meta.id},
+            bson::to_document(&doc)?,
+            upsert.clone(),
+        )
+        .await?;
     }
 
     Ok(())
@@ -66,17 +69,12 @@ pub async fn migrate_documents_to_db(
 
 /// Takes an unprocessed document with metadata, passing it through our TEI
 /// template to produce an xml document named like the given title.
-pub fn write_to_file(meta: DocumentMetadata, lines: &[SemanticLine]) -> Result<()> {
+pub fn write_to_file(doc: &AnnotatedDoc) -> Result<()> {
     let mut tera = tera::Tera::new("*.tera.xml")?;
-    let annotated = AnnotatedLine::many_from_semantic(lines);
-    let file_name = format!("{}/{}.xml", OUTPUT_DIR, meta.id);
+    let file_name = format!("{}/{}.xml", OUTPUT_DIR, doc.meta.id);
     println!("writing to {}", file_name);
     tera.register_filter("convert_breaks", convert_breaks);
-    let segments = AnnotatedLine::to_segments(annotated, &meta.id, &meta.date);
-    let contents = tera.render(
-        "template.tera.xml",
-        &tera::Context::from_serialize(AnnotatedDoc::new(meta, segments))?,
-    )?;
+    let contents = tera.render("template.tera.xml", &tera::Context::from_serialize(doc)?)?;
     // Make sure the output folder exists.
     std::fs::create_dir_all(OUTPUT_DIR)?;
     let mut f = File::create(file_name)?;
@@ -95,9 +93,18 @@ pub struct SheetResult {
 
 impl SheetResult {
     pub async fn from_sheet(sheet_id: &str, sheet_name: Option<&str>) -> Result<Self> {
+        let mut tries = 0;
         let (t, _attempt) = FutureRetry::new(
             move || Self::from_sheet_weak(sheet_id, sheet_name.clone()),
-            |_| RetryPolicy::<anyhow::Error>::WaitRetry(Duration::from_millis(500)),
+            |e| {
+                // Try three times before giving up.
+                if tries > 2 {
+                    RetryPolicy::<anyhow::Error>::ForwardError(e)
+                } else {
+                    tries += 1;
+                    RetryPolicy::<anyhow::Error>::WaitRetry(Duration::from_millis(350))
+                }
+            },
         )
         .await
         .map_err(|(e, _attempts)| e)?;
@@ -116,7 +123,6 @@ impl SheetResult {
     }
     /// Parse this sheet as the document index.
     pub fn into_index(self) -> Result<DocumentIndex> {
-        // Example URL: https://docs.google.com/spreadsheets/d/1sDTRFoJylUqsZlxU57k1Uj8oHhbM3MAzU8sDgTfO7Mk/edit#gid=0
         Ok(DocumentIndex {
             sheet_ids: self
                 .values
@@ -198,7 +204,7 @@ impl SheetResult {
                                 source: root,
                                 position: Some(PositionInDocument {
                                     document_id: doc_id.to_owned(),
-                                    page_number: 1,
+                                    page_number: 1.to_string(),
                                     index: index as i32 + 1,
                                 }),
                             },
@@ -232,7 +238,8 @@ impl SheetResult {
                 let root_gloss = root_values.next()?;
                 let root_id = LexicalEntry::make_id(doc_id, &root_gloss);
                 // Skip page ref.
-                let mut form_values = root_values.skip(1);
+                let page_number = root_values.next()?;
+                let mut form_values = root_values;
                 let date = DateTime::new(chrono::Utc.ymd(year, 1, 1).and_hms(0, 0, 0));
                 Some(LexicalEntryWithForms {
                     forms: root_verb_surface_forms(
@@ -266,7 +273,7 @@ impl SheetResult {
                             position: Some(PositionInDocument {
                                 document_id: doc_id.to_owned(),
                                 index: idx as i32 + 1,
-                                page_number: 1,
+                                page_number,
                             }),
                         },
                     },
@@ -323,7 +330,7 @@ impl SheetResult {
                                 position: Some(PositionInDocument {
                                     document_id: doc_id.to_owned(),
                                     index: idx as i32 + 1,
-                                    page_number: 1,
+                                    page_number: 1.to_string(),
                                 }),
                                 normalized_source: None,
                                 simple_phonetics: None,
@@ -344,6 +351,23 @@ impl SheetResult {
                     })
                 } else {
                     None
+                }
+            })
+            .collect())
+    }
+
+    pub async fn into_references(self, doc_id: &str) -> Result<Vec<dailp::LexicalConnection>> {
+        // First column is the name of the field, useless when parsing so we ignore it.
+        let values = self.values.into_iter().skip(1);
+
+        Ok(values
+            .map(|mut row| {
+                let from = format!("{}:{}", doc_id, row.remove(0));
+                let to = row.remove(0);
+                dailp::LexicalConnection {
+                    id: format!("{}->{}", from, to),
+                    from,
+                    to,
                 }
             })
             .collect())
@@ -515,13 +539,12 @@ impl SemanticLine {
 
 #[derive(Serialize, Deserialize)]
 pub struct AnnotatedLine {
-    number: String,
     pub words: Vec<AnnotatedForm>,
     ends_page: bool,
 }
 
 impl<'a> AnnotatedLine {
-    pub fn many_from_semantic(lines: &[SemanticLine]) -> Vec<Self> {
+    pub fn many_from_semantic(lines: &[SemanticLine], meta: &DocumentMetadata) -> Vec<Self> {
         let mut word_index = 0;
         lines
             .into_iter()
@@ -546,7 +569,7 @@ impl<'a> AnnotatedLine {
                                 .map(|x| x.replace("ʔ", "'")),
                             phonemic: line.rows[3].items.get(i).map(|x| x.to_owned()),
                             segments: if let (Some(m), Some(g)) = (morphemes, glosses) {
-                                MorphemeSegment::parse_many(m, g)
+                                MorphemeSegment::parse_many(m, g, Some(&meta.id))
                             } else {
                                 None
                             },
@@ -569,7 +592,6 @@ impl<'a> AnnotatedLine {
                     })
                     .collect();
                 Self {
-                    number: line.number.clone(),
                     words,
                     ends_page: line.ends_page,
                 }
@@ -615,7 +637,7 @@ impl<'a> AnnotatedLine {
                     position: Some(PositionInDocument {
                         index: word_idx,
                         document_id: document_id.to_owned(),
-                        page_number: page_num,
+                        page_number: page_num.to_string(),
                     }),
                     date_recorded: date.clone(),
                     ..word

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "dailp"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Taylor Snead <taylorsnead@gmail.com>"]
 edition = "2018"
 
 [lib]
 name = "dailp"
 path = "src/lib.rs"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 serde = {version = "1.0", features = ["derive"]}

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -16,7 +16,7 @@ tera = "1"
 tokio = { version = "0.2", features = ["full", "time"] }
 anyhow = "1.0"
 itertools = "0.9"
-async-graphql = "2.0"
+async-graphql = "2.1"
 futures = "0.3"
 mongodb = "1.1"
 lazy_static = "1.4"

--- a/types/src/database.rs
+++ b/types/src/database.rs
@@ -56,7 +56,7 @@ impl Database {
             .and_then(|doc| bson::from_document(doc).ok()))
     }
 
-    pub async fn all_documents(&self, collection: Option<String>) -> Result<Vec<AnnotatedDoc>> {
+    pub async fn all_documents(&self, collection: Option<&str>) -> Result<Vec<AnnotatedDoc>> {
         use tokio::stream::StreamExt as _;
         Ok(self
             .documents_collection()

--- a/types/src/document.rs
+++ b/types/src/document.rs
@@ -211,7 +211,7 @@ impl DocumentCollection {
     ) -> async_graphql::FieldResult<Vec<AnnotatedDoc>> {
         Ok(context
             .data::<Database>()?
-            .all_documents(Some(self.name.clone()))
+            .all_documents(Some(&*self.name))
             .await?)
     }
 }

--- a/types/src/gloss.rs
+++ b/types/src/gloss.rs
@@ -17,6 +17,7 @@ const SEPARATORS: &str = "-=~\\";
 pub fn parse_gloss_layers<'a>(
     layer_one: &'a str,
     layer_two: &'a str,
+    root_prefix: Option<&'a str>,
 ) -> IResult<&'a [u8], Vec<MorphemeSegment>> {
     let (_, one) = gloss_line(layer_one.as_bytes())?;
     let (_, two) = gloss_line(layer_two.as_bytes())?;
@@ -25,9 +26,19 @@ pub fn parse_gloss_layers<'a>(
         one.into_iter()
             .zip(two)
             .map(|(a, b)| {
+                let gloss = String::from_utf8_lossy(b.tag);
+                let gloss = if let Some(prefix) = root_prefix {
+                    if gloss.contains(|c: char| c.is_lowercase()) {
+                        format!("{}:{}", prefix, gloss)
+                    } else {
+                        gloss.into_owned()
+                    }
+                } else {
+                    gloss.into_owned()
+                };
                 MorphemeSegment::new(
                     String::from_utf8_lossy(a.tag).into_owned(),
-                    String::from_utf8_lossy(b.tag).into_owned(),
+                    gloss,
                     // The gloss line is most likely to have the correct separator.
                     b.followed_by,
                 )

--- a/types/src/gloss.rs
+++ b/types/src/gloss.rs
@@ -27,14 +27,15 @@ pub fn parse_gloss_layers<'a>(
             .zip(two)
             .map(|(a, b)| {
                 let gloss = String::from_utf8_lossy(b.tag);
+                let gloss = gloss.trim();
                 let gloss = if let Some(prefix) = root_prefix {
                     if gloss.contains(|c: char| c.is_lowercase()) {
                         format!("{}:{}", prefix, gloss)
                     } else {
-                        gloss.into_owned()
+                        gloss.to_owned()
                     }
                 } else {
-                    gloss.into_owned()
+                    gloss.to_owned()
                 };
                 MorphemeSegment::new(
                     String::from_utf8_lossy(a.tag).into_owned(),

--- a/types/src/lexical.rs
+++ b/types/src/lexical.rs
@@ -79,11 +79,11 @@ impl LexicalEntry {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct PositionInDocument {
     pub document_id: String,
-    pub page_number: i32,
+    pub page_number: String,
     pub index: i32,
 }
 impl PositionInDocument {
-    pub fn new(document_id: String, page_number: i32, index: i32) -> Self {
+    pub fn new(document_id: String, page_number: String, index: i32) -> Self {
         Self {
             document_id,
             page_number,
@@ -113,8 +113,8 @@ impl PositionInDocument {
     }
 
     /// 1-indexed page number
-    async fn page_number(&self) -> i32 {
-        self.page_number
+    async fn page_number(&self) -> &str {
+        &self.page_number
     }
 
     /// 1-indexed position indicating where the form sits in the ordering of all
@@ -228,16 +228,16 @@ pub fn root_verb_surface_form(
 
     Some(UniqueAnnotatedForm {
         form: AnnotatedForm {
-            position: Some(PositionInDocument {
-                document_id: doc_id.to_owned(),
-                index: 1,
-                page_number: 1,
-            }),
+            position: Some(PositionInDocument::new(doc_id.to_owned(), 1.to_string(), 1)),
             source: syllabary.clone(),
             normalized_source: None,
             simple_phonetics: Some(phonetic),
             phonemic: Some(convert_udb(&phonemic).to_dailp()),
-            segments: Some(MorphemeSegment::parse_many(&morpheme_layer, &gloss_layer)?),
+            segments: Some(MorphemeSegment::parse_many(
+                &morpheme_layer,
+                &gloss_layer,
+                None,
+            )?),
             english_gloss: translations,
             commentary,
             line_break: None,
@@ -303,16 +303,16 @@ pub fn root_noun_surface_form(
 
     Some(UniqueAnnotatedForm {
         form: AnnotatedForm {
-            position: Some(PositionInDocument {
-                document_id: doc_id.to_owned(),
-                index: 1,
-                page_number: 1,
-            }),
+            position: Some(PositionInDocument::new(doc_id.to_owned(), 1.to_string(), 1)),
             source: syllabary,
             normalized_source: None,
             simple_phonetics: Some(phonetic),
             phonemic: Some(convert_udb(&phonemic).to_dailp()),
-            segments: Some(MorphemeSegment::parse_many(&morpheme_layer, &gloss_layer)?),
+            segments: Some(MorphemeSegment::parse_many(
+                &morpheme_layer,
+                &gloss_layer,
+                None,
+            )?),
             english_gloss: translations.collect(),
             commentary: None,
             line_break: None,

--- a/types/src/lexical.rs
+++ b/types/src/lexical.rs
@@ -134,6 +134,91 @@ pub struct LexicalConnection {
     pub to: String,
 }
 
+pub fn seg_verb_surface_forms(
+    doc_id: &str,
+    date: &DateTime,
+    cols: &mut impl Iterator<Item = String>,
+    translation_count: usize,
+    has_numeric: bool,
+    has_comment: bool,
+    has_spacer: bool,
+) -> Vec<UniqueAnnotatedForm> {
+    let mut forms = Vec::new();
+    while let Some(form) = seg_verb_surface_form(
+        doc_id,
+        date,
+        cols,
+        translation_count,
+        has_numeric,
+        has_comment,
+        has_spacer,
+    ) {
+        forms.push(form);
+    }
+    forms
+}
+
+pub fn seg_verb_surface_form(
+    doc_id: &str,
+    date: &DateTime,
+    cols: &mut impl Iterator<Item = String>,
+    translation_count: usize,
+    has_numeric: bool,
+    has_comment: bool,
+    has_spacer: bool,
+) -> Option<UniqueAnnotatedForm> {
+    // Each form has an empty column before it.
+    // Then follows the morphemic segmentation.
+    // All tags except the last one come before the root.
+    let morpheme_layer = cols.next().filter(|s| !s.is_empty())?;
+    let gloss_layer = cols.next().filter(|s| !s.is_empty())?;
+    // Then, the representations of the full word.
+    let phonemic = cols.next().filter(|s| !s.is_empty())?;
+    let _numeric = if has_numeric {
+        cols.next().filter(|s| !s.is_empty())?
+    } else {
+        String::new()
+    };
+    let phonetic = cols.next().filter(|s| !s.is_empty())?;
+    let syllabary = cols.next().filter(|s| !s.is_empty())?;
+    // Finally, up to three translations of the word.
+    let mut translations = Vec::new();
+    for _ in 0..translation_count {
+        let t = cols.next()?;
+        if !t.is_empty() {
+            translations.push(t);
+        }
+    }
+
+    let commentary = if has_comment {
+        Some(cols.next()?)
+    } else {
+        None
+    };
+    if has_spacer {
+        cols.next();
+    }
+
+    let segments = MorphemeSegment::parse_many(&morpheme_layer, &gloss_layer, Some(doc_id))?;
+
+    Some(UniqueAnnotatedForm {
+        id: MorphemeSegment::gloss_layer(&segments),
+        form: AnnotatedForm {
+            position: Some(PositionInDocument::new(doc_id.to_owned(), 1.to_string(), 1)),
+            source: syllabary.clone(),
+            normalized_source: None,
+            simple_phonetics: Some(phonetic),
+            phonemic: Some(convert_udb(&phonemic).to_dailp()),
+            segments: Some(segments),
+            english_gloss: translations,
+            commentary,
+            line_break: None,
+            page_break: None,
+            date_recorded: Some(date.clone()),
+        },
+    })
+}
+
 /// Gather many verb surface forms from the given row.
 pub fn root_verb_surface_forms(
     doc_id: &str,

--- a/types/src/morpheme.rs
+++ b/types/src/morpheme.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use async_graphql::FieldResult;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 /// A single unit of meaning and its corresponding English gloss.
 #[derive(Serialize, Clone, Deserialize, Debug)]
@@ -40,28 +41,38 @@ impl MorphemeSegment {
 #[async_graphql::Object(cache_control(max_age = 60))]
 impl MorphemeSegment {
     /// Phonemic representation of the morpheme
-    async fn morpheme(&self, system: Option<CherokeeOrthography>) -> String {
+    async fn morpheme(&self, system: Option<CherokeeOrthography>) -> Cow<'_, str> {
         match system {
-            Some(CherokeeOrthography::Dt) => convert_tth_to_dt(&self.morpheme, false),
-            _ => self.morpheme.clone(),
+            Some(CherokeeOrthography::Dt) => Cow::Owned(convert_tth_to_dt(&self.morpheme, false)),
+            _ => Cow::Borrowed(&*self.morpheme),
         }
     }
 
     /// English gloss for display
-    async fn display_gloss(&self, context: &async_graphql::Context<'_>) -> FieldResult<String> {
+    async fn display_gloss(
+        &self,
+        context: &async_graphql::Context<'_>,
+    ) -> FieldResult<Cow<'_, str>> {
         Ok(context
             .data::<Database>()?
             .lexical_entry(&self.gloss)
             .await?
-            .and_then(|entry| entry.form.english_gloss.get(0).map(|x| x.clone()))
-            .unwrap_or_else(|| {
-                if self.gloss.contains(|c: char| c.is_lowercase()) {
-                    self.gloss.splitn(2, ":").last().unwrap().to_owned()
+            .and_then(|mut entry| {
+                if entry.form.english_gloss.is_empty() {
+                    None
                 } else {
-                    self.gloss.clone()
+                    Some(Cow::Owned(entry.form.english_gloss.remove(0)))
                 }
             })
-            .to_owned())
+            .unwrap_or_else(|| {
+                // Strip the document ID from scoped glosses.
+                // TODO Make a function for checking if a morpheme is a tag or root.
+                if self.gloss.contains(|c: char| c.is_lowercase()) {
+                    Cow::Borrowed(self.gloss.splitn(2, ":").last().unwrap())
+                } else {
+                    Cow::Borrowed(&*self.gloss)
+                }
+            }))
     }
 
     /// English gloss in standard DAILP format that refers to a lexical item

--- a/types/src/morpheme.rs
+++ b/types/src/morpheme.rs
@@ -27,8 +27,12 @@ impl MorphemeSegment {
         }
     }
 
-    pub fn parse_many(morpheme_layer: &str, gloss_layer: &str) -> Option<Vec<Self>> {
-        let (_, result) = parse_gloss_layers(morpheme_layer, gloss_layer).ok()?;
+    pub fn parse_many(
+        morpheme_layer: &str,
+        gloss_layer: &str,
+        document_id: Option<&str>,
+    ) -> Option<Vec<Self>> {
+        let (_, result) = parse_gloss_layers(morpheme_layer, gloss_layer, document_id).ok()?;
         Some(result)
     }
 }
@@ -50,7 +54,13 @@ impl MorphemeSegment {
             .lexical_entry(&self.gloss)
             .await?
             .and_then(|entry| entry.form.english_gloss.get(0).map(|x| x.clone()))
-            .unwrap_or_else(|| self.gloss.clone())
+            .unwrap_or_else(|| {
+                if self.gloss.contains(|c: char| c.is_lowercase()) {
+                    self.gloss.splitn(2, ":").last().unwrap().to_owned()
+                } else {
+                    self.gloss.clone()
+                }
+            })
             .to_owned())
     }
 

--- a/website/src/__generated__/gatsby-types.d.ts
+++ b/website/src/__generated__/gatsby-types.d.ts
@@ -236,7 +236,7 @@ type Dailp_morphemesByDocumentArgs = {
 
 type Dailp_morphemeTimeClustersArgs = {
   gloss: Scalars['String'];
-  clusterYears: Scalars['Int'];
+  clusterYears?: Scalars['Int'];
 };
 
 


### PR DESCRIPTION
- Scopes all bare morpheme glosses in a manuscript (i.e. `die.human`) to that document. So if that annotation is contained in `WJ20`, it becomes `WJ20:die.human` upon ingestion.
- When we display such morphemes, we can strip the document ID from the front so that `WJ20:die.human` becomes `die.human` again.
- This is useful in the back-end because we can disambiguate between roots found in disparate documents that may or may not be related by their name. This eliminates the assumption that `die.human` in `EFN1` is exactly equivalent to `die.human` in `EFN9`, or to the root `die.human` from `DF1975`, by giving them each unique identifiers and a mechanism for annotating them as related.
- Relating our scoped forms like `WJ20:die.human` requires now adding a `References` page to the `WJ20` Google sheet which contains rows that link the document local form to other related forms. This acts like a citation, saying "this form looks like another form we've seen before." That looks like the following table:

| Morpheme Gloss | Related To |
|---|---|
| die.human | DF1975:die.human |
| sink | DF1975:sink |
| man | AG1836:man |
| dig | EFN1:dig |

When you search, then, for surface forms related to `DF1975:sink`, all instances of `sink` in `WJ20` will show up. This allows us to leave our annotations as they are while adding the `References` page to create links across our data.

**Important note:** The last row in that table connects `WJ20:dig` and `EFN1:dig`, which are both in DAILP manuscripts, rather than one being from a reference source like `DF1975`. This means we can develop concordance without necessarily binding a form to a reference. So if we find a root that occurs in multiple DAILP manuscripts, but has no attested instances elsewhere, we can simply link our instances together in this fashion.