### PR TITLE
Add 404 page

### DIFF
--- a/cf-templates/website.template.yaml
+++ b/cf-templates/website.template.yaml
@@ -25,6 +25,10 @@ Resources:
       Repository: ${env:GIT_REPOSITORY_URL}
       OauthToken: ${env:OAUTH_TOKEN}
       IAMServiceRole: !GetAtt AmplifyRole.Arn
+      CustomRules:
+        - Source: "/<*>"
+          Status: 404-200
+          Target: "/404.html"
       BuildSpec:
         Fn::Sub:
           - |-

--- a/website/src/pages/404.tsx
+++ b/website/src/pages/404.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+import { Link } from "gatsby"
+import Layout from "../layout"
+
+export default () => (
+  <Layout title="Not Found">
+    <main>
+      <h1>Page Not Found</h1>
+      <p>
+        We aren't sure what page you were looking for.{" "}
+        <Link to="/">View our collection of Cherokee manuscripts</Link>
+      </p>
+    </main>
+  </Layout>
+)


### PR DESCRIPTION
Adds gatsby-compatible 404 page under pages/404.tsx and a rewrite rule
for Amplify.