### PR TITLE
Add data modeling for audio

### DIFF
--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -25,5 +25,6 @@ lazy_static = "*"
 base64 = "*"
 log = "0.4"
 pretty_env_logger = "0.4"
+csv="1.1"
 
 dailp = {path = "../types"}

--- a/migration/src/audio.rs
+++ b/migration/src/audio.rs
@@ -1,0 +1,148 @@
+use dailp::{DocumentAudioId, AudioSlice};
+use serde::{Deserialize, Serialize};
+use reqwest::Client;
+
+extern crate pretty_env_logger;
+
+use log::{error, info};
+use std::collections::{HashSet, HashMap};
+use serde_json::Value;
+use itertools::Itertools;
+
+/// The string ID for a DRS item, usu. prefixed with "neu:"
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct DrsId(String);
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct ComplexDrsObject(HashMap<String, Value>);
+
+/// A file received from the DRS, following the DRS meta format
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct DrsRes {
+    pid: DrsId,
+    //breadcrumbs: ComplexDrsObject,
+    parent: DrsId,
+    thumbnails: Vec<String>,
+    canonical_object: ComplexDrsObject,
+    //content_objects: ComplexDrsObject,
+}
+
+impl DrsRes {
+    // TODO: flatten information held in ComplexDrsObjects
+    pub async fn new(client: &Client, drs_id: &str) -> Result<Self, anyhow::Error> {
+        let drs = "https://repository.library.northeastern.edu/api/v1/files/";
+        Ok(client.get(format!("{}{}", drs, drs_id))
+            .send()
+            .await?
+            .json::<DrsRes>()
+            .await?)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct AudioAnnotationRow {
+    layer: String,
+    start_time: u32,
+    end_time: u32,
+    word: String,
+}
+
+#[non_exhaustive]
+struct AudioLayer;
+
+impl AudioLayer {
+    pub const UNLABELLED: &'static str = "";
+    pub const DOCUMENT: &'static str = "Document";
+    pub const WORD: &'static str = "Syllabary Source";
+}
+
+/// Audio resource information served by the DRS.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AudioRes {
+    /// The URL for a DRS audio resource
+    audio_url: String,
+    /// The raw text for a file marking words within a recording
+    annotations: String,
+}
+
+impl AudioRes {
+    /// Calls the DRS API and collates the returned metadata
+    pub async fn new(audio_drs_id: &str, annotation_drs_id: &str) -> Result<Self, anyhow::Error> {
+        info!("Creating new Audio Resource");
+        // Prepare to call the DRS repeatedly
+        let client = Client::new();
+        // Get the DRS object for the audio file, using a provided ID
+        let audio_response = DrsRes::new(&client, audio_drs_id).await?;
+        let annotation_response = DrsRes::new(&client, annotation_drs_id).await?;
+
+        Ok(
+            Self {
+                // Keep the audio file url
+                audio_url: audio_response.canonical_object.0.keys().next().unwrap().clone(),
+                // Dig deeper in the annotations to get the raw TSV text
+                annotations: client.get(annotation_response.canonical_object.0.keys().next().unwrap().clone())
+                    .send()
+                    .await?
+                    .text()
+                    .await?,
+            })
+    }
+
+    /// Converts DRS response info to [AudioSlice]s based on segmentations in the annotation file
+    pub fn into_document_audio(self) -> AudioSlice {
+        AudioSlice {
+            resource_url: self.audio_url.clone(),
+            parent_track: Some(DocumentAudioId("".to_string())),
+            annotations: Some(self.into_audio_slices()),
+            index: 0,
+            start_time: None,
+            end_time: None,
+        }
+    }
+
+    /// Converts DRS response info to [AudioSlice]s based on segmentations in the annotation file
+    pub fn into_audio_slices(self /*from_layer: String*/) -> Vec<AudioSlice> {
+        let mut result: Vec<AudioSlice> = vec![];
+        use csv::{ReaderBuilder, Error};
+        // Read in the annotation info
+        let mut reader = ReaderBuilder::new()
+            .delimiter(b'\t')
+            .has_headers(false)
+            .from_reader(self.annotations.as_bytes());
+
+        // Structure column info for all audio of the right layer
+        for (i, annotation_line) in reader
+            .deserialize::<AudioAnnotationRow>()
+            .enumerate()
+        // TODO: Implement reading of Col 1 labels to assign audio to different "chunks" of documents
+        // .filter(Some(annotation_line.unwrap()) == from_layer)
+        {
+            info!("Attempting to add values from line {}", i);
+            if annotation_line.is_err() {
+                result.push(
+                    AudioSlice {
+                        resource_url: self.audio_url.clone(),
+                        parent_track: Some(DocumentAudioId("".to_string())),
+                        annotations: None,
+                        index: i,
+                        start_time: None,
+                        end_time: None,
+                    }
+                );
+            } else {
+                let annotation = annotation_line.unwrap();
+                result.push(
+                    AudioSlice {
+                        resource_url: self.audio_url.clone(),
+                        parent_track: Some(DocumentAudioId("".to_string())),
+                        annotations: None,
+                        index: i,
+                        start_time: Some(annotation.start_time * 1000),
+                        end_time: Some(annotation.end_time * 1000),
+                    }
+                );
+            };
+        };
+        result
+    }
+}

--- a/migration/src/early_vocab.rs
+++ b/migration/src/early_vocab.rs
@@ -94,6 +94,7 @@ async fn parse_early_vocab(
         page_images: None,
         translation: None,
         is_reference: true,
+        audio_recording: None,
     };
 
     let entries: Vec<_> = sheet
@@ -173,6 +174,7 @@ async fn parse_early_vocab(
                     ),
                     date_recorded: meta.date.clone(),
                     id,
+                    audio_track: None
                 },
                 links,
             })

