### PR TITLE
Migrate data directly to MongoDB instead of through GraphQL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,21 +87,30 @@ jobs:
           # If you chose API tokens for write access OR if you have a private cache
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           pushFilter: "(-dailp$|-dailp-|-terraform-config$|-source$|\\.tar\\.gz$|-output$|-plan$|-apply-now$|-apply$)"
-      - name: Add public IP to AWS security group
+      - name: Allow SSH access to MongoDB servers
         uses: sohelamin/aws-security-group-add-ip-action@master
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
           aws-security-group-id: ${{ secrets.AWS_DEPLOYMENT_SECURITY_GROUP }}
-          port: "22"
-          to-port: "22"
-          protocol: "tcp"
+          port: 22
+          to-port: 22
+          protocol: tcp
+      - name: Allow MongoDB access
+        uses: sohelamin/aws-security-group-add-ip-action@master
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          aws-security-group-id: ${{ secrets.AWS_DEPLOYMENT_SECURITY_GROUP }}
+          port: 27017
+          to-port: 27017
+          protocol: tcp
       - name: Build and test project
         # nix -L argument shows the full build log and --impure allows it to access environment variables.
         run: |
           nix build --impure -L
-          cp -f ./result/config.tf.json ./config.tf.json
       - name: Deploy back-end to AWS via terraform
         run: nix run --impure -L .#tf-apply-now
       - name: Encode documents as TEI and database entries

--- a/.github/workflows/migrate-data.yml
+++ b/.github/workflows/migrate-data.yml
@@ -42,10 +42,19 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+      - name: Add public IP to AWS security group
+        uses: sohelamin/aws-security-group-add-ip-action@master
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          aws-security-group-id: ${{ secrets.AWS_DEPLOYMENT_SECURITY_GROUP }}
+          port: 27017
+          to-port: 27017
+          protocol: tcp
       - name: Build project
         run: |
           nix build --impure -L
-          cp -f ./result/config.tf.json ./config.tf.json
       - name: Migrate data to MongoDB
         run: |
           nix run --impure -L .#tf-plan

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -11,10 +11,6 @@ use {
     serde_with::{rust::StringWithSeparator, CommaSeparator},
 };
 
-lazy_static::lazy_static! {
-    static ref MONGODB_PASSWORD: String = std::env::var("MONGODB_PASSWORD").unwrap();
-}
-
 /// Home for all read-only queries
 pub struct Query;
 
@@ -273,120 +269,6 @@ impl Mutation {
         "1.0"
     }
 
-    #[graphql(visible = false)]
-    async fn update_tag(
-        &self,
-        context: &Context<'_>,
-        #[graphql(secret)] password: String,
-        // Data encoded as JSON for now.
-        // FIXME Use real input objects.
-        contents: String,
-    ) -> FieldResult<bool> {
-        if password != *MONGODB_PASSWORD {
-            Ok(false)
-        } else {
-            let b = base64::decode(&contents)?;
-            let tag = serde_json::from_slice(&b)?;
-            context.data::<Database>()?.update_tag(tag).await?;
-            Ok(true)
-        }
-    }
-
-    #[graphql(visible = false)]
-    async fn update_document(
-        &self,
-        context: &Context<'_>,
-        #[graphql(secret)] password: String,
-        // Data encoded as JSON for now.
-        // FIXME Use real input objects.
-        contents: String,
-    ) -> FieldResult<bool> {
-        if password != *MONGODB_PASSWORD {
-            Ok(false)
-        } else {
-            let b = base64::decode(&contents)?;
-            let tag = serde_json::from_slice(&b)?;
-            context.data::<Database>()?.update_document(tag).await?;
-            Ok(true)
-        }
-    }
-
-    #[graphql(visible = false)]
-    async fn update_form(
-        &self,
-        context: &Context<'_>,
-        #[graphql(secret)] password: String,
-        // Data encoded as JSON for now.
-        // FIXME Use real input objects.
-        contents: String,
-    ) -> FieldResult<bool> {
-        if password != *MONGODB_PASSWORD {
-            Ok(false)
-        } else {
-            let b = base64::decode(&contents)?;
-            let tag = serde_json::from_slice(&b)?;
-            context.data::<Database>()?.update_form(tag).await?;
-            Ok(true)
-        }
-    }
-
-    #[graphql(visible = false)]
-    async fn update_connection(
-        &self,
-        context: &Context<'_>,
-        #[graphql(secret)] password: String,
-        // Data encoded as JSON for now.
-        // FIXME Use real input objects.
-        contents: String,
-    ) -> FieldResult<bool> {
-        if password != *MONGODB_PASSWORD {
-            Ok(false)
-        } else {
-            let b = base64::decode(&contents)?;
-            let tag = serde_json::from_slice(&b)?;
-            context.data::<Database>()?.update_connection(tag).await?;
-            Ok(true)
-        }
-    }
-
-    #[graphql(visible = false)]
-    async fn update_person(
-        &self,
-        context: &Context<'_>,
-        #[graphql(secret)] password: String,
-        // Data encoded as JSON for now.
-        // FIXME Use real input objects.
-        contents: String,
-    ) -> FieldResult<bool> {
-        if password != *MONGODB_PASSWORD {
-            Ok(false)
-        } else {
-            let b = base64::decode(&contents)?;
-            let tag = serde_json::from_slice(&b)?;
-            context.data::<Database>()?.update_person(tag).await?;
-            Ok(true)
-        }
-    }
-
-    #[graphql(visible = false)]
-    async fn update_image_source(
-        &self,
-        context: &Context<'_>,
-        #[graphql(secret)] password: String,
-        // Data encoded as JSON for now.
-        // FIXME Use real input objects.
-        contents: String,
-    ) -> FieldResult<bool> {
-        if password != *MONGODB_PASSWORD {
-            Ok(false)
-        } else {
-            let b = base64::decode(&contents)?;
-            let tag = serde_json::from_slice(&b)?;
-            context.data::<Database>()?.update_image_source(tag).await?;
-            Ok(true)
-        }
-    }
-
     #[graphql(guard(GroupGuard(group = "UserGroup::Editor")))]
     async fn update_page(
         &self,
@@ -411,20 +293,6 @@ impl Mutation {
             .update(data.0)
             .await?;
         Ok(true)
-    }
-
-    #[graphql(visible = false)]
-    async fn clear_database(
-        &self,
-        context: &Context<'_>,
-        #[graphql(secret)] password: String,
-    ) -> FieldResult<bool> {
-        if password != *MONGODB_PASSWORD {
-            Ok(false)
-        } else {
-            context.data::<Database>()?.clear_all().await?;
-            Ok(true)
-        }
     }
 }
 

