### PR TITLE
Add pagination to manuscript images

### DIFF
--- a/website/src/layout.tsx
+++ b/website/src/layout.tsx
@@ -189,6 +189,11 @@ css`
       }
     }
 
+    hr {
+      width: 40%;
+      margin: auto;
+    }
+
     button,
     input[type="radio"] {
       cursor: pointer;

--- a/website/src/layout.tsx
+++ b/website/src/layout.tsx
@@ -149,7 +149,10 @@ css`
       }
     }
 
-    *:focus {
+    button:focus,
+    a:focus,
+    img:focus,
+    *[tabindex]:focus {
       outline-color: ${theme.colors.link};
       outline-style: solid;
       outline-width: thin;

--- a/website/src/page-image.tsx
+++ b/website/src/page-image.tsx
@@ -1,42 +1,87 @@
-import React from "react"
-import { css } from "linaria"
-import theme from "./theme"
+import React, { useRef, useState } from "react"
+import { css, cx } from "linaria"
+import theme, { hideOnPrint, std } from "./theme"
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch"
 import { Helmet } from "react-helmet"
+import { Button } from "reakit/Button"
 
 const PageImages = (p: {
   document: GatsbyTypes.Dailp_AnnotatedDoc
-  pageImages?: readonly string[]
-}) => (
-  <figure className={annotationFigure} aria-label="Manuscript Source Images">
-    <Helmet>
-      <link
-        href="https://brbl-media.library.yale.edu"
-        rel="preconnect"
-        crossOrigin="true"
-      />
-    </Helmet>
-    {p.pageImages?.map((url, i) => (
-      <TransformWrapper key={i}>
-        <TransformComponent>
-          <img
-            className={pageImage}
-            src={url}
-            alt={`Manuscript Page ${i + 1}`}
-            loading="lazy"
-          />
-        </TransformComponent>
+  pageImages: readonly string[]
+}) => {
+  const [selectedPage, setSelectedPage] = useState(0)
+  const transform = useRef(null)
+  let url = p.pageImages[selectedPage]
+  return (
+    <figure className={annotationFigure} aria-label="Manuscript Source Images">
+      <Helmet>
+        <link
+          href="https://brbl-media.library.yale.edu"
+          rel="preconnect"
+          crossOrigin="true"
+        />
+      </Helmet>
+      <TransformWrapper
+        defaultScale={1}
+        defaultPositionX={0}
+        defaultPositionY={0}
+        options={{ maxScale: 6, centerContent: true }}
+      >
+        {({ resetTransform }) => (
+          <>
+            {p.pageImages.length > 1 && (
+              <nav aria-label="Pagination" className={cx(pageNav, hideOnPrint)}>
+                <Button
+                  className={std.button}
+                  onClick={() => {
+                    resetTransform()
+                    setSelectedPage(selectedPage - 1)
+                  }}
+                  disabled={selectedPage <= 0}
+                  aria-label="Previous Page"
+                >
+                  Previous Page
+                </Button>
+                <span aria-current="true">Page {selectedPage + 1}</span>
+                <Button
+                  className={std.button}
+                  onClick={() => {
+                    resetTransform()
+                    setSelectedPage(selectedPage + 1)
+                  }}
+                  disabled={selectedPage >= p.pageImages.length - 1}
+                  aria-label="Next Page"
+                >
+                  Next Page
+                </Button>
+              </nav>
+            )}
+            <TransformComponent>
+              <img
+                className={pageImage}
+                src={url}
+                alt={`Manuscript Page ${selectedPage + 1}`}
+              />
+            </TransformComponent>
+          </>
+        )}
       </TransformWrapper>
-    ))}
-    {p.document.sources.length ? (
-      <figcaption className={caption}>
-        Courtesy of{" "}
-        <a href={p.document.sources[0].link}>{p.document.sources[0].name}</a>
-      </figcaption>
-    ) : null}
-  </figure>
-)
+      {p.document.sources.length ? (
+        <figcaption className={caption}>
+          Courtesy of{" "}
+          <a href={p.document.sources[0].link}>{p.document.sources[0].name}</a>
+        </figcaption>
+      ) : null}
+    </figure>
+  )
+}
 export default PageImages