--- a/migration/src/lexical.rs
+++ b/migration/src/lexical.rs
@@ -98,6 +98,7 @@ pub async fn migrate_dictionaries() -> Result<()> {
                 translation: None,
                 page_images: None,
                 is_reference: true,
+                audio_recording: None,
             },
             segments: None,
         },
@@ -113,6 +114,7 @@ pub async fn migrate_dictionaries() -> Result<()> {
                 translation: None,
                 page_images: None,
                 is_reference: true,
+                audio_recording: None,
             },
             segments: None,
         },
@@ -162,6 +164,7 @@ async fn parse_numerals(sheet_id: &str, doc_id: &str, year: i32) -> Result<()> {
                 date_recorded: Some(date.clone()),
                 line_break: None,
                 page_break: None,
+                audio_track: None
             })
         })
         .collect::<Vec<_>>();
@@ -196,6 +199,7 @@ async fn parse_meta(sheet_id: &str, collection: &str) -> Result<DocumentMetadata
         page_images: None,
         translation: None,
         is_reference: true,
+        audio_recording: None
     })
 }
 
@@ -236,6 +240,7 @@ async fn parse_appendix(sheet_id: &str, to_skip: usize) -> Result<()> {
                 page_break: None,
                 commentary: None,
                 date_recorded: meta.date.clone(),
+                audio_track: None
             })
         })
         .collect();
@@ -328,6 +333,7 @@ fn parse_new_df1975(
                         date_recorded: Some(date),
                         source: root,
                         position: pos,
+                        audio_track: None
                     },
                 })
             } else {
@@ -364,6 +370,7 @@ async fn ingest_particle_index(document_id: &str) -> Result<()> {
                 date_recorded: None,
                 source: syllabary,
                 position: pos,
+                audio_track: None
             })
         })
         .collect::<Vec<_>>();
@@ -402,6 +409,7 @@ async fn ingest_ac1995(sheet_id: &str) -> Result<()> {
                 date_recorded: meta.date.clone(),
                 source: syllabary,
                 position: pos,
+                audio_track: None,
             })
         })
         .collect::<Vec<_>>();

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -7,6 +7,7 @@ mod lexical;
 mod spreadsheets;
 mod tags;
 mod translations;
+mod audio;
 
 use anyhow::{bail, Result};
 use log::{error, info};
@@ -21,9 +22,9 @@ async fn main() -> Result<()> {
     dotenv::dotenv().ok();
 
     pretty_env_logger::init();
-
+    info!("Migrating Image Sources");
     migrate_image_sources().await?;
-
+    info!("Migrating contributors");
     contributors::migrate_all().await?;
 
     info!("Migrating connections...");

--- a/migration/src/tags.rs
+++ b/migration/src/tags.rs
@@ -87,6 +87,7 @@ async fn migrate_glossary_metadata(sheet_id: &str) -> Result<()> {
                     page_images: None,
                     sources: Vec::new(),
                     translation: None,
+                    audio_recording: None
                 },
                 segments: None,
             })