--- a/migration/src/connections.rs
+++ b/migration/src/connections.rs
@@ -1,27 +1,24 @@
 use crate::spreadsheets::SheetResult;
-use dailp::LexicalConnection;
+use dailp::{Database, LexicalConnection};
 
-pub async fn migrate_connections() -> anyhow::Result<()> {
+pub async fn migrate_connections(db: &Database) -> anyhow::Result<()> {
     use itertools::Itertools as _;
 
     let res = SheetResult::from_sheet("1ab9ddOiuoCbCaYWwhDOLk-Xj8OOS0dkHwmMqktZabpM", None).await?;
     // Skip header row.
-    let connections: Vec<_> = res
-        .values
-        .iter()
-        .skip(1)
-        .flat_map(|row| {
-            // Silently ignore rows with only one value.
-            // This permits section headers in the first column.
-            row.iter()
-                .tuple_windows()
-                .filter_map(move |(from, to)| LexicalConnection::parse(from, to))
-        })
-        .collect();
+    let connections = res.values.iter().skip(1).flat_map(|row| {
+        // Silently ignore rows with only one value.
+        // This permits section headers in the first column.
+        row.iter()
+            .tuple_windows()
+            .filter_map(move |(from, to)| LexicalConnection::parse(from, to))
+    });
 
     // TODO Clear all connections before starting.
 
-    crate::update_connection(&connections).await?;
+    for conn in connections {
+        db.update_connection(conn).await?;
+    }
 
     Ok(())
 }

--- a/migration/src/contributors.rs
+++ b/migration/src/contributors.rs
@@ -1,27 +1,24 @@
 use crate::spreadsheets::SheetResult;
 use anyhow::Result;
-use dailp::ContributorDetails;
+use dailp::{ContributorDetails, Database};
 
-pub async fn migrate_all() -> Result<()> {
+pub async fn migrate_all(db: &Database) -> Result<()> {
     let sheet =
         SheetResult::from_sheet("1ATTekY411Jz63k6VMDn3ISFu8_f75LYFErCGY-pxVkQ", None).await?;
-    let contributors: Vec<_> = sheet
-        .values
-        .into_iter()
-        .skip(1)
-        .filter_map(|row| {
-            let mut row = row.into_iter();
-            let full_name = row.next()?;
-            let alternate_name = row.next();
-            let birth_date = row.next();
-            Some(ContributorDetails {
-                full_name,
-                alternate_name,
-                birth_date: birth_date.and_then(|d| dailp::Date::parse(&d).ok()),
-            })
+    let contributors = sheet.values.into_iter().skip(1).filter_map(|row| {
+        let mut row = row.into_iter();
+        let full_name = row.next()?;
+        let alternate_name = row.next();
+        let birth_date = row.next();
+        Some(ContributorDetails {
+            full_name,
+            alternate_name,
+            birth_date: birth_date.and_then(|d| dailp::Date::parse(&d).ok()),
         })
-        .collect();
+    });
 
-    crate::update_person(&contributors).await?;
+    for person in contributors {
+        db.update_person(person).await?;
+    }
     Ok(())
 }


### PR DESCRIPTION
- Simpler access pattern, just give the CI runner temporary access to MongoDB
- Remove horrible GraphQL mutations which take a password and base64 encoded data strings
- Should be somewhat faster, at least reducing the load on our GraphQL lambda function's invocation count