### PR TITLE
Remove lifecycle protection on MongoDB instances

### DIFF
--- a/terraform/database-nixos.nix
+++ b/terraform/database-nixos.nix
@@ -54,7 +54,7 @@ in {
         tags = {
           Name = "dailp-${toKebabCase volume.name}";
         } // config.setup.global_tags // config.servers.mongodb.storage_tags;
-        lifecycle.prevent_destroy = true;
+        lifecycle.prevent_destroy = false;
       };
 
       aws_volume_attachment."${volume.name}" = {
@@ -85,7 +85,7 @@ in {
                 Name = "dailp-${toKebabCase name}";
               } // config.setup.global_tags
                 // config.servers.mongodb.instance_tags;
-              lifecycle.prevent_destroy = true;
+              lifecycle.prevent_destroy = false;
             };
 
             aws_iam_instance_profile."${name}" = {

--- a/terraform/main.nix
+++ b/terraform/main.nix
@@ -66,8 +66,6 @@ in {
       env = {
         DATABASE_URL =
           "postgres://\${aws_db_instance.sql_database.username}:${config.servers.database.password}@\${aws_db_instance.sql_database.endpoint}/dailp";
-        MONGODB_URI =
-          "mongodb://\${aws_instance.mongodb_primary.public_dns}:27017/admin?retryWrites=true&w=majority";
       };
       endpoints = [
         {


### PR DESCRIPTION
First step toward decommissioning our MongoDB instances is removing the protection that keeps them from being accidentally deleted.