--- a/types/src/audio.rs
+++ b/types/src/audio.rs
@@ -1,0 +1,27 @@
+/// Audio for a whole manuscript document and
+pub struct DocumentAudio {
+    /// Unique identifier for this audio resource
+    pub id: String,
+    /// The ID for the [AnnotatedDocument] this audio resource represents
+    pub source: String,
+    /// Access link for the audio file.
+    /// TODO: Re-consider typing to best fit storage solution
+    pub resource: String,
+    /// Subdivisions of this audio track
+    pub slices: Optional<Vector<AudioSlice>>
+}
+
+/// A segment of audio representing a word, phrase,
+/// or other subunit within the audio for a full document.
+/// Slices should be associated with a [DocumentAudio] for the reading audio file
+/// this segment is a part of.
+pub struct AudioSlice {
+    /// The [DocumentAudio] this audio slice is taken from
+    pub parent_track: DocumentAudio,
+    /// This slice's relative position to other slices within an audio resource
+    pub index: u32,
+    /// The time (in seconds) in the parent track where this slice begins.
+    pub start_time: u16,
+    /// The time (in seconds) in the parent track where this slice ends.
+    pub end_time: u16
+}

--- a/types/src/audio.rs
+++ b/types/src/audio.rs
@@ -1,31 +1,19 @@
 use serde::{Deserialize, Serialize};
 
-/// Audio for a whole manuscript document
-#[derive(Serialize, Deserialize, Clone, Debug, async_graphql::SimpleObject)]
+/// A unique identifier for audio slices
+#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, async_graphql::NewType)]
+pub struct DocumentAudioId(pub String);
 
-pub struct DocumentAudio {
-    /// Unique identifier for this audio resource
-    pub id: String,
-    /// Access link for the audio file.
-    pub resource: String,
-    /// Subdivisions of this audio track
-    pub slices: Option<Vec<AudioSlice>>
-    // /// The ID for the [AnnotatedDocument] this audio resource represents
-    // pub source: String,
-}
-
-/// A segment of audio representing a word, phrase,
-/// or other subunit within the audio for a full document.
-/// Slices should be associated with a [DocumentAudio] for the reading audio file
-/// this segment is a part of.
+/// A segment of audio representing a document, word, phrase,
+/// or other audio unit
 #[derive(Serialize, Deserialize, Clone, Debug, async_graphql::SimpleObject)]
 pub struct AudioSlice {
-    /// The [DocumentAudio] this audio slice is taken from
-    pub parent_track: DocumentAudio,
+    /// The audio resource this audio slice is taken from, generally pulled from the DRS API
+    pub parent_track: DocumentAudioId,
     /// This slice's relative position to other slices within an audio resource
     pub index: u32,
     /// The time (in seconds) in the parent track where this slice begins.
-    pub start_time: u16,
+    pub start_time: u32,
     /// The time (in seconds) in the parent track where this slice ends.
-    pub end_time: u16
+    pub end_time: u32,
 }

--- a/types/src/audio.rs
+++ b/types/src/audio.rs
@@ -1,11 +1,15 @@
+use serde::{Deserialize, Serialize};
+
 /// Audio for a whole manuscript document
+#[derive(Serialize, Deserialize, Clone, Debug, async_graphql::SimpleObject)]
+
 pub struct DocumentAudio {
     /// Unique identifier for this audio resource
     pub id: String,
     /// Access link for the audio file.
     pub resource: String,
     /// Subdivisions of this audio track
-    pub slices: Optional<Vector<AudioSlice>>
+    pub slices: Option<Vec<AudioSlice>>
     // /// The ID for the [AnnotatedDocument] this audio resource represents
     // pub source: String,
 }