+
+const pageNav = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
 
 const pageImage = css`
   width: 100%;
@@ -51,13 +96,16 @@ const caption = css`
 const annotationFigure = css`
   width: 100%;
   margin: 0;
-  cursor: move;
-  cursor: grab;
   margin-bottom: ${theme.rhythm * 2}rem;
   .react-transform-component {
+    cursor: move;
+    cursor: grab;
     max-height: 20rem;
     ${theme.mediaQueries.medium} {
       max-height: 30rem;
+    }
+    ${theme.mediaQueries.print} {
+      max-height: initial;
     }
   }
   .react-transform-element {

--- a/website/src/page-image.tsx
+++ b/website/src/page-image.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from "react"
 import { css, cx } from "linaria"
-import theme, { hideOnPrint, std } from "./theme"
+import theme, { hideOnPrint, std, typography } from "./theme"
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch"
 import { Helmet } from "react-helmet"
 import { Button } from "reakit/Button"
@@ -9,9 +9,6 @@ const PageImages = (p: {
   document: GatsbyTypes.Dailp_AnnotatedDoc
   pageImages: readonly string[]
 }) => {
-  const [selectedPage, setSelectedPage] = useState(0)
-  const transform = useRef(null)
-  let url = p.pageImages[selectedPage]
   return (
     <figure className={annotationFigure} aria-label="Manuscript Source Images">
       <Helmet>
@@ -25,45 +22,14 @@ const PageImages = (p: {
         defaultScale={1}
         defaultPositionX={0}
         defaultPositionY={0}
+        wheel={{ disabled: true }}
         options={{ maxScale: 6, centerContent: true }}
       >
-        {({ resetTransform }) => (
-          <>
-            {p.pageImages.length > 1 && (
-              <nav aria-label="Pagination" className={cx(pageNav, hideOnPrint)}>
-                <Button
-                  className={std.button}
-                  onClick={() => {
-                    resetTransform()
-                    setSelectedPage(selectedPage - 1)
-                  }}
-                  disabled={selectedPage <= 0}
-                  aria-label="Previous Page"
-                >
-                  Previous Page
-                </Button>
-                <span aria-current="true">Page {selectedPage + 1}</span>
-                <Button
-                  className={std.button}
-                  onClick={() => {
-                    resetTransform()
-                    setSelectedPage(selectedPage + 1)
-                  }}
-                  disabled={selectedPage >= p.pageImages.length - 1}
-                  aria-label="Next Page"
-                >
-                  Next Page
-                </Button>
-              </nav>
-            )}
-            <TransformComponent>
-              <img
-                className={pageImage}
-                src={url}
-                alt={`Manuscript Page ${selectedPage + 1}`}
-              />
-            </TransformComponent>
-          </>
+        {({ setTransform }) => (
+          <CurrentPageImage
+            resetTransform={() => setTransform(0, 0, 1, 200, "easeOut")}
+            pageImages={p.pageImages}
+          />
         )}
       </TransformWrapper>
       {p.document.sources.length ? (
@@ -76,6 +42,52 @@ const PageImages = (p: {
   )
 }
 export default PageImages
+
+const CurrentPageImage = (p: {
+  resetTransform: any
+  pageImages: readonly string[]
+}) => {
+  const [selectedPage, setSelectedPage] = useState(0)
+  let url = p.pageImages[selectedPage]
+  return (
+    <>
+      {p.pageImages.length > 1 && (
+        <nav aria-label="Pagination" className={cx(pageNav, hideOnPrint)}>
+          <Button
+            className={std.button}
+            onClick={() => {
+              p.resetTransform()
+              setSelectedPage(selectedPage - 1)
+            }}
+            disabled={selectedPage <= 0}
+            aria-label="Previous Page"
+          >
+            Previous
+          </Button>
+          <span aria-current="true">Page {selectedPage + 1}</span>
+          <Button
+            className={std.button}
+            onClick={() => {
+              p.resetTransform()
+              setSelectedPage(selectedPage + 1)
+            }}
+            disabled={selectedPage >= p.pageImages.length - 1}
+            aria-label="Next Page"
+          >
+            Next
+          </Button>
+        </nav>
+      )}
+      <TransformComponent>
+        <img
+          className={pageImage}
+          src={url}
+          alt={`Manuscript Page ${selectedPage + 1}`}
+        />
+      </TransformComponent>
+    </>
+  )
+}
 
 const pageNav = css`
   display: flex;
