### PR TITLE
[DP-112] Remove page breaks at the very end of documents

### DIFF
--- a/migration/src/spreadsheets.rs
+++ b/migration/src/spreadsheets.rs
@@ -732,6 +732,13 @@ impl<'a> AnnotatedLine {
             error!("dangling block!");
             segments.push(AnnotatedSeg::Block(p));
         }
+
+        // If the document ends in a page break, remove it.
+        // This prevents having an extra page break at the end of each document.
+        if let Some(AnnotatedSeg::PageBreak(..)) = segments.last() {
+            segments.pop();
+        }
+
         segments
     }
 }


### PR DESCRIPTION
Removes extra page breaks at the end of many documents. In the future, we could write a regression test to avoid this from popping up again.

Before:
<img width="968" alt="Screen Shot 2022-02-04 at 10 20 23 AM" src="https://user-images.githubusercontent.com/3489148/152582359-5106c48a-5bda-441e-bb53-dc2a64aa3a04.png">

After:
<img width="967" alt="Screen Shot 2022-02-04 at 10 21 18 AM" src="https://user-images.githubusercontent.com/3489148/152582388-244c468f-b921-4635-a566-80de3f438e7b.png">
