### PR TITLE
[DP-128] Adding Collapsible Details Panels to the Word Panel

### DIFF
--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -4,9 +4,13 @@ import sprinkles, {
   colors,
   hspace,
   mediaQueries,
+  radii,
   theme,
+  thickness,
   vspace,
 } from "./sprinkles.css"
+
+const wordPanelPadding = "8px"
 
 export const cherHeader = style({
   color: colors.headings,
@@ -15,21 +19,61 @@ export const cherHeader = style({
 
 export const wordPanelButton = styleVariants({
   basic: [closeButton],
+  colpright: [
+    closeButton,
+    {
+      position: "relative",
+      float: "right",
+      top: "0px",
+    },
+  ],
+  colpleft: [
+    closeButton,
+    {
+      position: "relative",
+      float: "left",
+      top: "0px",
+      marginRight: wordPanelPadding,
+      left: "0px",
+    },
+  ],
+})
+
+export const collPanelContent = style({
+  padding: wordPanelPadding,
+  marginBottom: "0px",
+})
+
+export const collPanelButton = style({
+  flex: 1,
+  backgroundColor: "rgba(0, 0, 0, 0)",
+  border: "none",
+  textAlign: "left",
+  padding: wordPanelPadding,
+})
+
+export const collPanel = style({
+  width: "inherit",
+  display: "flex",
+  flexDirection: "column",
+  border: "1px solid #ddd",
 })
 
 export const wordPanelContent = style({
   position: "sticky",
-  top: 125,
-  height: "calc(100vh - 150px)",
+  top: 100,
+
   border: "none",
   borderRadius: "4px",
-  padding: "8px",
+  padding: wordPanelPadding,
   fontFamily: theme.fonts.body,
   "@media": {
     [mediaQueries.medium]: {
       border: "1px solid #ddd",
+      height: "calc(100vh - 125px)",
     },
   },
+  overflowY: "auto",
 })
 
 export const audioContainer = style({ paddingLeft: "40%" })

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -1,5 +1,7 @@
 import React from "react"
-import { MdClose } from "react-icons/md"
+import { AiFillCaretDown, AiFillCaretUp } from "react-icons/ai"
+import { IoEllipsisHorizontalCircle } from "react-icons/io5"
+import { MdClose, MdNotes, MdRecordVoiceOver } from "react-icons/md"
 import { Button } from "reakit/Button"
 import {
   Disclosure,
@@ -75,19 +77,77 @@ export const WordPanel = (p: {
         </Button>
         <h1>Selected word:</h1>
         <h2 className={css.cherHeader}>{p.segment.source}</h2>
-        {phonetics}
-        <MorphemicSegmentation
-          segments={p.segment.segments}
-          onOpenDetails={p.onOpenDetails}
-          level={p.viewMode}
-          tagSet={p.tagSet}
+        <CollapsiblePanel
+          title={"Phonetics"}
+          content={<>{phonetics}</>}
+          icon={
+            <MdRecordVoiceOver
+              size={24}
+              className={css.wordPanelButton.colpleft}
+            />
+          }
         />
-        {translation.length ? <div>&lsquo;{translation}&rsquo;</div> : <br />}
-        <br />
-        <p>{p.segment.commentary}</p>
+
+        <CollapsiblePanel
+          title={"Word Parts"}
+          content={
+            <>
+              <MorphemicSegmentation
+                segments={p.segment.segments}
+                onOpenDetails={p.onOpenDetails}
+                level={p.viewMode}
+                tagSet={p.tagSet}
+              />
+              {translation.length ? (
+                <div>&lsquo;{translation}&rsquo;</div>
+              ) : (
+                <br />
+              )}
+            </>
+          }
+          icon={
+            <IoEllipsisHorizontalCircle
+              size={24}
+              className={css.wordPanelButton.colpleft}
+            />
+          }
+        />
+        {p.segment.commentary ? (
+          <CollapsiblePanel
+            title={"Commentary"}
+            content={<>{p.segment.commentary}</>}
+            icon={
+              <MdNotes size={24} className={css.wordPanelButton.colpleft} />
+            }
+          />
+        ) : null}
       </div>
     )
   } else {
     return <p>No word has been selected</p>
   }
+}
+
+const CollapsiblePanel = (p: {
+  title: String
+  content: JSX.Element
+  icon: JSX.Element // Note : this is supposed to be an IconType
+}) => {
+  const disclosure = useDisclosureState({ visible: true })
+  return (
+    <div className={css.collPanel}>
+      <Disclosure {...disclosure} className={css.collPanelButton}>
+        {p.icon}
+        {" " + p.title}
+        {disclosure.visible ? (
+          <AiFillCaretDown className={css.wordPanelButton.colpright} />
+        ) : (
+          <AiFillCaretUp className={css.wordPanelButton.colpright} />
+        )}
+      </Disclosure>
+      <DisclosureContent {...disclosure} className={css.collPanelContent}>
+        {p.content}
+      </DisclosureContent>
+    </div>
+  )
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/92126390/157323591-1609106a-b333-4163-be0e-f18f28fb8b32.png)
The Word Panel now has its details show in collapsible panels.
![image](https://user-images.githubusercontent.com/92126390/157323709-8916a5e7-1517-4f28-b00f-26fa66e994e1.png)
The right arrow also changes based on whether the details are open are not. 
![image](https://user-images.githubusercontent.com/92126390/157323848-a31ecbe2-19dd-46e5-85eb-54cce7f57739.png)
If there are more details than can fit on the word panel, the word panel gets a scroll bar.

Some other notes:
- The last collapsible panel for commentary is only visible for when the word has commentary. Otherwise, only the first two appear.
- I've also added a new element function that will create collapsible panels based on Title, Icon, and Content. This is so that any future details can be added to the word panel.