### PR TITLE
Clean up morphemic segmentations

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.1.3",
+    "@fontsource/charis-sil": "^4.1.0",
     "@fontsource/quattrocento-sans": "^4.1.0",
     "@fontsource/spectral": "^4.1.0",
     "@fontsource/spectral-sc": "^4.1.0",

--- a/website/src/__generated__/gatsby-types.d.ts
+++ b/website/src/__generated__/gatsby-types.d.ts
@@ -358,6 +358,21 @@ enum Dailp_CherokeeOrthography {
 type Dailp_Contributor = {
   readonly name: Scalars['String'];
   readonly role: Scalars['String'];
+  readonly details: Maybe<Dailp_ContributorDetails>;
+};
+
+type Dailp_ContributorDetails = {
+  /**
+   * Full name of this person, this exact string must be used to identify
+   * them elsewhere, like in the attribution for a particular document.
+   */
+  readonly fullName: Scalars['String'];
+  /**
+   * Alternate name of this person, may be in a different language or writing
+   * system. Used only for descriptive purposes.
+   */
+  readonly alternateName: Maybe<Scalars['String']>;
+  readonly birthDate: Maybe<Dailp_Date>;
 };
 
 type Dailp_Date = {
@@ -10341,23 +10356,10 @@ type WpWritingSettingsFilterInput = {
   readonly useSmilies: Maybe<BooleanQueryOperatorInput>;
 };
 
-type GlossaryQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type GlossaryQuery = { readonly dailp: { readonly allTags: ReadonlyArray<(
-      Pick<Dailp_MorphemeTag, 'id' | 'morphemeType'>
-      & { readonly crg: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly taoc: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly learner: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>> }
-    )> } };
-
 type Unnamed_1_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type Unnamed_1_Query = { readonly currentBuildDate: Maybe<Pick<CurrentBuildDate, 'currentDate'>> };
-
-type Unnamed_2_QueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type Unnamed_2_Query = { readonly wpMenu: Maybe<{ readonly menuItems: Maybe<{ readonly nodes: Maybe<ReadonlyArray<Maybe<(
+type Unnamed_1_Query = { readonly wpMenu: Maybe<{ readonly menuItems: Maybe<{ readonly nodes: Maybe<ReadonlyArray<Maybe<(
         Pick<WpMenuItem, 'label' | 'path'>
         & { readonly childItems: Maybe<{ readonly nodes: Maybe<ReadonlyArray<Maybe<Pick<WpMenuItem, 'label' | 'path'>>>> }> }
       )>>> }> }> };
@@ -10366,6 +10368,19 @@ type IndexPageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type IndexPageQuery = { readonly dailp: { readonly allCollections: ReadonlyArray<Pick<Dailp_DocumentCollection, 'name' | 'slug'>> }, readonly aboutPage: Maybe<Pick<WpPage, 'title' | 'content'>> };
+
+type GlossaryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type GlossaryQuery = { readonly dailp: { readonly allTags: ReadonlyArray<(
+      Pick<Dailp_MorphemeTag, 'id' | 'morphemeType'>
+      & { readonly crg: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly taoc: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>>, readonly learner: Maybe<Pick<Dailp_TagForm, 'tag' | 'title' | 'definition'>> }
+    )> } };
+
+type Unnamed_2_QueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type Unnamed_2_Query = { readonly currentBuildDate: Maybe<Pick<CurrentBuildDate, 'currentDate'>> };
 
 type AllSourcesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -10403,6 +10418,17 @@ type FormFieldsFragment = (
   )>> }
 );
 
+type CollectionQueryVariables = Exact<{
+  name: Scalars['String'];
+  slug: Scalars['String'];
+}>;
+
+
+type CollectionQuery = { readonly dailp: { readonly allDocuments: ReadonlyArray<(
+      Pick<Dailp_AnnotatedDoc, 'id' | 'slug' | 'title'>
+      & { readonly date: Maybe<Pick<Dailp_Date, 'year'>> }
+    )> }, readonly wpPage: Maybe<Pick<WpPage, 'content'>> };
+
 type DocumentDetailsQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
@@ -10419,17 +10445,6 @@ type ContentPageQueryVariables = Exact<{
 
 
 type ContentPageQuery = { readonly page: Maybe<Pick<WpPage, 'title' | 'content'>> };
-
-type CollectionQueryVariables = Exact<{
-  name: Scalars['String'];
-  slug: Scalars['String'];
-}>;
-
-
-type CollectionQuery = { readonly dailp: { readonly allDocuments: ReadonlyArray<(
-      Pick<Dailp_AnnotatedDoc, 'id' | 'slug' | 'title'>
-      & { readonly date: Maybe<Pick<Dailp_Date, 'year'>> }
-    )> }, readonly wpPage: Maybe<Pick<WpPage, 'content'>> };
 
 type GatsbyImageSharpFixedFragment = Pick<ImageSharpFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;
 

--- a/website/src/breadcrumbs.tsx
+++ b/website/src/breadcrumbs.tsx
@@ -2,6 +2,8 @@ import { styled } from "linaria/react"
 import theme, { typography } from "./theme"
 
 export const Breadcrumbs = styled.ul`
+  font-family: ${theme.fonts.body};
+  font-weight: normal;
   list-style: none;
   padding-inline-start: 0;
   margin-bottom: ${typography.rhythm(1 / 2)};
@@ -12,6 +14,7 @@ export const Breadcrumbs = styled.ul`
     &:after {
       padding: 0 0.5rem;
       content: "/";
+      color: ${theme.colors.text};
     }
   }
 `

--- a/website/src/layout.tsx
+++ b/website/src/layout.tsx
@@ -8,9 +8,13 @@ import { Helmet } from "react-helmet"
 import Sticky from "react-stickynode"
 import { isMobile } from "react-device-detect"
 
-import "@fontsource/spectral"
-import "@fontsource/spectral-sc"
-import "@fontsource/quattrocento-sans"
+/* import "@fontsource/spectral/latin-ext.css" */
+/* import "@fontsource/spectral-sc" */
+import "@fontsource/charis-sil/400.css"
+import "@fontsource/charis-sil/400-italic.css"
+import "@fontsource/charis-sil/700.css"
+import "@fontsource/charis-sil/700-italic.css"
+import "@fontsource/quattrocento-sans/latin.css"
 import "./fonts.css"
 
 /** Wrapper for most site pages, providing them with a navigation header and footer. */

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -353,6 +353,7 @@ const wordGroup = css`
   border-radius: 2px;
   page-break-inside: avoid;
   break-inside: avoid;
+  line-height: ${typography.rhythm(1)};
   ${theme.mediaQueries.medium} {
     padding: 0;
     border: none;

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -109,13 +109,13 @@ export const AnnotatedForm = (
   }
   const showAnything = p.level > ExperienceLevel.Story
   if (showAnything) {
-    const showSegments = p.level > ExperienceLevel.Basic
+    const showSegments = p.level >= ExperienceLevel.Learner
     const translation = p.segment.englishGloss.join(", ")
     return (
       <div className={wordGroup} id={`w${p.segment.index}`}>
         <div className={syllabaryLayer} lang="chr">
           {p.segment.source}
-          {p.segment.commentary && showSegments && (
+          {p.segment.commentary && p.level >= ExperienceLevel.AdvancedDt && (
             <WordCommentaryInfo commentary={p.segment.commentary} />
           )}
         </div>
@@ -133,7 +133,7 @@ export const AnnotatedForm = (
             tagSet={p.tagSet}
           />
         ) : null}
-        {translation.length ? <div>{translation}</div> : <br />}
+        {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
       </div>
     )
   } else {
@@ -206,7 +206,7 @@ const MorphemicSegmentation = (p: {
 
   return (
     <>
-      <div>
+      <div className={italicSegmentation}>
         {p
           .segments!.map(function (segment) {
             // Adapt the segment shape to the chosen experience level.
@@ -249,6 +249,10 @@ const MorphemicSegmentation = (p: {
     </>
   )
 }
+
+const italicSegmentation = css`
+  font-style: italic;
+`
 
 function intersperse<T>(arr: T[], separator: (n: number) => T): T[] {
   return _.flatMap(arr, (a, i) => (i > 0 ? [separator(i - 1), a] : [a]))
@@ -319,11 +323,8 @@ const smallCaps = css`
   color: inherit;
   border: none;
   padding: 0;
-  border-bottom: 1px solid transparent;
   display: inline-block;
-  &:hover {
-    border-bottom: 1px solid darkblue;
-  }
+  background: none;
 `
 
 const atLeastThin = css`
@@ -337,11 +338,8 @@ const morphemeButton = css`
   color: inherit;
   border: none;
   padding: 0;
-  border-bottom: 1px solid transparent;
   display: inline-block;
-  &:hover {
-    border-bottom: 1px solid darkblue;
-  }
+  background: none;
 `
 
 const wordGroup = css`

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -319,6 +319,7 @@ const pageBreak = css`
 
 const smallCaps = css`
   font-family: ${theme.fonts.smallCaps};
+  font-feature-settings: "smcp";
   text-transform: lowercase;
   color: inherit;
   border: none;
@@ -389,7 +390,7 @@ const documentBlock = css`
 
 const bordered = css`
   ${theme.mediaQueries.medium}, print {
-    border-bottom: 2px solid ${theme.colors.text};
+    border-bottom: 1px solid ${theme.colors.text};
     &:last-of-type {
       border-bottom: none;
       margin-bottom: 0;

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -356,7 +356,7 @@ const wordGroup = css`
   ${theme.mediaQueries.medium} {
     padding: 0;
     border: none;
-    margin: ${typography.rhythm(1 / 2)} 3rem ${typography.rhythm(1 / 2)} 0;
+    margin: ${typography.rhythm(1 / 2)} 3rem ${typography.rhythm(1)} 0;
   }
   ${theme.mediaQueries.print} {
     padding: 0;
@@ -380,8 +380,9 @@ const documentBlock = css`
   position: relative;
   display: block;
   break-after: avoid;
-  margin-top: ${typography.rhythm(1)};
-  margin-bottom: ${typography.rhythm(2)};
+  margin-top: ${typography.rhythm(1.5)};
+  margin-bottom: ${typography.rhythm(1)};
+  padding-bottom: ${typography.rhythm(1)};
   ${theme.mediaQueries.print} {
     padding-bottom: ${typography.rhythm(1 / 4)};
     margin-bottom: ${typography.rhythm(2)};

--- a/website/src/templates/annotated-document.tsx
+++ b/website/src/templates/annotated-document.tsx
@@ -244,7 +244,9 @@ const docTabs = css`
 const docTabPanel = css`
   ${fullWidth}
   padding: 0 0.5rem;
-  outline: none;
+  &:focus {
+    outline: none;
+  }
   ${theme.mediaQueries.medium} {
     padding: 0;
   }

--- a/website/src/theme.ts
+++ b/website/src/theme.ts
@@ -54,7 +54,7 @@ export const typography = new Typography({
 export const fullWidth = {
   width: "100%",
   [theme.mediaQueries.medium]: {
-    width: "40rem",
+    width: "41rem",
   },
   [theme.mediaQueries.large]: {
     width: "50rem",

--- a/website/src/theme.ts
+++ b/website/src/theme.ts
@@ -6,10 +6,10 @@ const theme = {
   fonts: {
     // 4 fonts total: header + sans body, serif body, serif smallcaps, Cherokee.
     // Noto Serif supports glottal stops and more accents than other fonts.
-    bodyArr: ["Spectral", "Digohweli", "serif", "Arial"],
+    bodyArr: ["Charis SIL", "Digohweli", "serif", "Arial"],
     headerArr: ["Quattrocento Sans", "Segoe UI", "Arial", "sans-serif"],
     cherokee: `"Digohweli", "Spectral", "serif", "Arial"`,
-    smallCaps: "Spectral SC",
+    smallCaps: "Charis SIL",
     body: null,
     header: null,
   },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1111,6 +1111,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fontsource/charis-sil@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/charis-sil/-/charis-sil-4.1.0.tgz#362c2287970b900026eff57c5e3c6919060bd251"
+  integrity sha512-CAIFtnaN7oXwCYx4TWwPJleMdPKD1n4CQLuTVvtj/uTDiBpJ4DDO6z+HS/Y9bZsp0Z3WDl2wFxTv/B6jPB9mRw==
+
 "@fontsource/quattrocento-sans@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@fontsource/quattrocento-sans/-/quattrocento-sans-4.1.0.tgz#2dd3ab2652c8609ac6b279c10150d90042b97ade"


### PR DESCRIPTION
- Put English glosses into single quotes, as is standard practice with
language materials.
- Put the morphemic segmentation in italics, differentiating it from the
layers above and below.
- Only show commentary icons at the "Analysis" level.
- Remove visual noise from morpheme buttons