### PR TITLE
Optimize data migration process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       AWS_SSH_KEY: ${{ secrets.AWS_SSH_KEY }}
       GIT_REPOSITORY_URL: https://github.com/neu-dsg/dailp-encoding
       OAUTH_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-      RUST_LOG: info
+      RUST_LOG: warn
       TF_STAGE: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -126,7 +126,7 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -H $BASTION_IP >> ~/.ssh/known_hosts
           echo "Forwarding port 5432 to remote database $DATABASE_ENDPOINT through $BASTION_IP"
-          ssh -i ./dailp-deployment-key.pem -f -N -L 5432:$DATABASE_ENDPOINT ec2-user@$BASTION_IP -v
+          ssh -i ./dailp-deployment-key.pem -f -N -L 5432:$DATABASE_ENDPOINT ec2-user@$BASTION_IP
 
           export DAILP_API_URL=$(nix run --impure .#tf-output functions_url)
           export MONGODB_URI=mongodb://$(nix run --impure .#tf-output mongodb_primary_ip):27017

--- a/.github/workflows/migrate-data.yml
+++ b/.github/workflows/migrate-data.yml
@@ -16,10 +16,9 @@ jobs:
       AWS_SUBNET_SECONDARY1: ${{ secrets.AWS_SUBNET_SECONDARY1 }}
       AWS_ZONE_SECONDARY1: ${{ secrets.AWS_ZONE_SECONDARY1 }}
       AWS_SSH_KEY: ${{ secrets.AWS_SSH_KEY }}
-      AWS_BASTION_SSH_KEY: ${{ secrets.AWS_BASTION_SSH_KEY }}
       GIT_REPOSITORY_URL: https://github.com/neu-dsg/dailp-encoding
       OAUTH_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-      RUST_LOG: info
+      RUST_LOG: warn
       TF_STAGE: dev
     steps:
       - name: Checkout code
@@ -60,8 +59,9 @@ jobs:
         # Port forward 5432 to remote database
         run: |
           nix run --impure -L .#tf-init
+
           echo "Creating SSH key file..."
-          echo $AWS_BASTION_SSH_KEY > dailp-deployment-key.pem
+          echo "${{secrets.AWS_BASTION_SSH_KEY}}" > dailp-deployment-key.pem
           chmod 400 dailp-deployment-key.pem
           echo "Retrieving terraform outputs..."
           BASTION_IP=$(nix run --impure .#tf-output bastion_ip)

--- a/migration/src/audio.rs
+++ b/migration/src/audio.rs
@@ -69,7 +69,7 @@ pub struct AudioRes {
 impl AudioRes {
     /// Calls the DRS API and collates the returned metadata
     pub async fn new(audio_drs_id: &str, annotation_drs_id: &str) -> Result<Self, anyhow::Error> {
-        info!("Creating new Audio Resource");
+        println!("Creating new Audio Resource...");
         // Prepare to call the DRS repeatedly
         let client = Client::new();
         // Get the DRS object for the audio file, using a provided ID

--- a/migration/src/lexical.rs
+++ b/migration/src/lexical.rs
@@ -110,11 +110,10 @@ pub async fn migrate_dictionaries(db: &Database) -> Result<()> {
 
     println!("Pushing entries to database...");
     // Push all lexical entries to the database.
-    try_join_all(entries.into_iter().map(|entry| {
+    for entry in entries {
         // Push all the surface forms to the sea of words.
-        db.insert_lexical_entry(entry.entry, entry.forms)
-    }))
-    .await?;
+        db.insert_lexical_entry(entry.entry, entry.forms).await?;
+    }
 
     // DF1975 Grammatical Appendix (PF1975)
     parse_appendix(db, "1VjpKXMqb7CgFKE5lk9E6gqL-k6JKZ3FVUvhnqiMZYQg", 2).await?;

--- a/migration/src/lexical.rs
+++ b/migration/src/lexical.rs
@@ -107,7 +107,7 @@ pub async fn migrate_dictionaries(db: &Database) -> Result<()> {
         .chain(ptcp_nouns)
         .chain(inf_nouns);
 
-    info!("Pushing entries to database...");
+    println!("Pushing entries to database...");
     // Push all lexical entries to the database.
     for entry in entries {
         // Push all the surface forms to the sea of words.

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -77,6 +77,7 @@ async fn migrate_data(db: &Database) -> Result<()> {
     // This process encodes the ordering in the Index sheet to allow us to
     // manually order different document collections.
     let mut morpheme_relations = Vec::new();
+    let mut document_contents = Vec::new();
     for (coll_index, collection) in index.collections.into_iter().enumerate() {
         let collection_id = db
             .insert_top_collection(collection.title, coll_index as i64)
@@ -87,12 +88,19 @@ async fn migrate_data(db: &Database) -> Result<()> {
             {
                 morpheme_relations.append(&mut refs);
                 // spreadsheets::write_to_file(&doc)?;
-                db.insert_document_contents(doc).await?;
+                document_contents.push(doc);
             } else {
                 error!("Failed to process {}", sheet_id);
             }
         }
     }
+
+    try_join_all(
+        document_contents
+            .into_iter()
+            .map(|doc| db.insert_document_contents(doc)),
+    )
+    .await?;
 
     try_join_all(
         morpheme_relations

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -25,25 +25,24 @@ async fn main() -> Result<()> {
 
     let db = Database::connect().await?;
 
-    info!("Migrating Image Sources");
+    println!("Migrating Image Sources...");
     migrate_image_sources(&db).await?;
 
-    info!("Migrating contributors");
+    println!("Migrating contributors...");
     contributors::migrate_all(&db).await?;
 
-    info!("Migrating tags to database...");
+    println!("Migrating tags to database...");
     tags::migrate_tags(&db).await?;
 
-    info!("Migrating DF1975 and DF2003...");
+    println!("Migrating DF1975 and DF2003...");
     lexical::migrate_dictionaries(&db).await?;
 
-    info!("Migrating early vocabularies...");
+    println!("Migrating early vocabularies...");
     early_vocab::migrate_all(&db).await?;
-
-    info!("Migrating connections...");
 
     migrate_data(&db).await?;
 
+    println!("Migrating connections...");
     connections::migrate_connections(&db).await?;
 
     Ok(())
@@ -69,7 +68,7 @@ async fn migrate_data(db: &Database) -> Result<()> {
             .await?
             .into_index()?;
 
-    info!("Migrating documents to database...");
+    println!("Migrating documents to database...");
 
     // Retrieve data for spreadsheets in sequence.
     // Because of Google API rate limits, we have to process them sequentially
@@ -117,10 +116,10 @@ async fn fetch_sheet(
     if let Ok(meta_sheet) = meta {
         let meta = meta_sheet.into_metadata(db, false, order_index).await?;
 
-        info!("---Processing document: {}---", meta.short_name);
+        println!("---Processing document: {}---", meta.short_name);
 
         // Parse references for this particular document.
-        info!("parsing references...");
+        println!("parsing references...");
         let refs =
             spreadsheets::SheetResult::from_sheet(sheet_id, Some(REFERENCES_SHEET_NAME)).await;
         let refs = if let Ok(refs) = refs {
@@ -147,7 +146,7 @@ async fn fetch_sheet(
         // Each document page lives in its own tab.
         for index in 0..page_count {
             let tab_name = if page_count > 1 {
-                info!("Pulling Page {}...", index + 1);
+                println!("Pulling Page {}...", index + 1);
                 Some(format!("Page {}", index + 1))
             } else {
                 None

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -11,6 +11,7 @@ mod translations;
 
 use anyhow::Result;
 use dailp::{Database, Uuid};
+use futures::future::try_join_all;
 use log::{error, info};
 use std::time::Duration;
 
@@ -93,9 +94,12 @@ async fn migrate_data(db: &Database) -> Result<()> {
         }
     }
 
-    for l in morpheme_relations {
-        db.insert_morpheme_relation(l).await?;
-    }
+    try_join_all(
+        morpheme_relations
+            .into_iter()
+            .map(|l| db.insert_morpheme_relation(l)),
+    )
+    .await?;
 
     Ok(())
 }

--- a/migration/src/tags.rs
+++ b/migration/src/tags.rs
@@ -16,7 +16,7 @@ pub async fn migrate_tags(db: &Database) -> Result<()> {
     )
     .await;
 
-    info!("Parsing sheet results...");
+    println!("Parsing sheet results...");
     let glossary = parse_tag_glossary(glossary?)?;
 
     let crg = db
@@ -29,7 +29,7 @@ pub async fn migrate_tags(db: &Database) -> Result<()> {
         .insert_morpheme_system("LEARNER".into(), "Learner System".into())
         .await?;
 
-    info!("Pushing tags to db...");
+    println!("Pushing tags to db...");
     for tag in glossary {
         db.insert_morpheme_tag(tag, crg, taoc, learner).await?;
     }

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -225,6 +225,54 @@
     },
     "query": "insert into morpheme_gloss (document_id, gloss, example_shape, tag_id)\n  values ($1, $2, $3, $4)\non conflict (document_id, gloss)\n  do update set example_shape = excluded.example_shape,\n     tag_id = excluded.tag_id\nreturning id\n"
   },
+  "271ddc6e129a3b2b8a6fed0d17222ae54ba19990886b020b5fd96789e9e43d80": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "short_name",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "title",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "written_at",
+          "ordinal": 3,
+          "type_info": "Date"
+        },
+        {
+          "name": "is_reference",
+          "ordinal": 4,
+          "type_info": "Bool"
+        },
+        {
+          "name": "contributors",
+          "ordinal": 5,
+          "type_info": "Jsonb"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        false,
+        null
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "select\n  d.id,\n  d.short_name,\n  d.title,\n  d.written_at,\n  d.is_reference,\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'name', contributor.full_name, 'role', attr.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  )\n  as contributors\nfrom document as d\n  left join contributor_attribution as attr on attr.document_id = d.id\n  left join contributor on contributor.id = attr.contributor_id\ngroup by d.id\n"
+  },
   "2874ae8f9cec1ce09c268adc74b096a15ca1d90cbb324289c679df9e451cb2ee": {
     "describe": {
       "columns": [],
@@ -1673,53 +1721,5 @@
       }
     },
     "query": "insert into word (source_text, simple_phonetics, phonemic, english_gloss, recorded_at, commentary,\n  document_id, page_number, index_in_document, page_id, character_range)\nvalues ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\non conflict (document_id, index_in_document)\ndo update set\n  source_text = EXCLUDED.source_text,\n  simple_phonetics = EXCLUDED.simple_phonetics,\n  phonemic = EXCLUDED.phonemic,\n  english_gloss = EXCLUDED.english_gloss,\n  commentary = EXCLUDED.commentary\nreturning id\n"
-  },
-  "ff0aa95d3c2d21fdd4e03be8957b1637ffb6cffb6fae76021997b8a5c85e3e65": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "short_name",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "title",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "written_at",
-          "ordinal": 3,
-          "type_info": "Date"
-        },
-        {
-          "name": "is_reference",
-          "ordinal": 4,
-          "type_info": "Bool"
-        },
-        {
-          "name": "contributors",
-          "ordinal": 5,
-          "type_info": "Jsonb"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        true,
-        false,
-        null
-      ],
-      "parameters": {
-        "Left": []
-      }
-    },
-    "query": "select\n  d.id,\n  d.short_name,\n  d.title,\n  d.written_at,\n  d.is_reference,\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'name', contributor.full_name, 'role', attr.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  )\n  as contributors\nfrom document as d\n  left join contributor_attribution as attr on attr.document_id = d.id\n  left join contributor on contributor.id = attr.contributor_id\ngroup by d.id,\n  attr.contributor_id,\n  attr.document_id\n"
   }
 }

--- a/types/queries/all_documents.sql
+++ b/types/queries/all_documents.sql
@@ -16,6 +16,4 @@ select
 from document as d
   left join contributor_attribution as attr on attr.document_id = d.id
   left join contributor on contributor.id = attr.contributor_id
-group by d.id,
-  attr.contributor_id,
-  attr.document_id
+group by d.id

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -3,6 +3,7 @@ use {
     anyhow::Result,
     async_graphql::dataloader::*,
     async_trait::async_trait,
+    futures::future::try_join_all,
     itertools::Itertools,
     sqlx::{
         postgres::{types::PgRange, PgPoolOptions},
@@ -23,7 +24,7 @@ impl Database {
     pub async fn connect() -> Result<Self> {
         let db_url = std::env::var("DATABASE_URL")?;
         let conn = PgPoolOptions::new()
-            .max_connections(1)
+            .max_connections(2)
             .connect(&db_url)
             .await?;
         Ok(Database { client: conn })
@@ -577,13 +578,18 @@ impl Database {
         &self,
         forms: impl Iterator<Item = AnnotatedForm>,
     ) -> Result<()> {
-        let mut tx = self.client.begin().await?;
-        for form in forms {
-            let doc_id = form.position.document_id.0;
-            self.insert_word(&mut tx, form, doc_id, None, None).await?;
-        }
-        tx.commit().await?;
+        try_join_all(forms.map(|form| self.only_insert_word(form))).await?;
         Ok(())
+    }
+
+    async fn only_insert_word<'a>(&self, form: AnnotatedForm) -> Result<Uuid> {
+        let mut tx = self.client.begin().await?;
+        let document_id = form.position.document_id.0;
+        let id = self
+            .insert_word(&mut tx, form, document_id, None, None)
+            .await?;
+        tx.commit().await?;
+        Ok(id)
     }
 
     pub async fn insert_word<'a>(

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -11,6 +11,7 @@ use {
     },
     std::collections::HashMap,
     std::sync::Arc,
+    std::time::Duration,
     tokio_stream::StreamExt,
     uuid::Uuid,
 };
@@ -24,7 +25,8 @@ impl Database {
     pub async fn connect() -> Result<Self> {
         let db_url = std::env::var("DATABASE_URL")?;
         let conn = PgPoolOptions::new()
-            .max_connections(2)
+            .max_connections(std::thread::available_parallelism().map_or(2, |x| x.get() as u32))
+            .connect_timeout(Duration::from_secs(60))
             .connect(&db_url)
             .await?;
         Ok(Database { client: conn })


### PR DESCRIPTION
- Migrations from spreadsheets to postgres are currently painfully slow
- It's because we make a bunch of round trips to the DB in the process
- We were also emitting a ton of logs, which can sometimes slow things down

Solutions:
- Run big chunks of the migration process, especially for the lexical datasets, concurrently so that more work can be done while waiting for other database insertions to finish.
- Reduce the log level for CI workflows to `warn` and turn some of our log messages into normal `println` calls so that we always see them, no matter what the log level is.