### PR TITLE
Initial attempt to provision bastion host

### DIFF
--- a/terraform/bastion-host.nix
+++ b/terraform/bastion-host.nix
@@ -14,6 +14,8 @@
     stage = config.setup.stage;
     name = "bastion";
 
+    key_name = "dailp-deployment-terraform";
+
     assign_eip_address = true;
     associate_public_ip_address = true;
     vpc_id = config.setup.vpc;

--- a/terraform/bastion-host.nix
+++ b/terraform/bastion-host.nix
@@ -22,7 +22,7 @@
     # Don't create a new security group for this server.
     security_group_enabled = false;
     # Use the existing one setup for MongoDB access.
-    security_groups = ["\${aws_security_group.nixos_test.id}"];
+    security_groups = ["\${aws_security_group.mongodb_access.id}" "\${aws_security_group.nixos_test.id}"];
 
     tags = config.setup.global_tags // config.servers.bastion.instance_tags;
   };

--- a/terraform/bastion-host.nix
+++ b/terraform/bastion-host.nix
@@ -5,7 +5,7 @@
   };
 
   config.module.bastion_host = {
-    source = "github.com/cloudposse/terraform-aws-ec2-bastion-server?rev=7f8fc52095ef466fedd1c06876e281a1ac6bb75b";
+    source = "github.com/cloudposse/terraform-aws-ec2-bastion-server?ref=7f8fc52095ef466fedd1c06876e281a1ac6bb75b";
     enabled = true;
     instance_type = "t4g.micro";
 

--- a/terraform/bastion-host.nix
+++ b/terraform/bastion-host.nix
@@ -1,0 +1,29 @@
+{ lib, config, ... }:
+{
+  options.servers.bastion = with lib; with types; {
+    instance_tags = mkOption { type = attrsOf str; };
+  };
+
+  config.module.bastion_host = {
+    source = "github.com/cloudposse/terraform-aws-ec2-bastion-server?rev=7f8fc52095ef466fedd1c06876e281a1ac6bb75b";
+    enabled = true;
+    instance_type = "t4g.micro";
+
+    # ID will be constructed from these namespace, stage, and name for some reason.
+    namespace = "dailp";
+    stage = config.setup.stage;
+    name = "bastion";
+
+    assign_eip_address = true;
+    associate_public_ip_address = true;
+    vpc_id = config.setup.vpc;
+    subnets = [config.setup.subnets.primary config.setup.subnets.secondary config.setup.subnets.tertiary];
+
+    # Don't create a new security group for this server.
+    security_group_enabled = false;
+    # Use the existing one setup for MongoDB access.
+    security_groups = ["\${aws_security_group.nixos_test.id}"];
+
+    tags = config.setup.global_tags // config.servers.bastion.instance_tags;
+  };
+}

--- a/terraform/main.nix
+++ b/terraform/main.nix
@@ -23,6 +23,7 @@ in {
     ./website.nix
     ./nu-tags.nix
     ./database-sql.nix
+    ./bastion-host.nix
   ];
 
   # Gives all modules access to which stage we're deploying to, while also

--- a/terraform/nu-tags.nix
+++ b/terraform/nu-tags.nix
@@ -24,5 +24,10 @@
     "nu:function" = "database";
     "nu:backups" = "no";
   };
+  servers.bastion.instance_tags = {
+    "nu:function" = "bastion";
+    "nu:os" = "linux";
+    "nu:backups" = "no";
+  };
   functions.tags = { "nu:function" = "application-server"; };
 }


### PR DESCRIPTION
Provision a bastion host to allow external access to our database, but only for IP addresses configured in the `mongodb_access` security group. This equates to: 1. NEU VPN, and 2. GitHub Actions runners.