@@ -90,13 +102,15 @@ const pageImage = css`
 `
 
 const caption = css`
-  margin-top: ${theme.rhythm / 2}rem;
+  margin-top: ${typography.rhythm(0.5)};
+  margin-left: ${theme.edgeSpacing};
+  margin-right: ${theme.edgeSpacing};
 `
 
 const annotationFigure = css`
   width: 100%;
   margin: 0;
-  margin-bottom: ${theme.rhythm * 2}rem;
+  margin-bottom: ${typography.rhythm(2)}rem;
   .react-transform-component {
     cursor: move;
     cursor: grab;

--- a/website/src/page-image.tsx
+++ b/website/src/page-image.tsx
@@ -1,9 +1,11 @@
-import React, { useRef, useState } from "react"
+import React, { useState } from "react"
 import { css, cx } from "linaria"
 import theme, { hideOnPrint, std, typography } from "./theme"
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch"
 import { Helmet } from "react-helmet"
 import { Button } from "reakit/Button"
+import { MdZoomIn, MdZoomOut } from "react-icons/md"
+import { FaMinus, FaPlus } from "react-icons/fa"
 
 const PageImages = (p: {
   document: GatsbyTypes.Dailp_AnnotatedDoc
@@ -20,21 +22,23 @@ const PageImages = (p: {
       </Helmet>
       <TransformWrapper
         defaultScale={1}
-        defaultPositionX={0}
-        defaultPositionY={0}
+        positionX={0}
+        positionY={0}
         wheel={{ disabled: true }}
         options={{ maxScale: 6, centerContent: true }}
       >
-        {({ setTransform }) => (
+        {({ setTransform, zoomIn, zoomOut }) => (
           <CurrentPageImage
             resetTransform={() => setTransform(0, 0, 1, 200, "easeOut")}
+            zoomIn={zoomIn}
+            zoomOut={zoomOut}
             pageImages={p.pageImages}
           />
         )}
       </TransformWrapper>
       {p.document.sources.length ? (
         <figcaption className={caption}>
-          Courtesy of{" "}
+          Source:{" "}
           <a href={p.document.sources[0].link}>{p.document.sources[0].name}</a>
         </figcaption>
       ) : null}
@@ -44,7 +48,9 @@ const PageImages = (p: {
 export default PageImages
 
 const CurrentPageImage = (p: {
-  resetTransform: any
+  resetTransform: () => void
+  zoomIn: () => void
+  zoomOut: () => void
   pageImages: readonly string[]
 }) => {
   const [selectedPage, setSelectedPage] = useState(0)
@@ -64,7 +70,9 @@ const CurrentPageImage = (p: {
           >
             Previous
           </Button>
+
           <span aria-current="true">Page {selectedPage + 1}</span>
+
           <Button
             className={std.button}
             onClick={() => {
@@ -78,16 +86,44 @@ const CurrentPageImage = (p: {
           </Button>
         </nav>
       )}
-      <TransformComponent>
-        <img
-          className={pageImage}
-          src={url}
-          alt={`Manuscript Page ${selectedPage + 1}`}
-        />
-      </TransformComponent>
+      <div style={{ position: "relative" }}>
+        <TransformComponent>
+          <img
+            className={pageImage}
+            src={url}
+            alt={`Manuscript Page ${selectedPage + 1}`}
+          />
+        </TransformComponent>
+        <div className={floatingControls}>
+          <Button
+            onClick={p.zoomIn}
+            className={std.iconButton}
+            aria-label="Zoom In"
+          >
+            <FaPlus size={20} />
+          </Button>
+          <Button
+            onClick={p.zoomOut}
+            className={std.iconButton}
+            aria-label="Zoom Out"
+          >
+            <FaMinus size={20} />
+          </Button>
+        </div>
+      </div>
     </>
   )
 }
+
+const floatingControls = css`
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  background: ${theme.colors.body};
+  & > * {
+    display: block;
+  }
+`
 
 const pageNav = css`
   display: flex;
