### PR TITLE
Hide the "Sign In" button on production

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Encode documents as TEI and database entries
         if: steps.filter.outputs.data == 'true'
         run: |
-          export DAILP_GRAPHQL_URL=$(nix develop --impure --command output functions_url)/graphql
+          export DAILP_API_URL=$(nix develop --impure --command output functions_url)
           nix run .#migrate-data -L
       - name: Publish website
         run: |

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -2,7 +2,7 @@ name: Terraform Plan
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, dev]
+    branches: [main]
     paths:
       - "terraform/**/*.nix"
       - "flake.nix"
@@ -10,7 +10,7 @@ on:
 jobs:
   plan:
     runs-on: ubuntu-20.04
-    environment: ${{ github.base_ref == 'main' && 'Production' || 'Development' }}
+    environment: ${{ github.base_ref == 'main' && 'Development' || 'Production' }}
     env:
       MONGODB_PASSWORD: ${{ secrets.MONGODB_PASSWORD }}
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
@@ -25,7 +25,7 @@ jobs:
       GIT_REPOSITORY_URL: https://github.com/neu-dsg/dailp-encoding
       OAUTH_TOKEN: ${{ secrets.OAUTH_TOKEN }}
       RUST_LOG: info
-      TF_STAGE: ${{ github.base_ref == 'main' && 'prod' || 'dev' }}
+      TF_STAGE: ${{ github.base_ref == 'main' && 'dev' || 'prod' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -149,7 +149,7 @@ async fn graphql_mutate(
     use itertools::Itertools as _;
     lazy_static::lazy_static! {
         static ref CLIENT: reqwest::Client = reqwest::Client::new();
-        static ref ENDPOINT: String = std::env::var("DAILP_GRAPHQL_URL").unwrap();
+        static ref ENDPOINT: String = format!("{}/graphql", std::env::var("DAILP_API_URL").unwrap());
         static ref PASSWORD: String = std::env::var("MONGODB_PASSWORD").unwrap();
     }
     // Chunk our contents to make fewer requests to the server that handles

--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -62,6 +62,7 @@ with builtins; {
             DAILP_AWS_REGION = config.provider.aws.region;
             DAILP_USER_POOL = "\${aws_cognito_user_pool.main.id}";
             DAILP_USER_POOL_CLIENT = "\${aws_cognito_user_pool_client.main.id}";
+            TF_STAGE = config.setup.stage;
           };
           frontend = {
             artifacts = {

--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -58,7 +58,7 @@ with builtins; {
         build_spec = toJSON {
           version = "1";
           env.variables = {
-            DAILP_GRAPHQL_URL = "${apiUrl}/graphql";
+            DAILP_API_URL = apiUrl;
             DAILP_AWS_REGION = config.provider.aws.region;
             DAILP_USER_POOL = "\${aws_cognito_user_pool.main.id}";
             DAILP_USER_POOL_CLIENT = "\${aws_cognito_user_pool_client.main.id}";

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -71,7 +71,7 @@ module.exports = {
       options: {
         typeName: "Dailp",
         fieldName: "dailp",
-        url: process.env.DAILP_GRAPHQL_URL,
+        url: `${process.env.DAILP_API_URL}/graphql`,
       },
     },
     "gatsby-transformer-sharp",

--- a/website/src/apollo.ts
+++ b/website/src/apollo.ts
@@ -12,9 +12,7 @@ export const apolloClient = (token: string) =>
 
 const httpLink = (token: string) =>
   new HttpLink({
-    uri: `https://dailp.northeastern.edu/${
-      token ? "api/graphql-edit" : "graphql"
-    }`,
+    uri: process.env.DAILP_API_URL + (token ? "/graphql-edit" : "/graphql"),
     fetch,
   })
 

--- a/website/src/cms/routes.ts
+++ b/website/src/cms/routes.ts
@@ -8,6 +8,8 @@ export function useHasMounted() {
   return hasMounted
 }
 
+export const isProductionDeployment = () => process.env.TF_STAGE === "prod"
+
 export const ClientOnly = (props: { children: any }) => {
   const hasMounted = useHasMounted()
   if (hasMounted) {

--- a/website/src/layout.tsx
+++ b/website/src/layout.tsx
@@ -8,7 +8,7 @@ import Footer from "./footer"
 import theme, { fullWidth, hideOnPrint, typography } from "./theme"
 import { isMobile } from "react-device-detect"
 import loadable from "@loadable/component"
-import { useHasMounted } from "./cms/routes"
+import { isProductionDeployment, useHasMounted } from "./cms/routes"
 import globalStyles from "./global-styles"
 import ClientLayout from "./client/layout"
 
@@ -53,7 +53,7 @@ const Layout = (p: { title?: string; children: any }) => {
 
 export const SignIn = () => {
   const hasMounted = useHasMounted()
-  if (hasMounted) {
+  if (hasMounted && !isProductionDeployment()) {
     return <ClientSignIn />
   } else {
     return null


### PR DESCRIPTION
- Add `isProductionDeployment()` function for conditional rendering.
- Hide "Sign In" on production, since authenticated actions have a lot of work left on them.

This mechanism should be used only when absolutely necessary for code that has been vetted and deployed to production, but then a major breaking bug is found and we need to revert. Otherwise, just avoid releasing code that you know isn't ready for the public.