@@ -14,6 +18,7 @@ pub struct DocumentAudio {
 /// or other subunit within the audio for a full document.
 /// Slices should be associated with a [DocumentAudio] for the reading audio file
 /// this segment is a part of.
+#[derive(Serialize, Deserialize, Clone, Debug, async_graphql::SimpleObject)]
 pub struct AudioSlice {
     /// The [DocumentAudio] this audio slice is taken from
     pub parent_track: DocumentAudio,

--- a/types/src/audio.rs
+++ b/types/src/audio.rs
@@ -1,14 +1,13 @@
-/// Audio for a whole manuscript document and
+/// Audio for a whole manuscript document
 pub struct DocumentAudio {
     /// Unique identifier for this audio resource
     pub id: String,
-    /// The ID for the [AnnotatedDocument] this audio resource represents
-    pub source: String,
     /// Access link for the audio file.
-    /// TODO: Re-consider typing to best fit storage solution
     pub resource: String,
     /// Subdivisions of this audio track
     pub slices: Optional<Vector<AudioSlice>>
+    // /// The ID for the [AnnotatedDocument] this audio resource represents
+    // pub source: String,
 }
 
 /// A segment of audio representing a word, phrase,

--- a/types/src/document.rs
+++ b/types/src/document.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnnotatedForm, Contributor, Database, Date, SourceAttribution, Translation, TranslationBlock,
+    AnnotatedForm, Contributor, Database, Date, DocumentAudio, SourceAttribution, Translation, TranslationBlock,
 };
 use async_graphql::{dataloader::DataLoader, FieldResult};
 use serde::{Deserialize, Serialize};
@@ -250,6 +250,8 @@ pub struct DocumentMetadata {
     pub date: Option<Date>,
     /// Whether this document is a reference, therefore just a list of forms.
     pub is_reference: bool,
+    /// Audio recording of this document, if one exists
+    pub audio_recording: Option<DocumentAudio>
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, async_graphql::NewType)]

--- a/types/src/document.rs
+++ b/types/src/document.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnnotatedForm, Contributor, Database, Date, DocumentAudio, SourceAttribution, Translation, TranslationBlock,
+    AnnotatedForm, Contributor, Database, Date, AudioSlice, SourceAttribution, Translation, TranslationBlock,
 };
 use async_graphql::{dataloader::DataLoader, FieldResult};
 use serde::{Deserialize, Serialize};
@@ -251,7 +251,7 @@ pub struct DocumentMetadata {
     /// Whether this document is a reference, therefore just a list of forms.
     pub is_reference: bool,
     /// Audio recording of this document, if one exists
-    pub audio_recording: Option<DocumentAudio>
+    pub audio_recording: Option<AudioSlice>
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, async_graphql::NewType)]

--- a/types/src/form.rs
+++ b/types/src/form.rs
@@ -1,4 +1,4 @@
-use crate::{AnnotatedDoc, Database, Date, MorphemeId, MorphemeSegment, PositionInDocument};
+use crate::{AnnotatedDoc, AudioSlice, Database, Date, MorphemeId, MorphemeSegment, PositionInDocument};
 use async_graphql::{dataloader::DataLoader, FieldResult};
 use serde::{Deserialize, Serialize};
 
@@ -39,6 +39,8 @@ pub struct AnnotatedForm {
     pub position: PositionInDocument,
     /// The date and time this form was recorded
     pub date_recorded: Option<Date>,
+    /// A slice of audio associated with this word in the context of a document
+    pub audio_track: Option<AudioSlice>
 }
 
 #[async_graphql::ComplexObject]

--- a/types/src/lexical.rs
+++ b/types/src/lexical.rs
@@ -280,6 +280,7 @@ pub fn seg_verb_surface_form(
         line_break: None,
         page_break: None,
         date_recorded: Some(date.clone()),
+        audio_track: None
     })
 }
 
@@ -390,6 +391,7 @@ pub fn root_verb_surface_form(
         line_break: None,
         page_break: None,
         date_recorded: Some(date.clone()),
+        audio_track: None
     })
 }
 
@@ -468,6 +470,7 @@ pub fn root_noun_surface_form(
         line_break: None,
         page_break: None,
         date_recorded: Some(date.clone()),
+        audio_track: None
     })
 }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -33,6 +33,7 @@ pub mod page;
 mod person;
 mod tag;
 mod translation;
+mod audio;
 
 pub use database::*;
 pub use date::*;
@@ -46,3 +47,4 @@ pub use orthography::*;
 pub use person::*;
 pub use tag::*;
 pub use translation::*;
+pub use audio::*;


### PR DESCRIPTION
Added 2 types for organizing audio
- `DocumentAudio` represents a full manuscript's audio track(s)
- `AudioSlice` represents any slice selected from the main document audio, allowing for words, phrases, and other segments to be represented. Currently, this is only for words