@@ -110,8 +146,9 @@ const caption = css`
 const annotationFigure = css`
   width: 100%;
   margin: 0;
-  margin-bottom: ${typography.rhythm(2)}rem;
+  margin-bottom: ${typography.rhythm(2)};
   .react-transform-component {
+    position: relative;
     cursor: move;
     cursor: grab;
     max-height: 20rem;

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -10,7 +10,7 @@ import {
   BasicMorphemeSegment,
   morphemeDisplayTag,
 } from "./types"
-import theme, { hideOnPrint, std, withBg } from "./theme"
+import theme, { hideOnPrint, std, typography, withBg } from "./theme"
 
 interface Props {
   segment: GatsbyTypes.Dailp_AnnotatedSeg
@@ -66,12 +66,15 @@ export const Segment = (p: Props) => {
       return <>{children}</>
     }
   } else if (isPageBreak(p.segment)) {
+    const num = p.segment.index + 1
     return (
-      <hr
-        id={`document-page-${p.segment.index}`}
+      <div
+        id={`document-page-${num}`}
         className={pageBreak}
-        aria-label={`Start of document page ${p.segment.index + 1}`}
-      />
+        aria-label={`Start of page ${num}`}
+      >
+        Page {num}
+      </div>
     )
   } else {
     return null
@@ -280,8 +283,12 @@ const MorphemeSegment = (p: {
 }
 
 const pageBreak = css`
+  display: block;
   width: 40%;
   margin: auto;
+  text-align: center;
+  border-top: 1px solid gray;
+  padding-top: ${typography.rhythm(0.5)};
 
   &:first-child,
   &:last-child {

--- a/website/src/templates/annotated-document.tsx
+++ b/website/src/templates/annotated-document.tsx
@@ -135,7 +135,9 @@ const AnnotatedDocumentPage = (p: {
           id="id-1-4"
           tabId={Tabs.IMAGES}
         >
-          <PageImages pageImages={doc.pageImages} document={doc as any} />
+          {doc.pageImages ? (
+            <PageImages pageImages={doc.pageImages} document={doc as any} />
+          ) : null}
         </TabPanel>
       </main>
     </Layout>
@@ -249,6 +251,7 @@ const docTabPanel = css`
 
 const imageTabPanel = css`
   ${fullWidth}
+  outline: none;
 `
 
 const docHeader = css`

--- a/website/src/theme.ts
+++ b/website/src/theme.ts
@@ -98,6 +98,22 @@ const button = css`
     outline: none;
     border-style: dashed;
   }
+
+  &[disabled] {
+    color: darkgray;
+    background-color: lightgray;
+    border-color: darkgray;
+    opacity: 80;
+  }
+`
+
+const iconButton = css`
+  border: none;
+  margin: 0;
+  padding: 8px;
+  & > svg {
+    display: block;
+  }
 `
 
 const smallCaps = css`
@@ -107,6 +123,7 @@ const smallCaps = css`
 
 export const std = {
   button,
+  iconButton,
   smallCaps,
   tooltip: withBg,
 }


### PR DESCRIPTION
The transcription and translation of each document is freely scrollable, but the manuscript images need pagination to be easily browseable. This PR does that and resolves #61.

Left to do:
- [x] Reset the image position and zoom when moving between pages.
- [x] Mark where page breaks occur in the transcription.