### PR TITLE
Enrich tag information in context

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo
       - name: Run unit tests
         run: cargo test --release
       - name: Configure AWS credentials

--- a/website/package.json
+++ b/website/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "description": "Front-end for exploring Cherokee documents from DAILP",
   "scripts": {
-    "start": "GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY=2 GATSBY_CONCURRENT_DOWNLOAD=5 gatsby develop",
-    "build": "GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY=2 GATSBY_CONCURRENT_DOWNLOAD=5 gatsby build",
+    "start": "GATSBY_CONCURRENT_DOWNLOAD=5 gatsby develop",
+    "build": "GATSBY_CONCURRENT_DOWNLOAD=5 gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean"
   },

--- a/website/src/__generated__/gatsby-types.d.ts
+++ b/website/src/__generated__/gatsby-types.d.ts
@@ -412,6 +412,7 @@ type Dailp_MorphemeSegment = {
 
 type Dailp_MorphemeSegment_morphemeArgs = {
   system: Maybe<Dailp_CherokeeOrthography>;
+  simplify: Maybe<Scalars['Boolean']>;
 };
 
 type Dailp_MorphemeTag = {
@@ -10346,11 +10347,11 @@ type ContentPageQuery = { readonly page: Maybe<Pick<WpPage, 'title' | 'content'>
 type FormFieldsFragment = (
   Pick<Dailp_AnnotatedForm, 'index' | 'source' | 'simplePhonetics' | 'phonemic' | 'englishGloss' | 'commentary'>
   & { readonly segments: Maybe<ReadonlyArray<(
-    Pick<Dailp_MorphemeSegment, 'morpheme' | 'gloss' | 'nextSeparator'>
-    & { simpleMorpheme: Dailp_MorphemeSegment['morpheme'] }
+    Pick<Dailp_MorphemeSegment, 'gloss' | 'nextSeparator'>
+    & { shapeTth: Dailp_MorphemeSegment['morpheme'], shapeDt: Dailp_MorphemeSegment['morpheme'], shapeDtSimple: Dailp_MorphemeSegment['morpheme'] }
     & { readonly matchingTag: Maybe<(
       Pick<Dailp_MorphemeTag, 'id'>
-      & { readonly taoc: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly learner: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly crg: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>> }
+      & { readonly taoc: Maybe<Pick<Dailp_TagForm, 'tag' | 'title'>>, readonly learner: Maybe<Pick<Dailp_TagForm, 'tag' | 'title'>>, readonly crg: Maybe<Pick<Dailp_TagForm, 'tag' | 'title'>> }
     )> }
   )>> }
 );
@@ -10420,5 +10421,18 @@ type IndexPageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type IndexPageQuery = { readonly dailp: { readonly allCollections: ReadonlyArray<Pick<Dailp_DocumentCollection, 'name' | 'slug'>> }, readonly aboutPage: Maybe<Pick<WpPage, 'title' | 'content'>> };
+
+type homesneadpiedailpEncodingwebsitesrcfooterTsx1552981879QueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type homesneadpiedailpEncodingwebsitesrcfooterTsx1552981879Query = { readonly currentBuildDate: Maybe<Pick<CurrentBuildDate, 'currentDate'>> };
+
+type homesneadpiedailpEncodingwebsitesrcmenuTsx2377851188QueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type homesneadpiedailpEncodingwebsitesrcmenuTsx2377851188Query = { readonly wpMenu: Maybe<{ readonly menuItems: Maybe<{ readonly nodes: Maybe<ReadonlyArray<Maybe<(
+        Pick<WpMenuItem, 'label' | 'path'>
+        & { readonly childItems: Maybe<{ readonly nodes: Maybe<ReadonlyArray<Maybe<Pick<WpMenuItem, 'label' | 'path'>>>> }> }
+      )>>> }> }> };
 
 }

--- a/website/src/templates/annotated-document.tsx
+++ b/website/src/templates/annotated-document.tsx
@@ -48,9 +48,11 @@ const AnnotatedDocumentPage = (p: {
   }, [experienceLevel.state])
 
   let tagSet = TagSet.Dailp
-  if (experienceLevel.state! >= ExperienceLevel.AdvancedDt) {
+  if (experienceLevel.state! === ExperienceLevel.AdvancedTth) {
     tagSet = TagSet.Taoc
-  } else if (experienceLevel.state! >= ExperienceLevel.Learner) {
+  } else if (experienceLevel.state! === ExperienceLevel.AdvancedDt) {
+    tagSet = TagSet.Crg
+  } else if (experienceLevel.state! === ExperienceLevel.Learner) {
     tagSet = TagSet.Learner
   }
 

--- a/website/src/templates/annotated-document.tsx
+++ b/website/src/templates/annotated-document.tsx
@@ -32,7 +32,6 @@ enum Tabs {
 const AnnotatedDocumentPage = (p: {
   data: GatsbyTypes.AnnotatedDocumentQuery
 }) => {
-  const isSSR = typeof window === "undefined"
   const doc = p.data.dailp.document!
   const tabs = useScrollableTabState({ selectedId: Tabs.ANNOTATION })
   const dialog = useDialogState()
@@ -48,10 +47,12 @@ const AnnotatedDocumentPage = (p: {
     Cookies.set("experienceLevel", experienceLevel.state!.toString())
   }, [experienceLevel.state])
 
-  const tagSet =
-    experienceLevel.state! > ExperienceLevel.Learner
-      ? TagSet.Taoc
-      : TagSet.Learner
+  let tagSet = TagSet.Dailp
+  if (experienceLevel.state! >= ExperienceLevel.AdvancedDt) {
+    tagSet = TagSet.Taoc
+  } else if (experienceLevel.state! >= ExperienceLevel.Learner) {
+    tagSet = TagSet.Learner
+  }
 
   return (
     <Layout title={doc.title}>
@@ -67,6 +68,7 @@ const AnnotatedDocumentPage = (p: {
                 documentId={doc.id}
                 segment={selectedMorpheme}
                 dialog={dialog}
+                tagSet={tagSet}
               />
             ) : null}
           </Dialog>
@@ -235,22 +237,27 @@ const docHeader = css`
   }
 `
 
-const thingIsNaN = (l: any) => isNaN(Number(l))
+const notNumber = (l: any) => isNaN(Number(l))
+const levelNameMapping = {
+  [ExperienceLevel.Story]: "Story",
+  [ExperienceLevel.Basic]: "Basic",
+  [ExperienceLevel.Learner]: "Learner",
+  [ExperienceLevel.AdvancedDt]: "Advanced (d/t)",
+  [ExperienceLevel.AdvancedTth]: "Advanced (t/th)",
+}
 
 const ExperiencePicker = (p: { radio: RadioStateReturn }) => {
   return (
     <RadioGroup {...p.radio} className={levelGroup}>
       {Object.keys(ExperienceLevel)
-        .filter(thingIsNaN)
+        .filter(notNumber)
         .map(function (level: string) {
+          const value = ExperienceLevel[level as keyof typeof ExperienceLevel]
           return (
             <label key={level} className={levelLabel}>
-              <Radio
-                {...p.radio}
-                value={ExperienceLevel[level as keyof typeof ExperienceLevel]}
-              />
+              <Radio {...p.radio} value={value} />
               {"  "}
-              {level}
+              {levelNameMapping[value]}
             </label>
           )
         })}
@@ -321,25 +328,23 @@ export const query = graphql`
     simplePhonetics
     phonemic
     segments {
-      morpheme
-      simpleMorpheme: morpheme(system: LEARNER)
+      shapeTth: morpheme(system: TAOC)
+      shapeDt: morpheme(system: CRG)
+      shapeDtSimple: morpheme(system: LEARNER)
       gloss
       matchingTag {
         id
         taoc {
           tag
           title
-          definition
         }
         learner {
           tag
           title
-          definition
         }
         crg {
           tag
           title
-          definition
         }
       }
       nextSeparator

--- a/website/src/types.ts
+++ b/website/src/types.ts
@@ -2,10 +2,12 @@ export enum ExperienceLevel {
   Story = 0,
   Basic = 1,
   Learner = 2,
-  Advanced = 3,
+  AdvancedDt = 3,
+  AdvancedTth = 4,
 }
 
 export enum TagSet {
+  Dailp,
   Taoc,
   Learner,
   Crg,
@@ -14,3 +16,19 @@ export enum TagSet {
 export type BasicMorphemeSegment = NonNullable<
   GatsbyTypes.FormFieldsFragment["segments"]
 >[0]
+
+export type BasicMorphemeTag = BasicMorphemeSegment["matchingTag"]
+
+export const morphemeDisplayTag = (tag: BasicMorphemeTag, tagSet: TagSet) => {
+  let matchingTag = null
+  if (tag) {
+    if (tagSet === TagSet.Learner) {
+      matchingTag = tag.learner || tag.crg
+    } else if (tagSet === TagSet.Taoc) {
+      matchingTag = tag.taoc
+    } else if (tagSet === TagSet.Crg) {
+      matchingTag = tag.crg
+    }
+  }
+  return matchingTag
+}


### PR DESCRIPTION
After a long bout of setup and configuration, I'm back to making actual PRs instead of pushing recklessly to `main` (for the front-end at least). This PR is intended to enhance the information we show about each functional morpheme in context.
So far completed:
- [x] Show morpheme title in a tooltip.
- [x] Show the title and definition in the selected morpheme dialog, if available.
- [x] Split the "Advanced" mode into "Advanced (d/t)" and "Advanced (t/th)".

What's left?
- [x] Validate `d/t` and `t/th` against our orthography charts. I think this also means giving "Advanced (d/t)" its vowel length + tone back.
- [x] Use CRG tag set for Advanced (d/t)

[Preview](https://deploy-preview-68--dailp.netlify.app/)