### PR TITLE
Sort document collections by order in "Annotated Texts Index"

### DIFF
--- a/migration/src/early_vocab.rs
+++ b/migration/src/early_vocab.rs
@@ -94,6 +94,7 @@ async fn parse_early_vocab(
         page_images: None,
         translation: None,
         is_reference: true,
+        order_index: 0,
     };
 
     let entries: Vec<_> = sheet

--- a/migration/src/lexical.rs
+++ b/migration/src/lexical.rs
@@ -98,6 +98,7 @@ pub async fn migrate_dictionaries() -> Result<()> {
                 translation: None,
                 page_images: None,
                 is_reference: true,
+                order_index: 0,
             },
             segments: None,
         },
@@ -113,6 +114,7 @@ pub async fn migrate_dictionaries() -> Result<()> {
                 translation: None,
                 page_images: None,
                 is_reference: true,
+                order_index: 0,
             },
             segments: None,
         },
@@ -196,6 +198,7 @@ async fn parse_meta(sheet_id: &str, collection: &str) -> Result<DocumentMetadata
         page_images: None,
         translation: None,
         is_reference: true,
+        order_index: 0,
     })
 }
 

--- a/migration/src/spreadsheets.rs
+++ b/migration/src/spreadsheets.rs
@@ -284,7 +284,7 @@ impl SheetResult {
     }
 
     /// Parse this sheet as a document metadata listing.
-    pub async fn into_metadata(self, is_reference: bool) -> Result<DocumentMetadata> {
+    pub async fn into_metadata(self, is_reference: bool, order_index: i64) -> Result<DocumentMetadata> {
         // Field order: genre, source, title, source page #, page count, translation
         // First column is the name of the field, useless when parsing so we ignore it.
         let mut values = self.values.into_iter();
@@ -374,6 +374,7 @@ impl SheetResult {
                 .and_then(|s| chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
                 .map(Date::new),
             is_reference,
+            order_index,
         })
     }
 

--- a/migration/src/tags.rs
+++ b/migration/src/tags.rs
@@ -87,6 +87,7 @@ async fn migrate_glossary_metadata(sheet_id: &str) -> Result<()> {
                     page_images: None,
                     sources: Vec::new(),
                     translation: None,
+                    order_index: 0,
                 },
                 segments: None,
             })

--- a/types/src/document.rs
+++ b/types/src/document.rs
@@ -94,6 +94,12 @@ impl AnnotatedDoc {
         self.meta.is_reference
     }
 
+    /// Arbitrary number used for manually ordering documents in a collection.
+    /// For collections without manual ordering, use zero here.
+    async fn order_index(&self) -> i64 {
+        self.meta.order_index
+    }
+
     /// URL-ready slug for this document, generated from the title
     async fn slug(&self) -> String {
         self.meta.id.slug()

--- a/types/src/document.rs
+++ b/types/src/document.rs
@@ -250,6 +250,10 @@ pub struct DocumentMetadata {
     pub date: Option<Date>,
     /// Whether this document is a reference, therefore just a list of forms.
     pub is_reference: bool,
+    #[serde(default)]
+    /// Arbitrary number used for manually ordering documents in a collection.
+    /// For collections without manual ordering, use zero here.
+    pub order_index: i64,
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, async_graphql::NewType)]

--- a/website/src/templates/collection.tsx
+++ b/website/src/templates/collection.tsx
@@ -19,6 +19,7 @@ const CollectionPage = (p: {
   // Sort documents into natural order by their ID.
   // This means that "10" comes after "9" instead of after "1".
   documents.sort((a, b) => collator.compare(a.id, b.id))
+           .sort((a, b) => collator.compare(a.orderIndex, b.orderIndex))
 
   return (
     <Layout title={p.pageContext.name}>
@@ -63,6 +64,7 @@ export const query = graphql`
         date {
           year
         }
+        orderIndex
       }
     }
     wpPage(slug: { eq: $slug }) {


### PR DESCRIPTION
- Add new `order_index` field to documents which records relative ordering information