### PR TITLE
Optimize migrations further

### DIFF
--- a/migration/src/lexical.rs
+++ b/migration/src/lexical.rs
@@ -86,6 +86,17 @@ pub async fn migrate_dictionaries(db: &Database) -> Result<()> {
         3,
     );
 
+    let entries = df1975
+        .chain(df2003)
+        .chain(root_nouns)
+        .chain(root_adjs)
+        .chain(body_parts)
+        .chain(irreg_nouns)
+        .chain(ptcp_nouns)
+        .chain(inf_nouns);
+
+    println!("Pushing entries to database...");
+
     parse_numerals(
         db,
         "1MB_FCG3QhmX-pw9t9PyMtFlV8SCvgXzWz8B9BdvEtec",
@@ -99,16 +110,6 @@ pub async fn migrate_dictionaries(db: &Database) -> Result<()> {
 
     ingest_ac1995(db, "1x02KTuF0yyEFcrJwkfFiBKj79ysQTZfLKB6hKeq-ZT8").await?;
 
-    let entries = df1975
-        .chain(df2003)
-        .chain(root_nouns)
-        .chain(root_adjs)
-        .chain(body_parts)
-        .chain(irreg_nouns)
-        .chain(ptcp_nouns)
-        .chain(inf_nouns);
-
-    println!("Pushing entries to database...");
     // Push all lexical entries to the database.
     for entry in entries {
         // Push all the surface forms to the sea of words.

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -119,7 +119,7 @@ pub async fn batch_join_all<
     it: I,
 ) -> Result<()> {
     use futures::StreamExt;
-    let mut all_done = futures::stream::iter(it).buffer_unordered(4);
+    let mut all_done = futures::stream::iter(it).buffer_unordered(8);
     while let Some(res) = all_done.next().await {
         res?;
     }

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -119,7 +119,7 @@ pub async fn batch_join_all<
     it: I,
 ) -> Result<()> {
     use futures::StreamExt;
-    let mut all_done = futures::stream::iter(it).buffer_unordered(8);
+    let mut all_done = futures::stream::iter(it).buffer_unordered(6);
     while let Some(res) = all_done.next().await {
         res?;
     }

--- a/migration/src/tags.rs
+++ b/migration/src/tags.rs
@@ -1,3 +1,4 @@
+use crate::batch_join_all;
 use crate::spreadsheets::SheetResult;
 use anyhow::Result;
 use dailp::{Database, MorphemeTag, TagForm};
@@ -30,9 +31,12 @@ pub async fn migrate_tags(db: &Database) -> Result<()> {
         .await?;
 
     println!("Pushing tags to db...");
-    for tag in glossary {
-        db.insert_morpheme_tag(tag, crg, taoc, learner).await?;
-    }
+    batch_join_all(
+        glossary
+            .into_iter()
+            .map(|tag| db.insert_morpheme_tag(tag, crg, taoc, learner)),
+    )
+    .await?;
 
     Ok(())
 }

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -353,26 +353,6 @@
     },
     "query": "select\n  id,\n  source_text,\n  simple_phonetics,\n  phonemic,\n  english_gloss,\n  commentary,\n  document_id,\n  index_in_document,\n  page_number\nfrom word\nwhere source_text ilike $1\n  or simple_phonetics ilike $1\n  or english_gloss ilike $1\n"
   },
-  "2d0fce2bf80b70718b421e5ace5ecbe7bca8a2b5cb3b421ef76431c4599f0cd6": {
-    "describe": {
-      "columns": [
-        {
-          "name": "gloss_id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      }
-    },
-    "query": "select morpheme_gloss.id as gloss_id\nfrom morpheme_gloss\n  inner join\n    abstract_morpheme_tag as abstract on morpheme_gloss.tag_id = abstract.id\nwhere document_id is null and gloss = $1\n"
-  },
   "30cd42e3b5c9974cb94b5b116e35555ca460648807f08265a80375f2edd92c53": {
     "describe": {
       "columns": [
@@ -1159,32 +1139,6 @@
     },
     "query": "insert into contributor (full_name)\nvalues ($1)\non conflict (full_name) do update\nset full_name = EXCLUDED.full_name\n"
   },
-  "992e1fe8f13bc7d96a99bd4672fd5135cd536202fba0c78a668888dd6224637f": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int8",
-          "Text",
-          "Uuid",
-          {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "Morpheme",
-                  "Clitic"
-                ]
-              },
-              "name": "segment_type"
-            }
-          }
-        ]
-      }
-    },
-    "query": "insert into word_segment (word_id, index_in_word, morpheme, gloss_id, followed_by)\nvalues ($1, $2, $3, $4, $5)\non conflict (word_id, index_in_word)\n  do update set\n    morpheme = EXCLUDED.morpheme,\n    gloss_id = EXCLUDED.gloss_id,\n    followed_by = EXCLUDED.followed_by\n"
-  },
   "992ff11ed26e43847c6b73fa0c8be2eb3b4268f192fa309f39252b5b68e00eb9": {
     "describe": {
       "columns": [
@@ -1369,6 +1323,33 @@
       }
     },
     "query": "with t as (\n  select distinct on (morpheme_tag.gloss)\n    abbreviation_system.short_name as system_name,\n    morpheme_tag.gloss,\n    morpheme_tag.title,\n    abstract_morpheme_tag.description,\n    abstract_morpheme_tag.linguistic_type\n  from abbreviation_system\n    inner join\n      morpheme_tag on abbreviation_system.id = morpheme_tag.system_id\n    inner join\n      abstract_morpheme_tag on\n        abstract_morpheme_tag.id = any(morpheme_tag.abstract_ids)\n  where abbreviation_system.short_name = $1\n)\n\nselect *\nfrom t\norder by linguistic_type asc, gloss asc;\n"
+  },
+  "ca83210b006993f01c2ad98d67410d22e0f633d560482988b442bfb10dd6a1f0": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Uuid",
+          "Int8",
+          "Text",
+          {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "Morpheme",
+                  "Clitic"
+                ]
+              },
+              "name": "segment_type"
+            }
+          }
+        ]
+      }
+    },
+    "query": "-- Look for a matching global gloss before trying to create a document-local gloss.\nwith global_gloss as (\n  select morpheme_gloss.id\n  from morpheme_gloss\n    inner join\n      abstract_morpheme_tag as abstract on morpheme_gloss.tag_id = abstract.id\n  where document_id is null and gloss = $2\n  limit 1\n), inserted_gloss as (\n  insert into morpheme_gloss (document_id, gloss)\n    select $1, $2\n    where not exists (select id from global_gloss)\n  on conflict (document_id, gloss)\n    do update set example_shape = excluded.example_shape,\n       tag_id = excluded.tag_id\n  returning id\n)\n\ninsert into word_segment (word_id, index_in_word, morpheme, gloss_id, followed_by)\nselect $3, $4, $5, coalesce(global_gloss.id, inserted_gloss.id), $6\nfrom global_gloss, inserted_gloss\non conflict (word_id, index_in_word)\n  do update set\n    morpheme = EXCLUDED.morpheme,\n    gloss_id = EXCLUDED.gloss_id,\n    followed_by = EXCLUDED.followed_by\n"
   },
   "d6377d5a54a702f7df73f287390c0c45a1309f7e705c93d49842b409a947a1fd": {
     "describe": {

--- a/types/queries/upsert_word_segment.sql
+++ b/types/queries/upsert_word_segment.sql
@@ -1,5 +1,24 @@
+-- Look for a matching global gloss before trying to create a document-local gloss.
+with global_gloss as (
+  select morpheme_gloss.id
+  from morpheme_gloss
+    inner join
+      abstract_morpheme_tag as abstract on morpheme_gloss.tag_id = abstract.id
+  where document_id is null and gloss = $2
+  limit 1
+), inserted_gloss as (
+  insert into morpheme_gloss (document_id, gloss)
+    select $1, $2
+    where not exists (select id from global_gloss)
+  on conflict (document_id, gloss)
+    do update set example_shape = excluded.example_shape,
+       tag_id = excluded.tag_id
+  returning id
+)
+
 insert into word_segment (word_id, index_in_word, morpheme, gloss_id, followed_by)
-values ($1, $2, $3, $4, $5)
+select $3, $4, $5, coalesce(global_gloss.id, inserted_gloss.id), $6
+from global_gloss, inserted_gloss
 on conflict (word_id, index_in_word)
   do update set
     morpheme = EXCLUDED.morpheme,

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -621,30 +621,13 @@ impl Database {
                     .split_whitespace()
                     .join(".");
 
-                let morpheme_tag = query_file!("queries/find_global_gloss.sql", gloss)
-                    .fetch_one(&mut tx)
-                    .await;
-
-                let gloss_id = if let Ok(morpheme_tag) = morpheme_tag {
-                    morpheme_tag.gloss_id
-                } else {
-                    query_file_scalar!(
-                        "queries/upsert_morpheme_gloss.sql",
-                        document_id,
-                        gloss,
-                        None as Option<String>,
-                        None as Option<Uuid>
-                    )
-                    .fetch_one(&mut tx)
-                    .await?
-                };
-
                 query_file!(
                     "queries/upsert_word_segment.sql",
+                    document_id,
+                    gloss,
                     word_id,
                     index as i64,
                     segment.morpheme,
-                    gloss_id,
                     segment.followed_by as Option<SegmentType>
                 )
                 .execute(&mut tx)

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -24,7 +24,7 @@ impl Database {
         let db_url = std::env::var("DATABASE_URL")?;
         let conn = PgPoolOptions::new()
             .max_connections(std::thread::available_parallelism().map_or(2, |x| x.get() as u32))
-            .connect_timeout(Duration::from_secs(60 * 2))
+            .connect_timeout(Duration::from_secs(60 * 4))
             // Disable excessive pings to the database.
             .test_before_acquire(false)
             .connect(&db_url)

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -25,6 +25,8 @@ impl Database {
         let conn = PgPoolOptions::new()
             .max_connections(std::thread::available_parallelism().map_or(2, |x| x.get() as u32))
             .connect_timeout(Duration::from_secs(60 * 2))
+            // Disable excessive pings to the database.
+            .test_before_acquire(false)
             .connect(&db_url)
             .await?;
         Ok(Database { client: conn })


### PR DESCRIPTION
- Migrations are still taking about 2 hours, though I made them slightly faster I think.
- The issue is roundtrips to the DB through an SSH tunnel. Some queries can take up to 1 second each!!
- In this PR I'm focusing on combining multiple queries into single queries where possible to just reduce the number of connections we have to make to the DB over such a slow tunnel.
- Disable the pings to the DB that `sqlx` normally makes as a health check. This should alleviate a significant amount of latency by turning the normal [ping, query, ping] => [query]