### PR TITLE
Question mark segment helper

### DIFF
--- a/website/src/__generated__/gatsby-types.d.ts
+++ b/website/src/__generated__/gatsby-types.d.ts
@@ -10339,19 +10339,6 @@ type Unnamed_1_QueryVariables = Exact<{ [key: string]: never; }>;
 
 type Unnamed_1_Query = { readonly currentBuildDate: Maybe<Pick<CurrentBuildDate, 'currentDate'>> };
 
-type IndexPageQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type IndexPageQuery = { readonly dailp: { readonly allCollections: ReadonlyArray<Pick<Dailp_DocumentCollection, 'name' | 'slug'>> }, readonly aboutPage: Maybe<Pick<WpPage, 'title' | 'content'>> };
-
-type GlossaryQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type GlossaryQuery = { readonly dailp: { readonly allTags: ReadonlyArray<(
-      Pick<Dailp_MorphemeTag, 'id' | 'morphemeType'>
-      & { readonly crg: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly taoc: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly learner: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>> }
-    )> } };
-
 type Unnamed_2_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -10388,12 +10375,10 @@ type FormFieldsFragment = (
   )>> }
 );
 
-type ContentPageQueryVariables = Exact<{
-  id: Scalars['String'];
-}>;
+type IndexPageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type ContentPageQuery = { readonly page: Maybe<Pick<WpPage, 'title' | 'content'>> };
+type IndexPageQuery = { readonly dailp: { readonly allCollections: ReadonlyArray<Pick<Dailp_DocumentCollection, 'name' | 'slug'>> }, readonly aboutPage: Maybe<Pick<WpPage, 'title' | 'content'>> };
 
 type CollectionQueryVariables = Exact<{
   name: Scalars['String'];
@@ -10405,6 +10390,31 @@ type CollectionQuery = { readonly dailp: { readonly allDocuments: ReadonlyArray<
       Pick<Dailp_AnnotatedDoc, 'id' | 'slug' | 'title'>
       & { readonly date: Maybe<Pick<Dailp_DateTime, 'year'>> }
     )> }, readonly wpPage: Maybe<Pick<WpPage, 'content'>> };
+
+type GlossaryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type GlossaryQuery = { readonly dailp: { readonly allTags: ReadonlyArray<(
+      Pick<Dailp_MorphemeTag, 'id' | 'morphemeType'>
+      & { readonly crg: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly taoc: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly learner: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>> }
+    )> } };
+
+type DocumentDetailsQueryVariables = Exact<{
+  id: Scalars['String'];
+}>;
+
+
+type DocumentDetailsQuery = { readonly dailp: { readonly document: Maybe<(
+      Pick<Dailp_AnnotatedDoc, 'id' | 'slug' | 'title'>
+      & { readonly collection: Maybe<Pick<Dailp_DocumentCollection, 'name' | 'slug'>>, readonly date: Maybe<Pick<Dailp_DateTime, 'year'>>, readonly contributors: ReadonlyArray<Pick<Dailp_Contributor, 'name' | 'role'>>, readonly sources: ReadonlyArray<Pick<Dailp_SourceAttribution, 'name' | 'link'>> }
+    )> } };
+
+type ContentPageQueryVariables = Exact<{
+  id: Scalars['String'];
+}>;
+
+
+type ContentPageQuery = { readonly page: Maybe<Pick<WpPage, 'title' | 'content'>> };
 
 type GatsbyImageSharpFixedFragment = Pick<ImageSharpFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;
 
@@ -10455,15 +10465,5 @@ type GatsbyImageSharpSizes_withWebp_tracedSVGFragment = Pick<ImageSharpSizes, 't
 type GatsbyImageSharpSizes_noBase64Fragment = Pick<ImageSharpSizes, 'aspectRatio' | 'src' | 'srcSet' | 'sizes'>;
 
 type GatsbyImageSharpSizes_withWebp_noBase64Fragment = Pick<ImageSharpSizes, 'aspectRatio' | 'src' | 'srcSet' | 'srcWebp' | 'srcSetWebp' | 'sizes'>;
-
-type DocumentDetailsQueryVariables = Exact<{
-  id: Scalars['String'];
-}>;
-
-
-type DocumentDetailsQuery = { readonly dailp: { readonly document: Maybe<(
-      Pick<Dailp_AnnotatedDoc, 'id' | 'slug' | 'title'>
-      & { readonly collection: Maybe<Pick<Dailp_DocumentCollection, 'name' | 'slug'>>, readonly date: Maybe<Pick<Dailp_DateTime, 'year'>>, readonly contributors: ReadonlyArray<Pick<Dailp_Contributor, 'name' | 'role'>>, readonly sources: ReadonlyArray<Pick<Dailp_SourceAttribution, 'name' | 'link'>> }
-    )> } };
 
 }

--- a/website/src/layout.tsx
+++ b/website/src/layout.tsx
@@ -100,6 +100,7 @@ css`
 
     html {
       font-size: ${theme.fontSizes.root} !important;
+      overflow: hidden;
       ${theme.mediaQueries.print} {
         font-size: 11pt !important;
       }
@@ -107,6 +108,9 @@ css`
 
     body {
       margin: 0;
+      padding: 0;
+      overflow-y: auto;
+      max-height: 100vh;
       background-color: ${theme.colors.footer} !important;
       ${theme.mediaQueries.print} {
         background-color: none !important;

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -215,7 +215,7 @@ const MorphemeSegment = (p: {
     ? cx(morphemeButton, smallCaps)
     : morphemeButton
 
-  let content = <>gloss</>
+  let content = <>{gloss}</>
   if (matchingTag && matchingTag.title) {
     content = <abbr title={matchingTag.title}>{gloss}</abbr>
   } else if (gloss === "?") {

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -215,31 +215,22 @@ const MorphemeSegment = (p: {
     ? cx(morphemeButton, smallCaps)
     : morphemeButton
 
+  let content = <>gloss</>
   if (matchingTag && matchingTag.title) {
-    return (
-      <>
-        <DialogDisclosure
-          {...p.dialog}
-          className={buttonStyle}
-          onClick={() => p.onOpenDetails(p.segment)}
-        >
-          <abbr title={matchingTag.title}>{gloss}</abbr>
-        </DialogDisclosure>
-      </>
-    )
-  } else if (gloss) {
-    return (
-      <DialogDisclosure
-        {...p.dialog}
-        className={buttonStyle}
-        onClick={() => p.onOpenDetails(p.segment)}
-      >
-        {gloss}
-      </DialogDisclosure>
-    )
-  } else {
-    return null
+    content = <abbr title={matchingTag.title}>{gloss}</abbr>
+  } else if (gloss === "?") {
+    content = <abbr title="Unanalyzed or unknown segment">{gloss}</abbr>
   }
+
+  return (
+    <DialogDisclosure
+      {...p.dialog}
+      className={buttonStyle}
+      onClick={() => p.onOpenDetails(p.segment)}
+    >
+      {content}
+    </DialogDisclosure>
+  )
 }
 
 const smallCaps = css`


### PR DESCRIPTION
Add tooltip to question mark morphemes that says `Unanalyzed or unknown segment`. Feedback is welcome on the exact text and how we should treat these segments on the website, visually or functionally. @jgbourns 

Resolves #60.

[Preview link](https://deploy-preview-72--dailp.netlify.app/documents/wj56#w50)