### PR TITLE
[DP-61] Adding a word panel

### DIFF
--- a/website/src/pages/documents/document.css.ts
+++ b/website/src/pages/documents/document.css.ts
@@ -1,5 +1,6 @@
 import { style } from "@vanilla-extract/css"
-import {
+import { position, rgba } from "polished"
+import sprinkles, {
   colors,
   hspace,
   largeDialog,
@@ -16,6 +17,7 @@ export const docTitle = std.fullWidth
 
 export const annotationContents = style({
   width: "100%",
+  flex: 3,
 })
 
 export const topMargin = style({
@@ -155,3 +157,34 @@ export const wideSticky = style({
   width: "100% !important",
   zIndex: 1,
 })
+
+export const contentContainer = style({
+  display: "flex",
+  flexDirection: "row",
+  flexWrap: "nowrap",
+})
+
+export const contentSection2 = style([
+  sprinkles({ display: { any: "none", medium: "block" } }),
+  {
+    flex: 1,
+  }
+])
+
+export const mobileWordPanel = style([
+  position("fixed", 0, 0, 0, "initial"),
+  paddingX(hspace.edge),
+  {
+    paddingTop: vspace.one,
+    width: "16rem",
+    backgroundColor: colors.body,
+    fontFamily: theme.fonts.header,
+    transition: "transform 150ms ease-in-out",
+    transform: "translateX(16rem)",
+    selectors: {
+      "&[data-enter]": {
+        transform: "translateX(0)",
+      },
+    },
+  },
+])

--- a/website/src/pages/documents/document.css.ts
+++ b/website/src/pages/documents/document.css.ts
@@ -17,7 +17,7 @@ export const docTitle = std.fullWidth
 
 export const annotationContents = style({
   width: "100%",
-  flex: 3,
+  flex: 2,
 })
 
 export const topMargin = style({

--- a/website/src/pages/documents/document.css.ts
+++ b/website/src/pages/documents/document.css.ts
@@ -176,7 +176,7 @@ export const mobileWordPanel = style([
   paddingX(hspace.edge),
   {
     paddingTop: vspace.one,
-    width: "16rem",
+    width: "20rem",
     backgroundColor: colors.body,
     fontFamily: theme.fonts.header,
     transition: "transform 150ms ease-in-out",

--- a/website/src/pages/documents/document.css.ts
+++ b/website/src/pages/documents/document.css.ts
@@ -116,7 +116,7 @@ export const morphemeDialog = style([
     maxWidth: "100vw",
     margin: 0,
     padding: 0,
-    zIndex: 999,
+    zIndex: 1009,
   },
 ])
 
@@ -124,7 +124,7 @@ export const morphemeDialogBackdrop = style({
   position: "fixed",
   inset: 0,
   backgroundColor: "rgba(0,0,0,0.2)",
-  zIndex: 998,
+  zIndex: 1008,
 })
 
 export const annotatedDocument = style({
@@ -176,7 +176,7 @@ export const mobileWordPanel = style([
   paddingX(hspace.edge),
   {
     paddingTop: vspace.one,
-    width: "20rem",
+    width: "13rem",
     backgroundColor: colors.body,
     fontFamily: theme.fonts.header,
     transition: "transform 150ms ease-in-out",

--- a/website/src/pages/documents/document.page.tsx
+++ b/website/src/pages/documents/document.page.tsx
@@ -1,6 +1,6 @@
 import { DialogContent, DialogOverlay } from "@reach/dialog"
 import "@reach/dialog/styles.css"
-import React, { Dispatch, SetStateAction, useState } from "react"
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react"
 import { isMobile } from "react-device-detect"
 import { Helmet } from "react-helmet"
 import Sticky from "react-stickynode"

--- a/website/src/pages/documents/document.page.tsx
+++ b/website/src/pages/documents/document.page.tsx
@@ -215,7 +215,7 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
         {/*<PhoneticsPicker onSelect={setPhoneticRepresentation} />*/}
       </SolidSticky>
 
-      <section className={css.contentContainer}>
+      <div className={css.contentContainer}>
         <article className={css.annotationContents}>
           <DocumentContents
             {...{
@@ -239,7 +239,7 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
             />
           </div>
         ) : null}
-      </section>
+      </div>
     </>
   )
 }

--- a/website/src/pages/documents/document.page.tsx
+++ b/website/src/pages/documents/document.page.tsx
@@ -151,6 +151,11 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
       dialog.hide()
     }
   }
+  useEffect(() => {
+    if (!dialog.visible) {
+      selectAndShowWord(null)
+    }
+  }, [dialog.visible])
   let wordPanelInfo = {
     currContents: selectedWord,
     setCurrContents: selectAndShowWord,

--- a/website/src/pages/documents/document.page.tsx
+++ b/website/src/pages/documents/document.page.tsx
@@ -140,7 +140,7 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
     setDialogOpen(true)
   }
 
-  const dialog = useDialogState({ animated: true })
+  const dialog = useDialogState({ animated: true, modal: false })
   const [selectedWord, setSelectedWord] =
     useState<Dailp.FormFieldsFragment | null>(null)
   const selectAndShowWord = (content: Dailp.FormFieldsFragment | null) => {
@@ -151,11 +151,13 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
       dialog.hide()
     }
   }
+  /* This useEffect makes that when the mobile version of the word panel is closed, the word is unselected*/
   useEffect(() => {
     if (!dialog.visible) {
       selectAndShowWord(null)
     }
   }, [dialog.visible])
+
   let wordPanelInfo = {
     currContents: selectedWord,
     setCurrContents: selectAndShowWord,
@@ -199,6 +201,7 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
           className={css.mobileWordPanel}
           aria-label="Word Panel Drawer"
           preventBodyScroll={false}
+          hideOnClickOutside={false}
         >
           <WordPanel
             segment={wordPanelInfo.currContents}
@@ -233,7 +236,7 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
             }}
           />
         </article>
-        {selectedWord ? (
+        {selectedWord && experienceLevel > 0 ? (
           <div className={css.contentSection2}>
             <WordPanel
               segment={wordPanelInfo.currContents}

--- a/website/src/segment.css.ts
+++ b/website/src/segment.css.ts
@@ -1,5 +1,5 @@
 import { StyleRule, style, styleVariants } from "@vanilla-extract/css"
-import { margin } from "polished"
+import { borderWidth, margin } from "polished"
 import {
   colors,
   hspace,
@@ -50,8 +50,7 @@ export const wordGroup = style([
   paddingY(vspace.half),
   {
     display: "block",
-    paddingLeft: hspace.halfEdge,
-    paddingRight: 0,
+    padding: hspace.halfEdge,
     borderWidth: thickness.thick,
     borderStyle: "solid",
     borderColor: colors.borders,
@@ -80,6 +79,18 @@ export const wordGroup = style([
 export const syllabaryLayer = style({
   fontFamily: theme.fonts.cherokee,
   fontSize: "1.15rem",
+})
+
+export const syllabarySelectedLayer = style({
+  fontFamily: theme.fonts.cherokee,
+  fontSize: "1.15rem",
+  display: "block",
+  borderWidth: thickness.thick,
+  borderStyle: "solid",
+  borderColor: colors.borders,
+  borderRadius: radii.medium,
+  paddingLeft: hspace.halfEdge,
+  paddingRight: hspace.halfEdge,
 })
 
 export const plainSyllabary = style({

--- a/website/src/segment.css.ts
+++ b/website/src/segment.css.ts
@@ -62,7 +62,15 @@ export const wordGroup = style([
     "@media": {
       [mediaQueries.medium]: {
         display: "inline-block",
-        padding: 0,
+      }
+    }
+  },
+])
+
+export const wordGroupSelection = styleVariants({
+  unselected: [wordGroup, {
+    "@media": {
+      [mediaQueries.medium]: {
         border: "none",
         ...margin(vspace.half, "3rem", vspace.one, 0),
       },
@@ -73,8 +81,9 @@ export const wordGroup = style([
         ...margin(0, "3.5rem", vspace[1.5], 0),
       },
     },
-  },
-])
+  }],
+  selected: [wordGroup],
+})
 
 export const syllabaryLayer = style({
   fontFamily: theme.fonts.cherokee,

--- a/website/src/segment.css.ts
+++ b/website/src/segment.css.ts
@@ -62,6 +62,7 @@ export const wordGroup = style([
     "@media": {
       [mediaQueries.medium]: {
         display: "inline-block",
+        ...margin(vspace.half, "3rem", vspace.one, 0),
       }
     }
   },
@@ -71,12 +72,10 @@ export const wordGroupSelection = styleVariants({
   unselected: [wordGroup, {
     "@media": {
       [mediaQueries.medium]: {
-        border: "none",
-        ...margin(vspace.half, "3rem", vspace.one, 0),
+        borderColor: "transparent",
       },
       [mediaQueries.print]: {
         display: "inline-block",
-        padding: 0,
         border: "none",
         ...margin(0, "3.5rem", vspace[1.5], 0),
       },
@@ -180,7 +179,7 @@ export const annotationSection = styleVariants({
 export const audioContainer = style({ paddingLeft: "40%" })
 
 export const infoIcon = style({
-  cursor: "help",
+  cursor: "pointer",
   marginLeft: hspace.halfEdge,
   "@media": {
     [mediaQueries.print]: {

--- a/website/src/segment.css.ts
+++ b/website/src/segment.css.ts
@@ -82,7 +82,10 @@ export const wordGroupSelection = styleVariants({
       },
     },
   }],
-  selected: [wordGroup],
+  selected: [wordGroup, {
+    borderColor: "black",
+    backgroundColor: colors.header,
+  }],
 })
 
 export const syllabaryLayer = style({

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -16,7 +16,7 @@ import {
   ViewMode,
   morphemeDisplayTag,
 } from "./types"
-import { wordPanelDetails } from "./word-panel"
+import { WordPanelDetails } from "./word-panel"
 
 type Segment = NonNullable<DocumentContents["translatedSegments"]>[0]["source"]
 
@@ -28,7 +28,7 @@ interface Props {
   tagSet: TagSet
   pageImages: readonly string[]
   phoneticRepresentation: PhoneticRepresentation
-  wordPanelInfo: wordPanelDetails
+  wordPanelDetails: WordPanelDetails
 }
 
 /** Displays one segment of the document, which may be a word, block, or phrase. */
@@ -38,7 +38,7 @@ export const Segment = (p: Props & { howl?: Howl }) => {
     return <AnnotatedForm {...p} segment={segment} />
   } else if (segment.__typename === "AnnotatedPhrase") {
     const children =
-      segment.parts?.map(function(seg, i) {
+      segment.parts?.map(function (seg, i) {
         return (
           <Segment
             key={i}
@@ -49,7 +49,7 @@ export const Segment = (p: Props & { howl?: Howl }) => {
             tagSet={p.tagSet}
             pageImages={p.pageImages}
             phoneticRepresentation={p.phoneticRepresentation}
-            wordPanelInfo={p.wordPanelInfo}
+            wordPanelDetails={p.wordPanelDetails}
           />
         )
       }) ?? null
@@ -90,7 +90,7 @@ export const AnnotatedForm = (
   }
   const showAnything = p.viewMode > ViewMode.Story
   let wordCSS = css.syllabaryLayer
-  if (p.wordPanelInfo.currContents?.source === p.segment.source) {
+  if (p.wordPanelDetails.currContents?.source === p.segment.source) {
     wordCSS = css.syllabarySelectedLayer
   }
   if (showAnything) {
@@ -99,23 +99,37 @@ export const AnnotatedForm = (
 
     return (
       <div className={css.wordGroup} id={`w${p.segment.index}`}>
-        
-        
-        <div 
-        className={wordCSS} 
-        lang="chr" 
-        onClick={() => p.wordPanelInfo.setCurrContents(p.segment)}>
+        <div
+          className={wordCSS}
+          lang="chr"
+          onClick={() => p.wordPanelDetails.setCurrContents(p.segment)}
+        >
           {p.segment.source}
           {p.segment.commentary && p.viewMode >= ViewMode.Pronunciation && (
             <WordCommentaryInfo commentary={p.segment.commentary} />
           )}
-        </div>
-        {p.segment.simplePhonetics ? (
-          <>
-            <div>{p.segment.romanizedSource}</div>
-            <div>
-              {p.segment.simplePhonetics}
-              {p.segment.audioTrack && (
+          {p.segment.simplePhonetics ? (
+            <>
+              <div>{p.segment.romanizedSource}</div>
+              <div>
+                {p.segment.simplePhonetics}
+                {p.segment.audioTrack && (
+                  <FormAudio
+                    endTime={p.segment.audioTrack.endTime}
+                    index={p.segment.audioTrack.index}
+                    parentTrack=""
+                    resourceUrl={p.segment.audioTrack.resourceUrl}
+                    startTime={p.segment.audioTrack.startTime}
+                  />
+                )}
+                {p.segment.phonemic && p.viewMode >= ViewMode.Pronunciation && (
+                  <div />
+                )}
+              </div>
+            </>
+          ) : (
+            (p.segment.audioTrack && (
+              <div className={css.audioContainer}>
                 <FormAudio
                   endTime={p.segment.audioTrack.endTime}
                   index={p.segment.audioTrack.index}
@@ -123,39 +137,24 @@ export const AnnotatedForm = (
                   resourceUrl={p.segment.audioTrack.resourceUrl}
                   startTime={p.segment.audioTrack.startTime}
                 />
-              )}
-              {p.segment.phonemic && p.viewMode >= ViewMode.Pronunciation && (
-                <div />
-              )}
-            </div>
-          </>
-        ) : (
-          (p.segment.audioTrack && (
-            <div className={css.audioContainer}>
-              <FormAudio
-                endTime={p.segment.audioTrack.endTime}
-                index={p.segment.audioTrack.index}
-                parentTrack=""
-                resourceUrl={p.segment.audioTrack.resourceUrl}
-                startTime={p.segment.audioTrack.startTime}
-              />
-            </div>
-          )) || (
-            <>
-              <br />
-              <br />
-            </>
-          )
-        )}
-        {showSegments ? (
-          <MorphemicSegmentation
-            segments={p.segment.segments}
-            onOpenDetails={p.onOpenDetails}
-            level={p.viewMode}
-            tagSet={p.tagSet}
-          />
-        ) : null}
-        {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
+              </div>
+            )) || (
+              <>
+                <br />
+                <br />
+              </>
+            )
+          )}
+          {showSegments ? (
+            <MorphemicSegmentation
+              segments={p.segment.segments}
+              onOpenDetails={p.onOpenDetails}
+              level={p.viewMode}
+              tagSet={p.tagSet}
+            />
+          ) : null}
+          {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
+        </div>
       </div>
     )
   } else {
@@ -227,7 +226,7 @@ export const MorphemicSegmentation = (p: {
     <>
       <i>{segmentation}</i>
       <div>
-        {p.segments.map(function(segment, i) {
+        {p.segments.map(function (segment, i) {
           return (
             <React.Fragment key={i}>
               <MorphemeSegment

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -95,6 +95,9 @@ export const AnnotatedForm = (
     p.wordPanelDetails.currContents?.index === p.segment.index
   ) {
     wordCSS = css.wordGroupSelection.selected
+    p.wordPanelDetails.setCurrContents(
+      p.segment
+    ) /* This makes sure the word panel updates for changes to the word panel*/
   }
   if (showAnything) {
     const showSegments = p.viewMode >= ViewMode.Segmentation

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -1,7 +1,8 @@
+import { DialogOverlay } from "@reach/dialog"
 import { Tooltip } from "@reach/tooltip"
 import "@reach/tooltip/styles.css"
 import { Howl } from "howler"
-import React from "react"
+import React, { Dispatch, SetStateAction, useState } from "react"
 import { MdInfoOutline } from "react-icons/md"
 import * as Dailp from "src/graphql/dailp"
 import { DocumentContents } from "src/pages/documents/document.page"
@@ -15,6 +16,7 @@ import {
   ViewMode,
   morphemeDisplayTag,
 } from "./types"
+import { wordPanelDetails } from "./word-panel"
 
 type Segment = NonNullable<DocumentContents["translatedSegments"]>[0]["source"]
 
@@ -26,6 +28,7 @@ interface Props {
   tagSet: TagSet
   pageImages: readonly string[]
   phoneticRepresentation: PhoneticRepresentation
+  wordPanelInfo: wordPanelDetails
 }
 
 /** Displays one segment of the document, which may be a word, block, or phrase. */
@@ -46,6 +49,7 @@ export const Segment = (p: Props & { howl?: Howl }) => {
             tagSet={p.tagSet}
             pageImages={p.pageImages}
             phoneticRepresentation={p.phoneticRepresentation}
+            wordPanelInfo={p.wordPanelInfo}
           />
         )
       }) ?? null
@@ -85,13 +89,22 @@ export const AnnotatedForm = (
     return null
   }
   const showAnything = p.viewMode > ViewMode.Story
+  let wordCSS = css.syllabaryLayer
+  if (p.wordPanelInfo.currContents?.source === p.segment.source) {
+    wordCSS = css.syllabarySelectedLayer
+  }
   if (showAnything) {
     const showSegments = p.viewMode >= ViewMode.Segmentation
     const translation = p.segment.englishGloss.join(", ")
 
     return (
       <div className={css.wordGroup} id={`w${p.segment.index}`}>
-        <div className={css.syllabaryLayer} lang="chr">
+        
+        
+        <div 
+        className={wordCSS} 
+        lang="chr" 
+        onClick={() => p.wordPanelInfo.setCurrContents(p.segment)}>
           {p.segment.source}
           {p.segment.commentary && p.viewMode >= ViewMode.Pronunciation && (
             <WordCommentaryInfo commentary={p.segment.commentary} />
@@ -184,7 +197,7 @@ const WithTooltip = (p: {
  * Displays the break-down of a word into its units of meaning and the English
  * glosses for each morpheme.
  */
-const MorphemicSegmentation = (p: {
+export const MorphemicSegmentation = (p: {
   segments: Dailp.FormFieldsFragment["segments"]
   tagSet: TagSet
   onOpenDetails: Props["onOpenDetails"]

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -89,18 +89,18 @@ export const AnnotatedForm = (
     return null
   }
   const showAnything = p.viewMode > ViewMode.Story
-  let wordCSS = css.syllabaryLayer
+  let wordCSS = css.wordGroupSelection.unselected
   if (p.wordPanelDetails.currContents?.source === p.segment.source) {
-    wordCSS = css.syllabarySelectedLayer
+    wordCSS = css.wordGroupSelection.selected
   }
   if (showAnything) {
     const showSegments = p.viewMode >= ViewMode.Segmentation
     const translation = p.segment.englishGloss.join(", ")
 
     return (
-      <div className={css.wordGroup} id={`w${p.segment.index}`}>
+      <div className={wordCSS} id={`w${p.segment.index}`}>
         <div
-          className={wordCSS}
+          className={css.syllabaryLayer}
           lang="chr"
           onClick={() => p.wordPanelDetails.setCurrContents(p.segment)}
         >
@@ -108,28 +108,13 @@ export const AnnotatedForm = (
           {p.segment.commentary && p.viewMode >= ViewMode.Pronunciation && (
             <WordCommentaryInfo commentary={p.segment.commentary} />
           )}
-          {p.segment.simplePhonetics ? (
-            <>
-              <div>{p.segment.romanizedSource}</div>
-              <div>
-                {p.segment.simplePhonetics}
-                {p.segment.audioTrack && (
-                  <FormAudio
-                    endTime={p.segment.audioTrack.endTime}
-                    index={p.segment.audioTrack.index}
-                    parentTrack=""
-                    resourceUrl={p.segment.audioTrack.resourceUrl}
-                    startTime={p.segment.audioTrack.startTime}
-                  />
-                )}
-                {p.segment.phonemic && p.viewMode >= ViewMode.Pronunciation && (
-                  <div />
-                )}
-              </div>
-            </>
-          ) : (
-            (p.segment.audioTrack && (
-              <div className={css.audioContainer}>
+        </div>
+        {p.segment.simplePhonetics ? (
+          <>
+            <div>{p.segment.romanizedSource}</div>
+            <div>
+              {p.segment.simplePhonetics}
+              {p.segment.audioTrack && (
                 <FormAudio
                   endTime={p.segment.audioTrack.endTime}
                   index={p.segment.audioTrack.index}
@@ -137,24 +122,39 @@ export const AnnotatedForm = (
                   resourceUrl={p.segment.audioTrack.resourceUrl}
                   startTime={p.segment.audioTrack.startTime}
                 />
-              </div>
-            )) || (
-              <>
-                <br />
-                <br />
-              </>
-            )
-          )}
-          {showSegments ? (
-            <MorphemicSegmentation
-              segments={p.segment.segments}
-              onOpenDetails={p.onOpenDetails}
-              level={p.viewMode}
-              tagSet={p.tagSet}
-            />
-          ) : null}
-          {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
-        </div>
+              )}
+              {p.segment.phonemic && p.viewMode >= ViewMode.Pronunciation && (
+                <div />
+              )}
+            </div>
+          </>
+        ) : (
+          (p.segment.audioTrack && (
+            <div className={css.audioContainer}>
+              <FormAudio
+                endTime={p.segment.audioTrack.endTime}
+                index={p.segment.audioTrack.index}
+                parentTrack=""
+                resourceUrl={p.segment.audioTrack.resourceUrl}
+                startTime={p.segment.audioTrack.startTime}
+              />
+            </div>
+          )) || (
+            <>
+              <br />
+              <br />
+            </>
+          )
+        )}
+        {showSegments ? (
+          <MorphemicSegmentation
+            segments={p.segment.segments}
+            onOpenDetails={p.onOpenDetails}
+            level={p.viewMode}
+            tagSet={p.tagSet}
+          />
+        ) : null}
+        {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
       </div>
     )
   } else {

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -99,15 +99,14 @@ export const AnnotatedForm = (
 
     return (
       <div className={wordCSS} id={`w${p.segment.index}`}>
-        <div
-          className={css.syllabaryLayer}
-          lang="chr"
-          onClick={() => p.wordPanelDetails.setCurrContents(p.segment)}
-        >
+        <div className={css.syllabaryLayer} lang="chr">
           {p.segment.source}
-          {p.segment.commentary && p.viewMode >= ViewMode.Pronunciation && (
-            <WordCommentaryInfo commentary={p.segment.commentary} />
-          )}
+          <span
+            className={css.infoIcon}
+            onClick={() => p.wordPanelDetails.setCurrContents(p.segment)}
+          >
+            <MdInfoOutline size={20} className={css.linkSvg} />
+          </span>
         </div>
         {p.segment.simplePhonetics ? (
           <>

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -90,7 +90,10 @@ export const AnnotatedForm = (
   }
   const showAnything = p.viewMode > ViewMode.Story
   let wordCSS = css.wordGroupSelection.unselected
-  if (p.wordPanelDetails.currContents?.source === p.segment.source) {
+  if (
+    p.wordPanelDetails.currContents?.source === p.segment.source &&
+    p.wordPanelDetails.currContents?.index === p.segment.index
+  ) {
     wordCSS = css.wordGroupSelection.selected
   }
   if (showAnything) {

--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -1,0 +1,32 @@
+import { style } from "@vanilla-extract/css"
+import sprinkles from "./sprinkles.css"
+
+export const wholePanel = style({
+    position: "sticky",
+    top: 150,
+})
+
+export const wordPanelButton = style({
+    lineHeight: 1.5,
+    boxSizing: "border-box",
+    border: "transparent",
+    cursor: "pointer",
+    fontSize: "16px",
+    borderRadius: "0.25rem",
+    ":before":{
+        display: "inline-block",
+        margin: "4px",
+    },
+    position: "absolute",
+    top: "5px",
+    right: "5px",
+})
+
+export const wordPanelContent = style({
+    border: "1px solid #ddd",
+    borderRadius: "4px",
+    padding: "8px",
+    position: "relative",
+})
+
+export const audioContainer = style({ paddingLeft: "40%" })

--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -1,33 +1,18 @@
-import { style } from "@vanilla-extract/css"
+import { style, styleVariants } from "@vanilla-extract/css"
+import { closeButton } from "./morpheme.css"
 import sprinkles, { hspace, mediaQueries, theme, vspace } from "./sprinkles.css"
 
-export const wholePanel = style({
-  position: "sticky",
-  top: 125,
-})
-
-export const wordPanelButton = style({
-  lineHeight: 1.5,
-  boxSizing: "border-box",
-  border: "transparent",
-  cursor: "pointer",
-  borderRadius: "0.25rem",
-  selectors: {
-    "&:before": {
-      display: "inline-block",
-      margin: "4px",
-    },
-  },
-  position: "absolute",
-  top: vspace.half,
-  right: hspace.halfEdge,
+export const wordPanelButton = styleVariants({
+  basic: [closeButton],
 })
 
 export const wordPanelContent = style({
+  position: "sticky",
+  top: 125,
+  height: "25rem",
   border: "none",
   borderRadius: "4px",
   padding: "8px",
-  position: "relative",
   fontFamily: theme.fonts.cherokee,
   "@media": {
     [mediaQueries.medium]: {

--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -1,32 +1,39 @@
 import { style } from "@vanilla-extract/css"
-import sprinkles from "./sprinkles.css"
+import sprinkles, { hspace, mediaQueries, theme, vspace } from "./sprinkles.css"
 
 export const wholePanel = style({
-    position: "sticky",
-    top: 150,
+  position: "sticky",
+  top: 125,
 })
 
 export const wordPanelButton = style({
-    lineHeight: 1.5,
-    boxSizing: "border-box",
-    border: "transparent",
-    cursor: "pointer",
-    fontSize: "16px",
-    borderRadius: "0.25rem",
-    ":before":{
-        display: "inline-block",
-        margin: "4px",
+  lineHeight: 1.5,
+  boxSizing: "border-box",
+  border: "transparent",
+  cursor: "pointer",
+  borderRadius: "0.25rem",
+  selectors: {
+    "&:before": {
+      display: "inline-block",
+      margin: "4px",
     },
-    position: "absolute",
-    top: "5px",
-    right: "5px",
+  },
+  position: "absolute",
+  top: vspace.half,
+  right: hspace.halfEdge,
 })
 
 export const wordPanelContent = style({
-    border: "1px solid #ddd",
-    borderRadius: "4px",
-    padding: "8px",
-    position: "relative",
+  border: "none",
+  borderRadius: "4px",
+  padding: "8px",
+  position: "relative",
+  fontFamily: theme.fonts.cherokee,
+  "@media": {
+    [mediaQueries.medium]: {
+      border: "1px solid #ddd",
+    },
+  },
 })
 
 export const audioContainer = style({ paddingLeft: "40%" })

--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -1,6 +1,17 @@
 import { style, styleVariants } from "@vanilla-extract/css"
 import { closeButton } from "./morpheme.css"
-import sprinkles, { hspace, mediaQueries, theme, vspace } from "./sprinkles.css"
+import sprinkles, {
+  colors,
+  hspace,
+  mediaQueries,
+  theme,
+  vspace,
+} from "./sprinkles.css"
+
+export const cherHeader = style({
+  color: colors.headings,
+  fontFamily: theme.fonts.cherokee,
+})
 
 export const wordPanelButton = styleVariants({
   basic: [closeButton],
@@ -13,7 +24,7 @@ export const wordPanelContent = style({
   border: "none",
   borderRadius: "4px",
   padding: "8px",
-  fontFamily: theme.fonts.cherokee,
+  fontFamily: theme.fonts.body,
   "@media": {
     [mediaQueries.medium]: {
       border: "1px solid #ddd",

--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -9,7 +9,7 @@ export const wordPanelButton = styleVariants({
 export const wordPanelContent = style({
   position: "sticky",
   top: 125,
-  height: "25rem",
+  height: "calc(100vh - 150px)",
   border: "none",
   borderRadius: "4px",
   padding: "8px",

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -74,7 +74,7 @@ export const WordPanel = (p: {
           <MdClose size={32} />
         </Button>
         <h1>Selected word:</h1>
-        <h2>{p.segment.source}</h2>
+        <h2 className={css.cherHeader}>{p.segment.source}</h2>
         {phonetics}
         {
           <MorphemicSegmentation

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -1,0 +1,87 @@
+import React from "react"
+import { Disclosure, DisclosureContent, useDisclosureState } from "reakit/Disclosure"
+import * as Dailp from "src/graphql/dailp"
+import { BasicMorphemeSegment, TagSet, ViewMode } from "./types"
+import * as css from "./word-panel.css"
+import { FormAudio } from "./audio-player"
+import { MorphemicSegmentation } from "./segment"
+import { Button } from "reakit/Button"
+
+export interface wordPanelDetails {
+    currContents: Dailp.FormFieldsFragment | null
+    setCurrContents: (currContents: Dailp.FormFieldsFragment | null) => void
+}
+
+export const WordPanel = (
+    p : {
+        segment : Dailp.FormFieldsFragment | null
+        setContent : (content: Dailp.FormFieldsFragment | null) => void
+        viewMode : ViewMode
+        onOpenDetails: (morpheme: BasicMorphemeSegment) => void
+        tagSet: TagSet
+    }
+) => {
+    if (p.segment) {
+        const disclosure = useDisclosureState({ visible: true });
+        const translation = p.segment.englishGloss.join(", ")
+        return (
+            <div className={css.wholePanel}>
+                
+                <div 
+                className={css.wordPanelContent}>
+                    <Button className={css.wordPanelButton} onClick={() => p.setContent(null)}>X</Button>
+
+                    <h2>{p.segment.source}</h2> 
+                    {p.segment.simplePhonetics ? (
+                    <>
+                        <div>{p.segment.romanizedSource}</div>
+                        <div>
+                        {p.segment.simplePhonetics}
+                        {p.segment.audioTrack && (
+                            <FormAudio
+                            endTime={p.segment.audioTrack.endTime}
+                            index={p.segment.audioTrack.index}
+                            parentTrack=""
+                            resourceUrl={p.segment.audioTrack.resourceUrl}
+                            startTime={p.segment.audioTrack.startTime}
+                            />
+                        )}
+                        </div>
+                    </>
+                    ) : (
+                    (p.segment.audioTrack && (
+                        <div className={css.audioContainer}>
+                        <FormAudio
+                            endTime={p.segment.audioTrack.endTime}
+                            index={p.segment.audioTrack.index}
+                            parentTrack=""
+                            resourceUrl={p.segment.audioTrack.resourceUrl}
+                            startTime={p.segment.audioTrack.startTime}
+                        />
+                        </div>
+                    )) || (
+                        <>
+                        <br />
+                        <br />
+                        </>
+                    )
+                    )}
+
+                    {<MorphemicSegmentation
+                            segments={p.segment.segments}
+                            onOpenDetails={p.onOpenDetails}
+                            level={p.viewMode}
+                            tagSet={p.tagSet}
+                        />}
+                    {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
+                </div>
+            </div>
+        )
+    }
+    else {
+        return (
+            <p>No word has been selected</p>
+        )
+    }
+    
+}

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -1,87 +1,95 @@
 import React from "react"
-import { Disclosure, DisclosureContent, useDisclosureState } from "reakit/Disclosure"
+import { MdClose } from "react-icons/md"
+import { Button } from "reakit/Button"
+import {
+  Disclosure,
+  DisclosureContent,
+  useDisclosureState,
+} from "reakit/Disclosure"
 import * as Dailp from "src/graphql/dailp"
-import { BasicMorphemeSegment, TagSet, ViewMode } from "./types"
-import * as css from "./word-panel.css"
 import { FormAudio } from "./audio-player"
 import { MorphemicSegmentation } from "./segment"
-import { Button } from "reakit/Button"
+import { BasicMorphemeSegment, TagSet, ViewMode } from "./types"
+import * as css from "./word-panel.css"
 
-export interface wordPanelDetails {
-    currContents: Dailp.FormFieldsFragment | null
-    setCurrContents: (currContents: Dailp.FormFieldsFragment | null) => void
+export interface WordPanelDetails {
+  currContents: Dailp.FormFieldsFragment | null
+  setCurrContents: (currContents: Dailp.FormFieldsFragment | null) => void
 }
 
-export const WordPanel = (
-    p : {
-        segment : Dailp.FormFieldsFragment | null
-        setContent : (content: Dailp.FormFieldsFragment | null) => void
-        viewMode : ViewMode
-        onOpenDetails: (morpheme: BasicMorphemeSegment) => void
-        tagSet: TagSet
+export const WordPanel = (p: {
+  segment: Dailp.FormFieldsFragment | null
+  setContent: (content: Dailp.FormFieldsFragment | null) => void
+  viewMode: ViewMode
+  onOpenDetails: (morpheme: BasicMorphemeSegment) => void
+  tagSet: TagSet
+}) => {
+  if (p.segment) {
+    const translation = p.segment.englishGloss.join(", ")
+    let phonetics = (
+      <>
+        <br />
+        <br />
+      </>
+    )
+    if (p.segment.simplePhonetics) {
+      phonetics = (
+        <>
+          <div>{p.segment.romanizedSource}</div>
+          <div>
+            {p.segment.simplePhonetics}
+            {p.segment.audioTrack && (
+              <FormAudio
+                endTime={p.segment.audioTrack.endTime}
+                index={p.segment.audioTrack.index}
+                parentTrack=""
+                resourceUrl={p.segment.audioTrack.resourceUrl}
+                startTime={p.segment.audioTrack.startTime}
+              />
+            )}
+          </div>
+        </>
+      )
+    } else if (p.segment.audioTrack) {
+      phonetics = (
+        <div className={css.audioContainer}>
+          <FormAudio
+            endTime={p.segment.audioTrack.endTime}
+            index={p.segment.audioTrack.index}
+            parentTrack=""
+            resourceUrl={p.segment.audioTrack.resourceUrl}
+            startTime={p.segment.audioTrack.startTime}
+          />
+        </div>
+      )
     }
-) => {
-    if (p.segment) {
-        const disclosure = useDisclosureState({ visible: true });
-        const translation = p.segment.englishGloss.join(", ")
-        return (
-            <div className={css.wholePanel}>
-                
-                <div 
-                className={css.wordPanelContent}>
-                    <Button className={css.wordPanelButton} onClick={() => p.setContent(null)}>X</Button>
 
-                    <h2>{p.segment.source}</h2> 
-                    {p.segment.simplePhonetics ? (
-                    <>
-                        <div>{p.segment.romanizedSource}</div>
-                        <div>
-                        {p.segment.simplePhonetics}
-                        {p.segment.audioTrack && (
-                            <FormAudio
-                            endTime={p.segment.audioTrack.endTime}
-                            index={p.segment.audioTrack.index}
-                            parentTrack=""
-                            resourceUrl={p.segment.audioTrack.resourceUrl}
-                            startTime={p.segment.audioTrack.startTime}
-                            />
-                        )}
-                        </div>
-                    </>
-                    ) : (
-                    (p.segment.audioTrack && (
-                        <div className={css.audioContainer}>
-                        <FormAudio
-                            endTime={p.segment.audioTrack.endTime}
-                            index={p.segment.audioTrack.index}
-                            parentTrack=""
-                            resourceUrl={p.segment.audioTrack.resourceUrl}
-                            startTime={p.segment.audioTrack.startTime}
-                        />
-                        </div>
-                    )) || (
-                        <>
-                        <br />
-                        <br />
-                        </>
-                    )
-                    )}
-
-                    {<MorphemicSegmentation
-                            segments={p.segment.segments}
-                            onOpenDetails={p.onOpenDetails}
-                            level={p.viewMode}
-                            tagSet={p.tagSet}
-                        />}
-                    {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
-                </div>
-            </div>
-        )
-    }
-    else {
-        return (
-            <p>No word has been selected</p>
-        )
-    }
-    
+    return (
+      <div className={css.wholePanel}>
+        <div className={css.wordPanelContent}>
+          <Button
+            className={css.wordPanelButton}
+            onClick={() => p.setContent(null)}
+            aria-label="Close Word Details"
+          >
+            <MdClose size={32} />
+          </Button>
+          <h2>Selected word:</h2>
+          <h1>{p.segment.source}</h1>
+          {phonetics}
+          {
+            <MorphemicSegmentation
+              segments={p.segment.segments}
+              onOpenDetails={p.onOpenDetails}
+              level={p.viewMode}
+              tagSet={p.tagSet}
+            />
+          }
+          {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
+        </div>
+      </div>
+    )
+  } else {
+    return <p>No word has been selected</p>
+  }
 }

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -76,14 +76,12 @@ export const WordPanel = (p: {
         <h1>Selected word:</h1>
         <h2 className={css.cherHeader}>{p.segment.source}</h2>
         {phonetics}
-        {
-          <MorphemicSegmentation
-            segments={p.segment.segments}
-            onOpenDetails={p.onOpenDetails}
-            level={p.viewMode}
-            tagSet={p.tagSet}
-          />
-        }
+        <MorphemicSegmentation
+          segments={p.segment.segments}
+          onOpenDetails={p.onOpenDetails}
+          level={p.viewMode}
+          tagSet={p.tagSet}
+        />
         {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
         <br />
         <p>{p.segment.commentary}</p>

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -65,28 +65,28 @@ export const WordPanel = (p: {
     }
 
     return (
-      <div className={css.wholePanel}>
-        <div className={css.wordPanelContent}>
-          <Button
-            className={css.wordPanelButton}
-            onClick={() => p.setContent(null)}
-            aria-label="Close Word Details"
-          >
-            <MdClose size={32} />
-          </Button>
-          <h2>Selected word:</h2>
-          <h1>{p.segment.source}</h1>
-          {phonetics}
-          {
-            <MorphemicSegmentation
-              segments={p.segment.segments}
-              onOpenDetails={p.onOpenDetails}
-              level={p.viewMode}
-              tagSet={p.tagSet}
-            />
-          }
-          {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
-        </div>
+      <div className={css.wordPanelContent}>
+        <Button
+          className={css.wordPanelButton.basic}
+          onClick={() => p.setContent(null)}
+          aria-label="Close Word Details"
+        >
+          <MdClose size={32} />
+        </Button>
+        <h1>Selected word:</h1>
+        <h2>{p.segment.source}</h2>
+        {phonetics}
+        {
+          <MorphemicSegmentation
+            segments={p.segment.segments}
+            onOpenDetails={p.onOpenDetails}
+            level={p.viewMode}
+            tagSet={p.tagSet}
+          />
+        }
+        {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
+        <br />
+        <p>{p.segment.commentary}</p>
       </div>
     )
   } else {


### PR DESCRIPTION
This adds a word panel to the side of the translation tab that can be opened up by clicking on a word.

![image](https://user-images.githubusercontent.com/92126390/153958074-19295c17-d7b1-4175-b8f9-d651b42d644c.png)

This Word panel remains on the side even as the main text is scrolled past or before, and a rectangle points out what word has been selected. The word panel has an "X" that will close the panel, but clicking on another word will change what word's details the panel is showing. 

![image](https://user-images.githubusercontent.com/92126390/153958590-648dead2-5280-454d-aa74-5891c8ae323a.png)

On a smaller screen or mobile device, the word panel will appear on a drawer from the right side. This drawer can be closed by either clicking the "X", or simply clicking off the drawer.