### PR TITLE
[DP-55] Support merging morphemes within words for CRG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -590,6 +590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,11 +758,11 @@ checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "aes-gcm",
  "base64 0.13.0",
- "hkdf",
+ "hkdf 0.10.0",
  "hmac 0.10.1",
  "percent-encoding",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.9.9",
  "time 0.2.27",
  "version_check",
 ]
@@ -852,6 +861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array 0.14.5",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,16 +885,6 @@ name = "crypto-mac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
-dependencies = [
- "generic-array 0.14.5",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.5",
  "subtle",
@@ -1063,6 +1072,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.5",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1480,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1513,6 +1533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,12 +1563,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac 0.11.1",
- "digest 0.9.0",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1900,13 +1928,11 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "md-5"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2780,6 +2806,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2805,6 +2842,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2897,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc15591eb44ffb5816a4a70a7efd5dd87bfd3aa84c4c200401c4396140525826"
+checksum = "551873805652ba0d912fec5bbb0f8b4cdd96baf8e2ebf5970e5671092966019b"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2907,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195183bf6ff8328bb82c0511a83faf60aacf75840103388851db61d7a9854ae3"
+checksum = "e48c61941ccf5ddcada342cd59e3e5173b007c509e1e8e990dafc830294d9dc5"
 dependencies = [
  "ahash",
  "atoi",
@@ -2922,13 +2970,15 @@ dependencies = [
  "crossbeam-queue",
  "dirs",
  "either",
+ "event-listener",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-util",
  "hashlink",
  "hex",
- "hmac 0.11.0",
+ "hkdf 0.12.3",
+ "hmac 0.12.1",
  "indexmap",
  "itoa 1.0.1",
  "libc",
@@ -2942,8 +2992,8 @@ dependencies = [
  "rustls 0.19.1",
  "serde",
  "serde_json",
- "sha-1 0.9.8",
- "sha2",
+ "sha-1 0.10.0",
+ "sha2 0.10.2",
  "smallvec",
  "sqlformat",
  "sqlx-rt",
@@ -2959,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee35713129561f5e55c554bba1c378e2a7e67f81257b7311183de98c50e6f94"
+checksum = "bc0fba2b0cae21fc00fe6046f8baa4c7fcb49e379f0f592b04696607f69ed2e1"
 dependencies = [
  "dotenv",
  "either",
@@ -2972,7 +3022,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.2",
  "sqlx-core",
  "sqlx-rt",
  "syn",
@@ -2981,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b555e70fbbf84e269ec3858b7a6515bcfe7a166a7cc9c636dd6efd20431678b6"
+checksum = "4db708cd3e459078f85f39f96a00960bd841f66ee2a669e90bf36907f5a79aae"
 dependencies = [
  "once_cell",
  "tokio",

--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "pkgs": {
       "locked": {
-        "lastModified": 1650161686,
-        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
+        "lastModified": 1651007983,
+        "narHash": "sha256-GNay7yDPtLcRcKCNHldug85AhAvBpTtPEJWSSDYBw8U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
+        "rev": "e10da1c7f542515b609f8dfbcf788f3d85b14936",
         "type": "github"
       },
       "original": {

--- a/graphql/src/lambda.rs
+++ b/graphql/src/lambda.rs
@@ -91,7 +91,7 @@ async fn handler(
     else if path.starts_with("/manifests") {
         let full_url = req.uri().to_string();
         let full_path = req.uri().path();
-        let mut parts = full_path.split("/");
+        let mut parts = full_path.split('/');
         let document_name = parts.nth(2).expect("No manifest ID given");
         let manifest = database.document_manifest(document_name, full_url).await?;
         let json = serde_json::to_string(&manifest)?;

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -210,7 +210,10 @@ impl Query {
         Ok(context
             .data::<DataLoader<Database>>()?
             .load_one(dailp::TagId(id, system))
-            .await?)
+            .await?
+            .unwrap_or_default()
+            .into_iter()
+            .next())
     }
 
     /// Search for words that match any one of the given queries.

--- a/migration/src/tags.rs
+++ b/migration/src/tags.rs
@@ -1,7 +1,7 @@
 use crate::batch_join_all;
 use crate::spreadsheets::SheetResult;
 use anyhow::Result;
-use dailp::{Database, MorphemeTag, TagForm};
+use dailp::{Database, MorphemeTag, SegmentType, TagForm, Uuid};
 use log::info;
 
 /// Cherokee has many functional morphemes that are documented.
@@ -20,24 +20,57 @@ pub async fn migrate_tags(db: &Database) -> Result<()> {
     println!("Parsing sheet results...");
     let glossary = parse_tag_glossary(glossary?)?;
 
+    // Insert all of the internal tags that each system will convert from.
+    batch_join_all(glossary.into_iter().map(|tag| db.insert_abstract_tag(tag))).await?;
+
     let crg = db
         .insert_morpheme_system("CRG".into(), "Cherokee Reference Grammar".into())
         .await?;
+    sync_morpheme_system(db, "CRG Merged Glossary", crg).await?;
     let taoc = db
         .insert_morpheme_system("TAOC".into(), "Tone and Accent in Oklahoma Cherokee".into())
         .await?;
+    sync_morpheme_system(db, "TAOC Glossary", taoc).await?;
     let learner = db
         .insert_morpheme_system("LEARNER".into(), "Learner System".into())
         .await?;
+    sync_morpheme_system(db, "Learner Glossary", learner).await?;
 
-    println!("Pushing tags to db...");
-    batch_join_all(
-        glossary
-            .into_iter()
-            .map(|tag| db.insert_morpheme_tag(tag, crg, taoc, learner)),
+    Ok(())
+}
+
+async fn sync_morpheme_system(db: &Database, sheet_name: &str, system_id: Uuid) -> Result<()> {
+    let sheet = SheetResult::from_sheet(
+        "17LSuDu7QHJfJyLDVJjO0f4wmTHQLVyHuSktr6OrbD_M",
+        Some(sheet_name),
     )
     .await?;
+    let glossary = sheet.values.into_iter().skip(1).filter_map(|row| {
+        let mut cols = row.into_iter();
+        let internal_tags_str = cols.next()?;
+        let target_tag = cols.next()?;
+        let name = cols.next()?;
+        let definition = cols.next().unwrap_or_default();
+        let _page_num = cols.next().filter(|x| !x.is_empty());
+        let shape = cols.next().filter(|x| !x.is_empty());
+        let details_url = cols.next().filter(|x| !x.is_empty());
+        let segment_type = cols.next().map_or(SegmentType::Morpheme, |s| match s.trim() {
+            "Combine" => SegmentType::Combine,
+            _ => SegmentType::Morpheme,
+        });
+        Some(TagForm {
+            internal_tags: internal_tags_str.split("-").map(|s| s.to_owned()).collect(),
+            tag: target_tag,
+            title: name,
+            definition,
+            shape,
+            details_url,
+            morpheme_type: String::new(),
+            segment_type,
+        })
+    });
 
+    batch_join_all(glossary.map(|tag| db.insert_morpheme_tag(tag, system_id))).await?;
     Ok(())
 }
 
@@ -49,7 +82,6 @@ fn parse_tag_glossary(sheet: SheetResult) -> Result<Vec<MorphemeTag>> {
         // The first row is headers.
         .skip(1)
         // There are a few empty spacing rows to ignore.
-        .filter(|row| !row.is_empty() && !row[0].is_empty())
         .filter_map(|row| {
             // Skip over allomorphs, and instead allow them to emerge from our texts.
             let mut cols = row.into_iter();
@@ -57,16 +89,7 @@ fn parse_tag_glossary(sheet: SheetResult) -> Result<Vec<MorphemeTag>> {
             let _name = cols.next()?;
             let morpheme_type = cols.next()?;
             let _dailp_form = cols.next()?;
-            let crg = parse_tag_section(&mut cols, true, &morpheme_type);
-            let taoc = parse_tag_section(&mut cols, true, &morpheme_type);
-            let learner = parse_tag_section(&mut cols, false, &morpheme_type);
-            Some(MorphemeTag {
-                id,
-                taoc,
-                crg,
-                morpheme_type,
-                learner,
-            })
+            Some(MorphemeTag { id, morpheme_type })
         })
         .collect())
 }
@@ -107,29 +130,4 @@ async fn migrate_glossary_metadata(db: &Database, sheet_id: &str) -> Result<()> 
         db.insert_dictionary_document(&doc).await?;
     }
     Ok(())
-}
-
-fn parse_tag_section(
-    values: &mut impl Iterator<Item = String>,
-    has_page: bool,
-    morpheme_type: &str,
-) -> Option<TagForm> {
-    let tag = values.next()?;
-    let title = values.next()?;
-    let definition = values.next().unwrap_or_default();
-    let _page_num = if has_page { values.next() } else { None };
-    let shape = values.next().filter(|x| !x.is_empty());
-    let details_url = values.next().filter(|x| !x.is_empty());
-    if !tag.is_empty() {
-        Some(TagForm {
-            tag,
-            title,
-            definition,
-            shape,
-            details_url,
-            morpheme_type: morpheme_type.to_owned(),
-        })
-    } else {
-        None
-    }
 }

--- a/migration/src/tags.rs
+++ b/migration/src/tags.rs
@@ -54,9 +54,10 @@ async fn sync_morpheme_system(db: &Database, sheet_name: &str, system_id: Uuid) 
         let _page_num = cols.next().filter(|x| !x.is_empty());
         let shape = cols.next().filter(|x| !x.is_empty());
         let details_url = cols.next().filter(|x| !x.is_empty());
-        let segment_type = cols.next().map_or(SegmentType::Morpheme, |s| match s.trim() {
-            "Combine" => SegmentType::Combine,
-            _ => SegmentType::Morpheme,
+        let segment_type = cols.next().and_then(|s| match s.trim() {
+            "Combine" => Some(SegmentType::Combine),
+            "Clitic" => Some(SegmentType::Clitic),
+            _ => None,
         });
         Some(TagForm {
             internal_tags: internal_tags_str.split("-").map(|s| s.to_owned()).collect(),

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -262,26 +262,6 @@
     },
     "query": "select\n  document.id as document_id,\n  document.is_reference,\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.recorded_at,\n  word.commentary,\n  word.index_in_document,\n  word.page_number\nfrom word\n  inner join document on document.id = word.document_id\n  left join word_segment on word_segment.word_id = word.id\n  inner join morpheme_gloss on morpheme_gloss.id = word_segment.gloss_id\nwhere morpheme_gloss.gloss = $1\n  and (word.document_id = $2 or $2 is null)\ngroup by document.id, word.id\norder by document.id\n"
   },
-  "20714e564b044b547847b8409845df829f46d518449846876efc7a7eb9f3d8b1": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        true
-      ],
-      "parameters": {
-        "Left": [
-          "TextArray"
-        ]
-      }
-    },
-    "query": "select abstract_morpheme_tag.id\nfrom unnest($1::text[]) as morpheme_gloss\ninner join abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss\n"
-  },
   "20b3a8559a28249b3662253e1fc300d63f1dceaf88f6fc00750bb101163212d3": {
     "describe": {
       "columns": [
@@ -429,6 +409,34 @@
       }
     },
     "query": "select\n  word_segment.morpheme,\n  word.id as word_id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number\nfrom morpheme_gloss\n  inner join document on document.id = morpheme_gloss.document_id\n  left join word_segment on word_segment.gloss_id = morpheme_gloss.id\n  left join word on word.id = word_segment.word_id\nwhere morpheme_gloss.gloss = $1\n  and document.short_name = $2\norder by word_segment.morpheme\n"
+  },
+  "3b58337042fb2a6e6d290327bae7a093867031db5dc1f16a4fba6d2b134c92cc": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "UuidArray",
+          "Text",
+          "Text",
+          {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "Morpheme",
+                  "Clitic",
+                  "Combine"
+                ]
+              },
+              "name": "segment_type"
+            }
+          },
+          "Text"
+        ]
+      }
+    },
+    "query": "insert into morpheme_tag (system_id, abstract_ids, gloss, title, segment_type, description)\nvalues ($1, $2, $3, $4, $5, $6)\non conflict (system_id, abstract_ids) do update set\ngloss = excluded.gloss,\ntitle = excluded.title,\nsegment_type = excluded.segment_type,\ndescription = excluded.description\n"
   },
   "43e42033828a07a488a1fbe4be6a5c7cea9d5c8d471d51a9fd39f939abd060f6": {
     "describe": {
@@ -956,33 +964,6 @@
       }
     },
     "query": "select\n  d.*,\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'name', contributor.full_name, 'role', attr.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  )\n  as contributors\nfrom document as d\n  left join contributor_attribution as attr on attr.document_id = d.id\n  left join contributor on contributor.id = attr.contributor_id\n  left join media_slice on media_slice.id = d.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\nwhere d.short_name = any($1)\ngroup by d.id,\n  media_slice.id,\n  media_resource.id\n"
-  },
-  "7ed33558920833b740a114815cd1607b81b53f9b81aa25a1759b2396dd4b2496": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "UuidArray",
-          "Text",
-          "Text",
-          {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "Morpheme",
-                  "Clitic",
-                  "Combine"
-                ]
-              },
-              "name": "segment_type"
-            }
-          }
-        ]
-      }
-    },
-    "query": "insert into morpheme_tag (system_id, abstract_ids, gloss, title, segment_type)\nvalues ($1, $2, $3, $4, $5)\non conflict (system_id, abstract_ids) do update set\ngloss = excluded.gloss,\ntitle = excluded.title,\nsegment_type = excluded.segment_type\n"
   },
   "801894d827b0385398a9e5fd631d66002634a8958eda5565544433318d0af6a4": {
     "describe": {
@@ -1679,6 +1660,26 @@
       }
     },
     "query": "select\n  document.id,\n  document.short_name,\n  document.title,\n  document.written_at,\n  document.is_reference,\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'name',\n        contributor.full_name,\n        'role',\n        contributor_attribution.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  )\n  as contributors\nfrom document\n  left join\n    contributor_attribution on contributor_attribution.document_id = document.id\n  left join contributor on contributor.id = contributor_attribution.contributor_id\ngroup by document.id\n"
+  },
+  "c3dcc89c659e12969f65484e59201b1d7cbe9ebe5b64b9ef515134125fc942ed": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id!",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "TextArray"
+        ]
+      }
+    },
+    "query": "select abstract_morpheme_tag.id as \"id!\"\nfrom unnest($1::text[]) as morpheme_gloss\ninner join abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss\n"
   },
   "d6377d5a54a702f7df73f287390c0c45a1309f7e705c93d49842b409a947a1fd": {
     "describe": {

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -101,27 +101,6 @@
     },
     "query": "insert into morpheme_gloss (document_id, gloss, example_shape, tag_id)\n  values ($1, $2, $3, $4)\non conflict (coalesce(document_id, uuid_nil()), gloss)\n  do update set example_shape = excluded.example_shape,\n     tag_id = excluded.tag_id\nreturning id\n"
   },
-  "18653ee1dc513510ca36ff2490d5cd5100acfe13527ccfe19b825a3c983c5ea5": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "-- Insert a collection with a certain slug.\ninsert into document_group (slug, title)\nvalues ($1, $2)\non conflict (slug)\n  do update set\n    title = excluded.title\n  returning id\n"
-  },
   "18b4d42a876bd0eb8185c8b573f3e20c213e711b797215987483a29a2e3780f6": {
     "describe": {
       "columns": [
@@ -283,6 +262,87 @@
     },
     "query": "select\n  document.id as document_id,\n  document.is_reference,\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.recorded_at,\n  word.commentary,\n  word.index_in_document,\n  word.page_number\nfrom word\n  inner join document on document.id = word.document_id\n  left join word_segment on word_segment.word_id = word.id\n  inner join morpheme_gloss on morpheme_gloss.id = word_segment.gloss_id\nwhere morpheme_gloss.gloss = $1\n  and (word.document_id = $2 or $2 is null)\ngroup by document.id, word.id\norder by document.id\n"
   },
+  "20714e564b044b547847b8409845df829f46d518449846876efc7a7eb9f3d8b1": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "TextArray"
+        ]
+      }
+    },
+    "query": "select abstract_morpheme_tag.id\nfrom unnest($1::text[]) as morpheme_gloss\ninner join abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss\n"
+  },
+  "20b3a8559a28249b3662253e1fc300d63f1dceaf88f6fc00750bb101163212d3": {
+    "describe": {
+      "columns": [
+        {
+          "name": "index_in_word",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "word_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "morpheme",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "gloss_id",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "gloss",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "segment_type: SegmentType",
+          "ordinal": 5,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "Morpheme",
+                  "Clitic",
+                  "Combine"
+                ]
+              },
+              "name": "segment_type"
+            }
+          }
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray"
+        ]
+      }
+    },
+    "query": "select distinct on (word_segment.word_id, word_segment.index_in_word)\n  word_segment.index_in_word,\n  word_segment.word_id,\n  word_segment.morpheme,\n  word_segment.gloss_id,\n  morpheme_gloss.gloss,\n  word_segment.segment_type as \"segment_type: SegmentType\"\nfrom word_segment\n  inner join morpheme_gloss on morpheme_gloss.id = word_segment.gloss_id\n  left join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id\n  left join morpheme_tag on abstract_morpheme_tag.id = morpheme_tag.abstract_ids[1]\nwhere word_segment.word_id = any($1)\norder by word_segment.word_id, word_segment.index_in_word\n"
+  },
   "2874ae8f9cec1ce09c268adc74b096a15ca1d90cbb324289c679df9e451cb2ee": {
     "describe": {
       "columns": [],
@@ -294,63 +354,6 @@
       }
     },
     "query": "-- Delete all document pages, which will cascade to delete all associated\n-- paragraphs and words.\ndelete from document_page\nwhere document_id = $1\n"
-  },
-  "30cd42e3b5c9974cb94b5b116e35555ca460648807f08265a80375f2edd92c53": {
-    "describe": {
-      "columns": [
-        {
-          "name": "gloss_id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "example_shape",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "system_name",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "gloss",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "title",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "description",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "linguistic_type",
-          "ordinal": 6,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray",
-          "TextArray"
-        ]
-      }
-    },
-    "query": "select\n  morpheme_gloss.id as gloss_id,\n  morpheme_gloss.example_shape,\n  abbreviation_system.short_name as system_name,\n  morpheme_tag.gloss,\n  morpheme_tag.title,\n  abstract_morpheme_tag.description,\n  abstract_morpheme_tag.linguistic_type\nfrom morpheme_gloss\n  inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id\n  left join abbreviation_system on abbreviation_system.short_name = any($2)\n  inner join morpheme_tag on morpheme_tag.abstract_ids[1] = abstract_morpheme_tag.id\nwhere morpheme_gloss.id = any($1)\n  and morpheme_tag.system_id = abbreviation_system.id\n"
   },
   "32052923a631af8b0a51564e9d08578fc30b5d0e58b1593e8651f53343c91156": {
     "describe": {
@@ -427,67 +430,6 @@
     },
     "query": "select\n  word_segment.morpheme,\n  word.id as word_id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number\nfrom morpheme_gloss\n  inner join document on document.id = morpheme_gloss.document_id\n  left join word_segment on word_segment.gloss_id = morpheme_gloss.id\n  left join word on word.id = word_segment.word_id\nwhere morpheme_gloss.gloss = $1\n  and document.short_name = $2\norder by word_segment.morpheme\n"
   },
-  "36b9fae68fe9f0285a0d9261962a98e75a2c9d930ebfb24dd9e8f238a18f729c": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "insert into abbreviation_system (short_name, title)\nvalues ($1, $2)\non conflict (short_name) do update set\n   title = excluded.title\nreturning id\n"
-  },
-  "384006c5df2ed9b1cc177734ae7cc0dc1b90e520bc183c02a29548549f38737b": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "UuidArray",
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "insert into morpheme_tag (system_id, abstract_ids, gloss, title)\nvalues ($1, $2, $3, $4)\non conflict (system_id, abstract_ids) do update set\n   gloss = excluded.gloss\n"
-  },
-  "391e7c60cfde1cad7cc5a893523ba05ea2dbd5a9ea184e6f2fdb2c5c4ba38281": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text",
-          "Bool",
-          "Date",
-          "Uuid",
-          "Uuid"
-        ]
-      }
-    },
-    "query": "insert into document (short_name, title, is_reference, written_at, audio_slice_id, group_id)\nvalues ($1, $2, $3, $4, $5, $6)\non conflict (short_name) do update set\n  title = excluded.title,\n  is_reference = excluded.is_reference,\n  written_at = excluded.written_at,\n  audio_slice_id = excluded.audio_slice_id,\n  group_id = excluded.group_id\nreturning id\n"
-  },
   "43e42033828a07a488a1fbe4be6a5c7cea9d5c8d471d51a9fd39f939abd060f6": {
     "describe": {
       "columns": [
@@ -531,6 +473,29 @@
       }
     },
     "query": "select\n  id,\n  index_in_document,\n  document_id,\n  iiif_source_id,\n  iiif_oid\nfrom document_page\nwhere document_id = any($1)\norder by index_in_document asc\n"
+  },
+  "47626f51affde3132dc7723df14672dfd5f606b93f3a7783bfad78bb528879a4": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int8",
+          "Uuid",
+          "Text"
+        ]
+      }
+    },
+    "query": "insert into document_page (document_id, index_in_document, iiif_source_id, iiif_oid)\nvalues ($1, $2, $3, $4)\non conflict (document_id, index_in_document) do update set\nindex_in_document = excluded.index_in_document,\niiif_source_id = excluded.iiif_source_id,\niiif_oid = excluded.iiif_oid\nreturning id\n"
   },
   "525b865b4c051117ca43bc0c2582bce2f5fee479d52e75340873ce0a1441a506": {
     "describe": {
@@ -660,6 +625,27 @@
     },
     "query": "select\n  slug,\n  title\nfrom document_group\nwhere slug = $1\n"
   },
+  "5e289d51c54b8f14432482d05e86ec9b6ffddd5b83acee04fcd76bdab6dd27a5": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "insert into abstract_morpheme_tag (internal_gloss, linguistic_type)\nvalues ($1, $2)\non conflict (internal_gloss) do update set\nlinguistic_type = excluded.linguistic_type\nreturning id\n"
+  },
   "5ed736651d677fd216c010f1dec8b0617a3d682d6a438b977185d94423e05300": {
     "describe": {
       "columns": [
@@ -725,85 +711,45 @@
     },
     "query": "delete from media_resource\nwhere id in (\n  select media_slice.resource_id\n  from media_slice\n    inner join document on document.audio_slice_id = media_slice.id\n  where document.short_name = $1\n)\n"
   },
-  "728770759c2d7e4f928ee6e867edbce9bb1fc5e23f8ce7c524aa978174c0c910": {
+  "774aa2feee9734f0cb7270b3e330731422aecbd72551cdd4a7f24b5fb1dc7c66": {
     "describe": {
-      "columns": [
-        {
-          "name": "word_id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "morpheme",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "gloss_id",
-          "ordinal": 2,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "gloss",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "followed_by: SegmentType",
-          "ordinal": 4,
-          "type_info": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "insert into contributor (full_name)\nvalues ($1)\non conflict (full_name) do update set\nfull_name = excluded.full_name\n"
+  },
+  "77f734b3a9d7cd649acb0d0f3b9b18a7fa232a75160b5279a78e169849d926dd": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Uuid",
+          "Int8",
+          "Text",
+          {
             "Custom": {
               "kind": {
                 "Enum": [
                   "Morpheme",
-                  "Clitic"
+                  "Clitic",
+                  "Combine"
                 ]
               },
               "name": "segment_type"
             }
           }
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        true,
-        false,
-        true
-      ],
-      "parameters": {
-        "Left": [
-          "UuidArray"
         ]
       }
     },
-    "query": "select\n  word_segment.word_id,\n  word_segment.morpheme,\n  word_segment.gloss_id,\n  morpheme_gloss.gloss,\n  word_segment.followed_by as \"followed_by: SegmentType\"\nfrom word_segment\n  inner join morpheme_gloss on morpheme_gloss.id = word_segment.gloss_id\nwhere word_id = any($1)\norder by index_in_word\n"
-  },
-  "760849b6680e2531468e679ea13bc3964fe5a4fba812e354e5d260a8691c614f": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text",
-          "Bool",
-          "Date",
-          "Uuid",
-          "Uuid",
-          "Int8"
-        ]
-      }
-    },
-    "query": "insert into document (short_name, title, is_reference, written_at, audio_slice_id, group_id, index_in_group)\nvalues ($1, $2, $3, $4, $5, $6, $7)\non conflict (short_name) do update set\n   title = excluded.title,\n   is_reference = excluded.is_reference,\n   written_at = excluded.written_at,\n   audio_slice_id = excluded.audio_slice_id,\n   group_id = excluded.group_id,\n   index_in_group = excluded.index_in_group\nreturning id\n"
+    "query": "-- Look for a matching global gloss before trying to create a document-local gloss.\nwith global_gloss as (\n  select morpheme_gloss.id\n  from morpheme_gloss\n  where document_id is null and gloss = $2\n), inserted_gloss as (\n  insert into morpheme_gloss (document_id, gloss)\n    select $1, $2\n    where not exists (select from global_gloss)\n  on conflict (coalesce(document_id, uuid_nil()), gloss)\n    do update set example_shape = excluded.example_shape,\n       tag_id = excluded.tag_id\n  returning id\n)\n\ninsert into word_segment (word_id, index_in_word, morpheme, gloss_id, segment_type)\nselect $3, $4, $5, coalesce(global_gloss.id, inserted_gloss.id), $6\nfrom global_gloss\nfull outer join inserted_gloss on true\non conflict (word_id, index_in_word)\n  do update set\n    morpheme = EXCLUDED.morpheme,\n    gloss_id = EXCLUDED.gloss_id,\n    segment_type = EXCLUDED.segment_type\n"
   },
   "7860f1d60b1f09d62987a89d413a7243cb23005b6f19bb539b88311dbfbd223d": {
     "describe": {
@@ -844,6 +790,92 @@
       }
     },
     "query": "insert into contributor_attribution (contributor_id, document_id, contribution_role)\nselect contributor.id, $2, $3\nfrom contributor\nwhere contributor.full_name = $1\n-- If this document already has this contributor, move on.\non conflict do nothing\n"
+  },
+  "7a45cab7bf76568f1742689708c94f5e6b87c83d67d86b6a2b3831e66242b9e5": {
+    "describe": {
+      "columns": [
+        {
+          "name": "gloss_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "example_shape",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "system_name",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "abstract_gloss",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "concrete_gloss",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "title",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "description",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "segment_type: SegmentType",
+          "ordinal": 7,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "Morpheme",
+                  "Clitic",
+                  "Combine"
+                ]
+              },
+              "name": "segment_type"
+            }
+          }
+        },
+        {
+          "name": "linguistic_type",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "internal_tags",
+          "ordinal": 9,
+          "type_info": "TextArray"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "TextArray",
+          "TextArray"
+        ]
+      }
+    },
+    "query": "select\n  morpheme_gloss.id as gloss_id,\n  morpheme_gloss.example_shape,\n  abbreviation_system.short_name as system_name,\n  morpheme_gloss.gloss as abstract_gloss,\n  morpheme_tag.gloss as concrete_gloss,\n  morpheme_tag.title,\n  morpheme_tag.description,\n  morpheme_tag.segment_type as \"segment_type: SegmentType\",\n  abstract_morpheme_tag.linguistic_type,\n  array(select abstract_morpheme_tag.internal_gloss from unnest(morpheme_tag.abstract_ids) as abstract_id\n        inner join abstract_morpheme_tag on abstract_morpheme_tag.id = abstract_id) as internal_tags\nfrom morpheme_gloss\n  inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id\n  left join abbreviation_system on abbreviation_system.short_name = any($2)\n  inner join morpheme_tag on morpheme_tag.abstract_ids[1] = abstract_morpheme_tag.id\nwhere morpheme_gloss.gloss = any($1)\n  and morpheme_tag.system_id = abbreviation_system.id\norder by array_length(morpheme_tag.abstract_ids, 1) desc\n"
   },
   "7c5b7543e8a03f45b536b36b6f6f5328d1932a9f9e038dd33157ecd5b8b18e73": {
     "describe": {
@@ -925,6 +957,216 @@
     },
     "query": "select\n  d.*,\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'name', contributor.full_name, 'role', attr.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  )\n  as contributors\nfrom document as d\n  left join contributor_attribution as attr on attr.document_id = d.id\n  left join contributor on contributor.id = attr.contributor_id\n  left join media_slice on media_slice.id = d.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\nwhere d.short_name = any($1)\ngroup by d.id,\n  media_slice.id,\n  media_resource.id\n"
   },
+  "7ed33558920833b740a114815cd1607b81b53f9b81aa25a1759b2396dd4b2496": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "UuidArray",
+          "Text",
+          "Text",
+          {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "Morpheme",
+                  "Clitic",
+                  "Combine"
+                ]
+              },
+              "name": "segment_type"
+            }
+          }
+        ]
+      }
+    },
+    "query": "insert into morpheme_tag (system_id, abstract_ids, gloss, title, segment_type)\nvalues ($1, $2, $3, $4, $5)\non conflict (system_id, abstract_ids) do update set\ngloss = excluded.gloss,\ntitle = excluded.title,\nsegment_type = excluded.segment_type\n"
+  },
+  "801894d827b0385398a9e5fd631d66002634a8958eda5565544433318d0af6a4": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "insert into abbreviation_system (short_name, title)\nvalues ($1, $2)\non conflict (short_name) do update set\ntitle = excluded.title\nreturning id\n"
+  },
+  "8560200ace3f76678ea54c3d60676d2f0a5d924d2c08a245f65eb90078af3468": {
+    "describe": {
+      "columns": [
+        {
+          "name": "system_name",
+          "ordinal": 0,
+          "type_info": "Text"
+        },
+        {
+          "name": "abstract_ids",
+          "ordinal": 1,
+          "type_info": "UuidArray"
+        },
+        {
+          "name": "gloss",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "title",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "description",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "segment_type: SegmentType",
+          "ordinal": 5,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "Morpheme",
+                  "Clitic",
+                  "Combine"
+                ]
+              },
+              "name": "segment_type"
+            }
+          }
+        },
+        {
+          "name": "linguistic_type",
+          "ordinal": 6,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "with t as (\n  select distinct on (morpheme_tag.gloss)\n    abbreviation_system.short_name as system_name,\n    morpheme_tag.abstract_ids,\n    morpheme_tag.gloss,\n    morpheme_tag.title,\n    morpheme_tag.description,\n    morpheme_tag.segment_type as \"segment_type: SegmentType\",\n    abstract_morpheme_tag.linguistic_type\n  from abbreviation_system\n    inner join\n      morpheme_tag on abbreviation_system.id = morpheme_tag.system_id\n    inner join\n      abstract_morpheme_tag on\n        abstract_morpheme_tag.id = any(morpheme_tag.abstract_ids)\n  where abbreviation_system.short_name = $1\n)\n\nselect *\nfrom t\norder by linguistic_type asc, gloss asc;\n"
+  },
+  "8745dd0df2b5eb1fbb0ba3ff91e5dde20307ca59ce01e404df608b4add4ef2ba": {
+    "describe": {
+      "columns": [
+        {
+          "name": "gloss_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "example_shape",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "system_name",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "gloss",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "title",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "description",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "segment_type: SegmentType",
+          "ordinal": 6,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "Morpheme",
+                  "Clitic",
+                  "Combine"
+                ]
+              },
+              "name": "segment_type"
+            }
+          }
+        },
+        {
+          "name": "linguistic_type",
+          "ordinal": 7,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "UuidArray",
+          "TextArray"
+        ]
+      }
+    },
+    "query": "select\n  morpheme_gloss.id as gloss_id,\n  morpheme_gloss.example_shape,\n  abbreviation_system.short_name as system_name,\n  morpheme_tag.gloss,\n  morpheme_tag.title,\n  morpheme_tag.description,\n  morpheme_tag.segment_type as \"segment_type: SegmentType\",\n  abstract_morpheme_tag.linguistic_type\nfrom morpheme_gloss\n  inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id\n  left join abbreviation_system on abbreviation_system.short_name = any($2)\n  inner join morpheme_tag on morpheme_tag.abstract_ids[1] = abstract_morpheme_tag.id\nwhere morpheme_gloss.id = any($1)\n  and morpheme_tag.system_id = abbreviation_system.id\n"
+  },
+  "8d3ceaae6a15910949eceeeff805e3a93231b1d234897dc2f8bd71fc6df3baaa": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "-- Insert a collection with a certain slug.\ninsert into document_group (slug, title)\nvalues ($1, $2)\non conflict (slug) do update set\ntitle = excluded.title\nreturning id\n"
+  },
   "8ecfe399e5e6da5a750c519bea8af91364076a89f472e9087afafda4b02599f4": {
     "describe": {
       "columns": [
@@ -1005,6 +1247,32 @@
     },
     "query": "select\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number,\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\"\nfrom word\n  left join media_slice on media_slice.id = word.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\nwhere source_text ilike $1\n  or simple_phonetics ilike $1\n  or english_gloss ilike $1\n"
   },
+  "8f23f2ea8730fc8f24aee4a5a62d102d386a68749f299d84b341513a5b9048c5": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text",
+          "Bool",
+          "Date",
+          "Uuid",
+          "Uuid",
+          "Int8"
+        ]
+      }
+    },
+    "query": "insert into document (\n  short_name, title, is_reference, written_at, audio_slice_id, group_id, index_in_group\n)\nvalues ($1, $2, $3, $4, $5, $6, $7)\non conflict (short_name) do update set\ntitle = excluded.title,\nis_reference = excluded.is_reference,\nwritten_at = excluded.written_at,\naudio_slice_id = excluded.audio_slice_id,\ngroup_id = excluded.group_id,\nindex_in_group = excluded.index_in_group\nreturning id\n"
+  },
   "93a6c0a72e2d56064fffad8eda07a6b8aa73080106ce3283a087b010bc3658dd": {
     "describe": {
       "columns": [
@@ -1028,40 +1296,6 @@
       }
     },
     "query": "select\n  document_group.title,\n  document_group.slug\nfrom document_group\n  left join document on document.group_id = document_group.id\nwhere document.is_reference is false\ngroup by document_group.id\norder by document_group.title asc\n"
-  },
-  "98f3ef23ebc76420a18f30502019f9d7e676ee9e7e2ebb14290beeda813c4fc4": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      }
-    },
-    "query": "insert into contributor (full_name)\nvalues ($1)\non conflict (full_name) do update\nset full_name = EXCLUDED.full_name\n"
-  },
-  "992ff11ed26e43847c6b73fa0c8be2eb3b4268f192fa309f39252b5b68e00eb9": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "insert into abstract_morpheme_tag (internal_gloss, description, linguistic_type)\nvalues ($1, $2, $3)\non conflict (internal_gloss) do update\n   set description = excluded.description,\n       linguistic_type = excluded.linguistic_type\nreturning id\n"
   },
   "9e02521e2e4f9bb5ee2e1c9dd33e18bb9b0ee8b7d584cf9867b889b92334f082": {
     "describe": {
@@ -1106,6 +1340,31 @@
       }
     },
     "query": "select\n  d.id,\n  d.short_name,\n  d.title,\n  d.written_at as \"date: Date\",\n  d.index_in_group as order_index\nfrom document_group\n  inner join document as d on document_group.id = d.group_id\nwhere document_group.slug = $1\norder by d.index_in_group asc\n"
+  },
+  "9f91be464c9e113d326e6ba91b03dc95f1b94adf482990dba756305fb68b0165": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text",
+          "Bool",
+          "Date",
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "insert into document (\n  short_name, title, is_reference, written_at, audio_slice_id, group_id\n)\nvalues ($1, $2, $3, $4, $5, $6)\non conflict (short_name) do update set\ntitle = excluded.title,\nis_reference = excluded.is_reference,\nwritten_at = excluded.written_at,\naudio_slice_id = excluded.audio_slice_id,\ngroup_id = excluded.group_id\nreturning id\n"
   },
   "a0cec5199d10a1135a4074b4620c0b45b552c38f26ecee945ef94f2afccdbe83": {
     "describe": {
@@ -1181,81 +1440,6 @@
       }
     },
     "query": "insert into iiif_source (title, base_url)\nvalues ($1, $2)\non conflict (base_url) do update\nset title = excluded.title\nreturning id\n"
-  },
-  "b079aeb69f26a8cb62928b7b088de36e3b1f26bd164a8a4010b06fbfdd8fa3b5": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Date",
-          "Text",
-          "Uuid",
-          "Text",
-          "Int8",
-          "Uuid",
-          "Int8Range",
-          "Uuid"
-        ]
-      }
-    },
-    "query": "insert into word (source_text, simple_phonetics, phonemic, english_gloss, recorded_at, commentary,\n  document_id, page_number, index_in_document, page_id, character_range, audio_slice_id)\nvalues ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\non conflict (document_id, index_in_document)\ndo update set\n  source_text = EXCLUDED.source_text,\n  simple_phonetics = EXCLUDED.simple_phonetics,\n  phonemic = EXCLUDED.phonemic,\n  english_gloss = EXCLUDED.english_gloss,\n  commentary = EXCLUDED.commentary,\n  audio_slice_id = EXCLUDED.audio_slice_id\nreturning id\n"
-  },
-  "b30945f3bfd15aee9755bd937498b07200b10f20f390c8cf700f500e67c2a15f": {
-    "describe": {
-      "columns": [
-        {
-          "name": "system_name",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "gloss",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "title",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "description",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "linguistic_type",
-          "ordinal": 4,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        true,
-        true
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      }
-    },
-    "query": "with t as (\n  select distinct on (morpheme_tag.gloss)\n    abbreviation_system.short_name as system_name,\n    morpheme_tag.gloss,\n    morpheme_tag.title,\n    abstract_morpheme_tag.description,\n    abstract_morpheme_tag.linguistic_type\n  from abbreviation_system\n    inner join\n      morpheme_tag on abbreviation_system.id = morpheme_tag.system_id\n    inner join\n      abstract_morpheme_tag on\n        abstract_morpheme_tag.id = any(morpheme_tag.abstract_ids)\n  where abbreviation_system.short_name = $1\n)\n\nselect *\nfrom t\norder by linguistic_type asc, gloss asc;\n"
   },
   "b8b71d5fe6c8a443d6173fc86d1b7dc4148fb67c1c934a55674945c568107a60": {
     "describe": {
@@ -1516,29 +1700,6 @@
     },
     "query": "select count(id)\nfrom word\nwhere document_id = $1\n"
   },
-  "d66fbd9754da7d0860ff8268efbbd4bd69dbed8aa0f4b16b250d725df9a2fd66": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int8",
-          "Uuid",
-          "Text"
-        ]
-      }
-    },
-    "query": "insert into document_page (document_id, index_in_document, iiif_source_id, iiif_oid)\nvalues ($1, $2, $3, $4)\non conflict (document_id, index_in_document)\n  do update set\n    index_in_document = excluded.index_in_document,\n    iiif_source_id = excluded.iiif_source_id,\n    iiif_oid = excluded.iiif_oid\n  returning id\n"
-  },
   "d8bc89c2d802ac2da071308eb27bdd1bc2bbdc31d64e8ccad71d4b861f8be12b": {
     "describe": {
       "columns": [
@@ -1570,63 +1731,6 @@
       }
     },
     "query": "select\n  id,\n  title,\n  base_url\nfrom iiif_source\nwhere id = any($1)\n"
-  },
-  "dca1e24c7740e8d32a9d7cecd80f28c95831b0bc9ea94297d1ef775f9524c8c5": {
-    "describe": {
-      "columns": [
-        {
-          "name": "gloss_id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "example_shape",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "system_name",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "gloss",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "title",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "description",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "linguistic_type",
-          "ordinal": 6,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
-      ],
-      "parameters": {
-        "Left": [
-          "TextArray",
-          "TextArray"
-        ]
-      }
-    },
-    "query": "select\n  morpheme_gloss.id as gloss_id,\n  morpheme_gloss.example_shape,\n  abbreviation_system.short_name as system_name,\n  morpheme_tag.gloss,\n  morpheme_tag.title,\n  abstract_morpheme_tag.description,\n  abstract_morpheme_tag.linguistic_type\nfrom morpheme_gloss\n  inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id\n  left join abbreviation_system on abbreviation_system.short_name = any($2)\n  inner join morpheme_tag on morpheme_tag.abstract_ids[1] = abstract_morpheme_tag.id\nwhere morpheme_gloss.gloss = any($1)\n  and morpheme_tag.system_id = abbreviation_system.id\n"
   },
   "e1ebe64b2e98a03f7803c63a2e9011b0a064d7a6819dfdbc1a8c4d4e1160db90": {
     "describe": {
@@ -1729,32 +1833,36 @@
     },
     "query": "select\n  d.*,\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'name', contributor.full_name, 'role', attr.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  )\n  as contributors\nfrom document as d\n  left join contributor_attribution as attr on attr.document_id = d.id\n  left join contributor on contributor.id = attr.contributor_id\n  left join media_slice on media_slice.id = d.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\nwhere d.id = any($1)\ngroup by d.id,\n  media_slice.id,\n  media_resource.id\n"
   },
-  "e81a4c2c38e1660c1e2a874f3b95bc9f5ae3bb8c69c9235bf6b47709dbe1d8f7": {
+  "f8323b5ff51161bdfb60b88e78650e0447fa620a96929c75d9afcaf5bfbce1c2": {
     "describe": {
-      "columns": [],
-      "nullable": [],
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
       "parameters": {
         "Left": [
-          "Uuid",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Date",
           "Text",
           "Uuid",
+          "Text",
           "Int8",
-          "Text",
-          {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "Morpheme",
-                  "Clitic"
-                ]
-              },
-              "name": "segment_type"
-            }
-          }
+          "Uuid",
+          "Int8Range",
+          "Uuid"
         ]
       }
     },
-    "query": "-- Look for a matching global gloss before trying to create a document-local gloss.\nwith global_gloss as (\n  select morpheme_gloss.id\n  from morpheme_gloss\n  where document_id is null and gloss = $2\n), inserted_gloss as (\n  insert into morpheme_gloss (document_id, gloss)\n    select $1, $2\n    where not exists (select from global_gloss)\n  on conflict (coalesce(document_id, uuid_nil()), gloss)\n    do update set example_shape = excluded.example_shape,\n       tag_id = excluded.tag_id\n  returning id\n)\n\ninsert into word_segment (word_id, index_in_word, morpheme, gloss_id, followed_by)\nselect $3, $4, $5, coalesce(global_gloss.id, inserted_gloss.id), $6\nfrom global_gloss\nfull outer join inserted_gloss on true\non conflict (word_id, index_in_word)\n  do update set\n    morpheme = EXCLUDED.morpheme,\n    gloss_id = EXCLUDED.gloss_id,\n    followed_by = EXCLUDED.followed_by\n"
+    "query": "insert into word (\n  source_text, simple_phonetics, phonemic, english_gloss, recorded_at, commentary,\n  document_id, page_number, index_in_document, page_id, character_range, audio_slice_id)\nvalues ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\non conflict (document_id, index_in_document) do update set\nsource_text = excluded.source_text,\nsimple_phonetics = excluded.simple_phonetics,\nphonemic = excluded.phonemic,\nenglish_gloss = excluded.english_gloss,\ncommentary = excluded.commentary,\naudio_slice_id = excluded.audio_slice_id\nreturning id\n"
   },
   "f86a2f62b58b5b404883e127574947027ff7a38f8ea4058a7dc4e9e68626c164": {
     "describe": {

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -410,33 +410,25 @@
     },
     "query": "select\n  word_segment.morpheme,\n  word.id as word_id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number\nfrom morpheme_gloss\n  inner join document on document.id = morpheme_gloss.document_id\n  left join word_segment on word_segment.gloss_id = morpheme_gloss.id\n  left join word on word.id = word_segment.word_id\nwhere morpheme_gloss.gloss = $1\n  and document.short_name = $2\norder by word_segment.morpheme\n"
   },
-  "3b58337042fb2a6e6d290327bae7a093867031db5dc1f16a4fba6d2b134c92cc": {
+  "388c671a0e5cf32298db07a5286a1ecb0efe59c9ddbdff1c7c49f79454a21801": {
     "describe": {
-      "columns": [],
-      "nullable": [],
+      "columns": [
+        {
+          "name": "id!",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        true
+      ],
       "parameters": {
         "Left": [
-          "Uuid",
-          "UuidArray",
-          "Text",
-          "Text",
-          {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "Morpheme",
-                  "Clitic",
-                  "Combine"
-                ]
-              },
-              "name": "segment_type"
-            }
-          },
-          "Text"
+          "TextArray"
         ]
       }
     },
-    "query": "insert into morpheme_tag (system_id, abstract_ids, gloss, title, segment_type, description)\nvalues ($1, $2, $3, $4, $5, $6)\non conflict (system_id, abstract_ids) do update set\ngloss = excluded.gloss,\ntitle = excluded.title,\nsegment_type = excluded.segment_type,\ndescription = excluded.description\n"
+    "query": "select abstract_morpheme_tag.id as \"id!\"\nfrom unnest($1::text[]) as morpheme_gloss\n  inner join\n    abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss\n"
   },
   "43e42033828a07a488a1fbe4be6a5c7cea9d5c8d471d51a9fd39f939abd060f6": {
     "describe": {
@@ -798,92 +790,6 @@
       }
     },
     "query": "insert into contributor_attribution (contributor_id, document_id, contribution_role)\nselect contributor.id, $2, $3\nfrom contributor\nwhere contributor.full_name = $1\n-- If this document already has this contributor, move on.\non conflict do nothing\n"
-  },
-  "7a45cab7bf76568f1742689708c94f5e6b87c83d67d86b6a2b3831e66242b9e5": {
-    "describe": {
-      "columns": [
-        {
-          "name": "gloss_id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "example_shape",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "system_name",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "abstract_gloss",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "concrete_gloss",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "title",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "description",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "segment_type: SegmentType",
-          "ordinal": 7,
-          "type_info": {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "Morpheme",
-                  "Clitic",
-                  "Combine"
-                ]
-              },
-              "name": "segment_type"
-            }
-          }
-        },
-        {
-          "name": "linguistic_type",
-          "ordinal": 8,
-          "type_info": "Text"
-        },
-        {
-          "name": "internal_tags",
-          "ordinal": 9,
-          "type_info": "TextArray"
-        }
-      ],
-      "nullable": [
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        true,
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "TextArray",
-          "TextArray"
-        ]
-      }
-    },
-    "query": "select\n  morpheme_gloss.id as gloss_id,\n  morpheme_gloss.example_shape,\n  abbreviation_system.short_name as system_name,\n  morpheme_gloss.gloss as abstract_gloss,\n  morpheme_tag.gloss as concrete_gloss,\n  morpheme_tag.title,\n  morpheme_tag.description,\n  morpheme_tag.segment_type as \"segment_type: SegmentType\",\n  abstract_morpheme_tag.linguistic_type,\n  array(select abstract_morpheme_tag.internal_gloss from unnest(morpheme_tag.abstract_ids) as abstract_id\n        inner join abstract_morpheme_tag on abstract_morpheme_tag.id = abstract_id) as internal_tags\nfrom morpheme_gloss\n  inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id\n  left join abbreviation_system on abbreviation_system.short_name = any($2)\n  inner join morpheme_tag on morpheme_tag.abstract_ids[1] = abstract_morpheme_tag.id\nwhere morpheme_gloss.gloss = any($1)\n  and morpheme_tag.system_id = abbreviation_system.id\norder by array_length(morpheme_tag.abstract_ids, 1) desc\n"
   },
   "7c5b7543e8a03f45b536b36b6f6f5328d1932a9f9e038dd33157ecd5b8b18e73": {
     "describe": {
@@ -1401,6 +1307,92 @@
     },
     "query": "insert into character_transcription (\n  page_id, index_in_page, possible_transcriptions\n)\nvalues ($1, $2, $3)\n"
   },
+  "af1d25307571845bdc8343b0ba23105229b4674b7250d839006febde48adf524": {
+    "describe": {
+      "columns": [
+        {
+          "name": "gloss_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "example_shape",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "system_name",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "abstract_gloss",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "concrete_gloss",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "title",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "description",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "segment_type: SegmentType",
+          "ordinal": 7,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "Morpheme",
+                  "Clitic",
+                  "Combine"
+                ]
+              },
+              "name": "segment_type"
+            }
+          }
+        },
+        {
+          "name": "linguistic_type",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "internal_tags",
+          "ordinal": 9,
+          "type_info": "TextArray"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "TextArray",
+          "TextArray"
+        ]
+      }
+    },
+    "query": "select\n  morpheme_gloss.id as gloss_id,\n  morpheme_gloss.example_shape,\n  abbreviation_system.short_name as system_name,\n  morpheme_gloss.gloss as abstract_gloss,\n  morpheme_tag.gloss as concrete_gloss,\n  morpheme_tag.title,\n  morpheme_tag.description,\n  morpheme_tag.segment_type as \"segment_type: SegmentType\",\n  abstract_morpheme_tag.linguistic_type,\n  array(\n    select abstract_morpheme_tag.internal_gloss\n    from unnest(morpheme_tag.abstract_ids) as abstract_id\n      inner join abstract_morpheme_tag on abstract_morpheme_tag.id = abstract_id) as internal_tags\nfrom morpheme_gloss\n  inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id\n  left join abbreviation_system on abbreviation_system.short_name = any($2)\n  inner join morpheme_tag on morpheme_tag.abstract_ids[1] = abstract_morpheme_tag.id\nwhere morpheme_gloss.gloss = any($1)\n  and morpheme_tag.system_id = abbreviation_system.id\norder by array_length(morpheme_tag.abstract_ids, 1) desc\n"
+  },
   "afca9b69fc11aef29379ab4d753d0b644b6ee3a698f3a6e857bfb6a83a4b38f1": {
     "describe": {
       "columns": [
@@ -1661,26 +1653,6 @@
     },
     "query": "select\n  document.id,\n  document.short_name,\n  document.title,\n  document.written_at,\n  document.is_reference,\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'name',\n        contributor.full_name,\n        'role',\n        contributor_attribution.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  )\n  as contributors\nfrom document\n  left join\n    contributor_attribution on contributor_attribution.document_id = document.id\n  left join contributor on contributor.id = contributor_attribution.contributor_id\ngroup by document.id\n"
   },
-  "c3dcc89c659e12969f65484e59201b1d7cbe9ebe5b64b9ef515134125fc942ed": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id!",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        true
-      ],
-      "parameters": {
-        "Left": [
-          "TextArray"
-        ]
-      }
-    },
-    "query": "select abstract_morpheme_tag.id as \"id!\"\nfrom unnest($1::text[]) as morpheme_gloss\ninner join abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss\n"
-  },
   "d6377d5a54a702f7df73f287390c0c45a1309f7e705c93d49842b409a947a1fd": {
     "describe": {
       "columns": [
@@ -1753,6 +1725,34 @@
       }
     },
     "query": "with resource as (\n  insert into media_resource (url)\n  values ($1)\n  on conflict (url) do update set\n     url = excluded.url\n  returning id\n)\n\ninsert into media_slice (resource_id, time_range)\nselect\n  id,\n  $2\nfrom resource\nreturning id\n"
+  },
+  "e28589cd31265f26c558b7045f7b9d354199678c02db780dd154820a0c776e95": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "UuidArray",
+          "Text",
+          "Text",
+          {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "Morpheme",
+                  "Clitic",
+                  "Combine"
+                ]
+              },
+              "name": "segment_type"
+            }
+          },
+          "Text"
+        ]
+      }
+    },
+    "query": "insert into morpheme_tag (\n  system_id, abstract_ids, gloss, title, segment_type, description\n)\nvalues ($1, $2, $3, $4, $5, $6)\non conflict (system_id, abstract_ids) do update set\ngloss = excluded.gloss,\ntitle = excluded.title,\nsegment_type = excluded.segment_type,\ndescription = excluded.description\n"
   },
   "e36a7ea38a54495cca4e743a5508d81384adf850009d9c1f9f74438042c0d6d0": {
     "describe": {

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,7 +17,7 @@ itertools = "0.9"
 async-graphql = { version = "3.0", features = ["dataloader", "uuid"] }
 futures = "0.3"
 uuid = { version = "0.8.2", default-features = false, features = ["std", "serde"] }
-sqlx = { version = "0.5", features = ["runtime-tokio-rustls", "postgres", "migrate", "macros", "chrono", "json", "uuid", "offline"] }
+sqlx = { version = "0.5.13", features = ["runtime-tokio-rustls", "postgres", "migrate", "macros", "chrono", "json", "uuid", "offline"] }
 lazy_static = "1.4"
 regex = "1.3"
 unicode-normalization = "0.1"

--- a/types/migrations/20220428234639_add_morpheme_tag_description.sql
+++ b/types/migrations/20220428234639_add_morpheme_tag_description.sql
@@ -1,3 +1,5 @@
+-- Move the description column from abstract_morpheme_tag to morpheme_tag, so
+-- that morpheme tags in each system can have a distinct description.
 alter table morpheme_tag
 add column description text;
 
@@ -9,16 +11,26 @@ where abstract_morpheme_tag.id = any(morpheme_tag.abstract_ids);
 alter table abstract_morpheme_tag
 drop column description;
 
+-- Add the Combine variant of SegmentType.
 alter type segment_type add value 'Combine';
 
+-- Allow tags to have a segment type override.
 alter table morpheme_tag
 add column segment_type segment_type;
 
+-- Replace the "followed_by" column with "segment_type".
 alter table word_segment
 add column segment_type segment_type not null default 'Morpheme';
 
+-- Set the type of each segment to the "followed_by" of the segment that comes
+-- before it.
 update word_segment
-set segment_type = (select followed_by from word_segment as prev where prev.word_id = word_segment.word_id and prev.index_in_word = word_segment.index_in_word - 1);
+set segment_type = (
+  select coalesce(prev.followed_by, 'Morpheme')
+  from word_segment as prev
+  where prev.word_id = word_segment.word_id
+    and prev.index_in_word = word_segment.index_in_word - 1
+);
 
 alter table word_segment
 drop column followed_by;

--- a/types/migrations/20220428234639_add_morpheme_tag_description.sql
+++ b/types/migrations/20220428234639_add_morpheme_tag_description.sql
@@ -1,0 +1,17 @@
+alter table morpheme_tag
+add column description text;
+
+update morpheme_tag
+set description = abstract_morpheme_tag.description
+from abstract_morpheme_tag
+where abstract_morpheme_tag.id = any(morpheme_tag.abstract_ids);
+
+alter table abstract_morpheme_tag
+drop column description;
+
+alter table morpheme_tag
+add column segment_type text;
+
+alter table word_segment
+drop column followed_by;
+

--- a/types/migrations/20220428234639_add_morpheme_tag_description.sql
+++ b/types/migrations/20220428234639_add_morpheme_tag_description.sql
@@ -9,9 +9,16 @@ where abstract_morpheme_tag.id = any(morpheme_tag.abstract_ids);
 alter table abstract_morpheme_tag
 drop column description;
 
+alter type segment_type add value 'Combine';
+
 alter table morpheme_tag
-add column segment_type text;
+add column segment_type segment_type;
+
+alter table word_segment
+add column segment_type segment_type not null default 'Morpheme';
+
+update word_segment
+set segment_type = (select followed_by from word_segment as prev where prev.word_id = word_segment.word_id and prev.index_in_word = word_segment.index_in_word - 1);
 
 alter table word_segment
 drop column followed_by;
-

--- a/types/queries/abstract_tag_ids_from_glosses.sql
+++ b/types/queries/abstract_tag_ids_from_glosses.sql
@@ -1,3 +1,4 @@
 select abstract_morpheme_tag.id as "id!"
 from unnest($1::text[]) as morpheme_gloss
-inner join abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss
+  inner join
+    abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss

--- a/types/queries/abstract_tag_ids_from_glosses.sql
+++ b/types/queries/abstract_tag_ids_from_glosses.sql
@@ -1,0 +1,3 @@
+select abstract_morpheme_tag.id
+from unnest($1::text[]) as morpheme_gloss
+inner join abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss

--- a/types/queries/abstract_tag_ids_from_glosses.sql
+++ b/types/queries/abstract_tag_ids_from_glosses.sql
@@ -1,3 +1,3 @@
-select abstract_morpheme_tag.id
+select abstract_morpheme_tag.id as "id!"
 from unnest($1::text[]) as morpheme_gloss
 inner join abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss

--- a/types/queries/all_morpheme_tags.sql
+++ b/types/queries/all_morpheme_tags.sql
@@ -1,9 +1,11 @@
 with t as (
   select distinct on (morpheme_tag.gloss)
     abbreviation_system.short_name as system_name,
+    morpheme_tag.abstract_ids,
     morpheme_tag.gloss,
     morpheme_tag.title,
-    abstract_morpheme_tag.description,
+    morpheme_tag.description,
+    morpheme_tag.segment_type,
     abstract_morpheme_tag.linguistic_type
   from abbreviation_system
     inner join

--- a/types/queries/all_morpheme_tags.sql
+++ b/types/queries/all_morpheme_tags.sql
@@ -5,7 +5,7 @@ with t as (
     morpheme_tag.gloss,
     morpheme_tag.title,
     morpheme_tag.description,
-    morpheme_tag.segment_type,
+    morpheme_tag.segment_type as "segment_type: SegmentType",
     abstract_morpheme_tag.linguistic_type
   from abbreviation_system
     inner join

--- a/types/queries/insert_abbreviation_system.sql
+++ b/types/queries/insert_abbreviation_system.sql
@@ -1,5 +1,5 @@
 insert into abbreviation_system (short_name, title)
 values ($1, $2)
 on conflict (short_name) do update set
-   title = excluded.title
+title = excluded.title
 returning id

--- a/types/queries/insert_document.sql
+++ b/types/queries/insert_document.sql
@@ -1,9 +1,11 @@
-insert into document (short_name, title, is_reference, written_at, audio_slice_id, group_id)
+insert into document (
+  short_name, title, is_reference, written_at, audio_slice_id, group_id
+)
 values ($1, $2, $3, $4, $5, $6)
 on conflict (short_name) do update set
-  title = excluded.title,
-  is_reference = excluded.is_reference,
-  written_at = excluded.written_at,
-  audio_slice_id = excluded.audio_slice_id,
-  group_id = excluded.group_id
+title = excluded.title,
+is_reference = excluded.is_reference,
+written_at = excluded.written_at,
+audio_slice_id = excluded.audio_slice_id,
+group_id = excluded.group_id
 returning id

--- a/types/queries/insert_document_group.sql
+++ b/types/queries/insert_document_group.sql
@@ -1,7 +1,6 @@
 -- Insert a collection with a certain slug.
 insert into document_group (slug, title)
 values ($1, $2)
-on conflict (slug)
-  do update set
-    title = excluded.title
-  returning id
+on conflict (slug) do update set
+title = excluded.title
+returning id

--- a/types/queries/insert_document_in_collection.sql
+++ b/types/queries/insert_document_in_collection.sql
@@ -1,10 +1,12 @@
-insert into document (short_name, title, is_reference, written_at, audio_slice_id, group_id, index_in_group)
+insert into document (
+  short_name, title, is_reference, written_at, audio_slice_id, group_id, index_in_group
+)
 values ($1, $2, $3, $4, $5, $6, $7)
 on conflict (short_name) do update set
-   title = excluded.title,
-   is_reference = excluded.is_reference,
-   written_at = excluded.written_at,
-   audio_slice_id = excluded.audio_slice_id,
-   group_id = excluded.group_id,
-   index_in_group = excluded.index_in_group
+title = excluded.title,
+is_reference = excluded.is_reference,
+written_at = excluded.written_at,
+audio_slice_id = excluded.audio_slice_id,
+group_id = excluded.group_id,
+index_in_group = excluded.index_in_group
 returning id

--- a/types/queries/morpheme_tags.sql
+++ b/types/queries/morpheme_tags.sql
@@ -4,7 +4,8 @@ select
   abbreviation_system.short_name as system_name,
   morpheme_tag.gloss,
   morpheme_tag.title,
-  abstract_morpheme_tag.description,
+  morpheme_tag.description,
+  morpheme_tag.segment_type,
   abstract_morpheme_tag.linguistic_type
 from morpheme_gloss
   inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id

--- a/types/queries/morpheme_tags.sql
+++ b/types/queries/morpheme_tags.sql
@@ -5,7 +5,7 @@ select
   morpheme_tag.gloss,
   morpheme_tag.title,
   morpheme_tag.description,
-  morpheme_tag.segment_type,
+  morpheme_tag.segment_type as "segment_type: SegmentType",
   abstract_morpheme_tag.linguistic_type
 from morpheme_gloss
   inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id

--- a/types/queries/morpheme_tags_by_gloss.sql
+++ b/types/queries/morpheme_tags_by_gloss.sql
@@ -2,13 +2,18 @@ select
   morpheme_gloss.id as gloss_id,
   morpheme_gloss.example_shape,
   abbreviation_system.short_name as system_name,
-  morpheme_tag.gloss,
+  morpheme_gloss.gloss as abstract_gloss,
+  morpheme_tag.gloss as concrete_gloss,
   morpheme_tag.title,
-  abstract_morpheme_tag.description,
-  abstract_morpheme_tag.linguistic_type
+  morpheme_tag.description,
+  morpheme_tag.segment_type,
+  abstract_morpheme_tag.linguistic_type,
+  array(select abstract_morpheme_tag.internal_gloss from unnest(morpheme_tag.abstract_ids) as abstract_id
+        inner join abstract_morpheme_tag on abstract_morpheme_tag.id = abstract_id) as internal_tags
 from morpheme_gloss
   inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id
   left join abbreviation_system on abbreviation_system.short_name = any($2)
   inner join morpheme_tag on morpheme_tag.abstract_ids[1] = abstract_morpheme_tag.id
 where morpheme_gloss.gloss = any($1)
   and morpheme_tag.system_id = abbreviation_system.id
+order by array_length(morpheme_tag.abstract_ids, 1) desc

--- a/types/queries/morpheme_tags_by_gloss.sql
+++ b/types/queries/morpheme_tags_by_gloss.sql
@@ -8,8 +8,10 @@ select
   morpheme_tag.description,
   morpheme_tag.segment_type as "segment_type: SegmentType",
   abstract_morpheme_tag.linguistic_type,
-  array(select abstract_morpheme_tag.internal_gloss from unnest(morpheme_tag.abstract_ids) as abstract_id
-        inner join abstract_morpheme_tag on abstract_morpheme_tag.id = abstract_id) as internal_tags
+  array(
+    select abstract_morpheme_tag.internal_gloss
+    from unnest(morpheme_tag.abstract_ids) as abstract_id
+      inner join abstract_morpheme_tag on abstract_morpheme_tag.id = abstract_id) as internal_tags
 from morpheme_gloss
   inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id
   left join abbreviation_system on abbreviation_system.short_name = any($2)

--- a/types/queries/morpheme_tags_by_gloss.sql
+++ b/types/queries/morpheme_tags_by_gloss.sql
@@ -6,7 +6,7 @@ select
   morpheme_tag.gloss as concrete_gloss,
   morpheme_tag.title,
   morpheme_tag.description,
-  morpheme_tag.segment_type,
+  morpheme_tag.segment_type as "segment_type: SegmentType",
   abstract_morpheme_tag.linguistic_type,
   array(select abstract_morpheme_tag.internal_gloss from unnest(morpheme_tag.abstract_ids) as abstract_id
         inner join abstract_morpheme_tag on abstract_morpheme_tag.id = abstract_id) as internal_tags

--- a/types/queries/upsert_concrete_tag.sql
+++ b/types/queries/upsert_concrete_tag.sql
@@ -1,4 +1,6 @@
-insert into morpheme_tag (system_id, abstract_ids, gloss, title, segment_type, description)
+insert into morpheme_tag (
+  system_id, abstract_ids, gloss, title, segment_type, description
+)
 values ($1, $2, $3, $4, $5, $6)
 on conflict (system_id, abstract_ids) do update set
 gloss = excluded.gloss,

--- a/types/queries/upsert_concrete_tag.sql
+++ b/types/queries/upsert_concrete_tag.sql
@@ -1,4 +1,6 @@
-insert into morpheme_tag (system_id, abstract_ids, gloss, title)
-values ($1, $2, $3, $4)
+insert into morpheme_tag (system_id, abstract_ids, gloss, title, segment_type)
+values ($1, $2, $3, $4, $5)
 on conflict (system_id, abstract_ids) do update set
-gloss = excluded.gloss
+gloss = excluded.gloss,
+title = excluded.title,
+segment_type = excluded.segment_type

--- a/types/queries/upsert_concrete_tag.sql
+++ b/types/queries/upsert_concrete_tag.sql
@@ -1,4 +1,4 @@
 insert into morpheme_tag (system_id, abstract_ids, gloss, title)
 values ($1, $2, $3, $4)
 on conflict (system_id, abstract_ids) do update set
-   gloss = excluded.gloss
+gloss = excluded.gloss

--- a/types/queries/upsert_concrete_tag.sql
+++ b/types/queries/upsert_concrete_tag.sql
@@ -1,6 +1,7 @@
-insert into morpheme_tag (system_id, abstract_ids, gloss, title, segment_type)
-values ($1, $2, $3, $4, $5)
+insert into morpheme_tag (system_id, abstract_ids, gloss, title, segment_type, description)
+values ($1, $2, $3, $4, $5, $6)
 on conflict (system_id, abstract_ids) do update set
 gloss = excluded.gloss,
 title = excluded.title,
-segment_type = excluded.segment_type
+segment_type = excluded.segment_type,
+description = excluded.description

--- a/types/queries/upsert_contributor.sql
+++ b/types/queries/upsert_contributor.sql
@@ -1,4 +1,4 @@
 insert into contributor (full_name)
 values ($1)
-on conflict (full_name) do update
-set full_name = EXCLUDED.full_name
+on conflict (full_name) do update set
+full_name = excluded.full_name

--- a/types/queries/upsert_document_page.sql
+++ b/types/queries/upsert_document_page.sql
@@ -1,8 +1,7 @@
 insert into document_page (document_id, index_in_document, iiif_source_id, iiif_oid)
 values ($1, $2, $3, $4)
-on conflict (document_id, index_in_document)
-  do update set
-    index_in_document = excluded.index_in_document,
-    iiif_source_id = excluded.iiif_source_id,
-    iiif_oid = excluded.iiif_oid
-  returning id
+on conflict (document_id, index_in_document) do update set
+index_in_document = excluded.index_in_document,
+iiif_source_id = excluded.iiif_source_id,
+iiif_oid = excluded.iiif_oid
+returning id

--- a/types/queries/upsert_morpheme_tag.sql
+++ b/types/queries/upsert_morpheme_tag.sql
@@ -1,6 +1,6 @@
 insert into abstract_morpheme_tag (internal_gloss, description, linguistic_type)
 values ($1, $2, $3)
-on conflict (internal_gloss) do update
-   set description = excluded.description,
-       linguistic_type = excluded.linguistic_type
+on conflict (internal_gloss) do update set
+description = excluded.description,
+linguistic_type = excluded.linguistic_type
 returning id

--- a/types/queries/upsert_morpheme_tag.sql
+++ b/types/queries/upsert_morpheme_tag.sql
@@ -1,6 +1,5 @@
-insert into abstract_morpheme_tag (internal_gloss, description, linguistic_type)
-values ($1, $2, $3)
+insert into abstract_morpheme_tag (internal_gloss, linguistic_type)
+values ($1, $2)
 on conflict (internal_gloss) do update set
-description = excluded.description,
 linguistic_type = excluded.linguistic_type
 returning id

--- a/types/queries/upsert_word_in_document.sql
+++ b/types/queries/upsert_word_in_document.sql
@@ -1,12 +1,12 @@
-insert into word (source_text, simple_phonetics, phonemic, english_gloss, recorded_at, commentary,
+insert into word (
+  source_text, simple_phonetics, phonemic, english_gloss, recorded_at, commentary,
   document_id, page_number, index_in_document, page_id, character_range, audio_slice_id)
 values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-on conflict (document_id, index_in_document)
-do update set
-  source_text = EXCLUDED.source_text,
-  simple_phonetics = EXCLUDED.simple_phonetics,
-  phonemic = EXCLUDED.phonemic,
-  english_gloss = EXCLUDED.english_gloss,
-  commentary = EXCLUDED.commentary,
-  audio_slice_id = EXCLUDED.audio_slice_id
+on conflict (document_id, index_in_document) do update set
+source_text = excluded.source_text,
+simple_phonetics = excluded.simple_phonetics,
+phonemic = excluded.phonemic,
+english_gloss = excluded.english_gloss,
+commentary = excluded.commentary,
+audio_slice_id = excluded.audio_slice_id
 returning id

--- a/types/queries/upsert_word_segment.sql
+++ b/types/queries/upsert_word_segment.sql
@@ -13,11 +13,12 @@ with global_gloss as (
   returning id
 )
 
-insert into word_segment (word_id, index_in_word, morpheme, gloss_id)
-select $3, $4, $5, coalesce(global_gloss.id, inserted_gloss.id)
+insert into word_segment (word_id, index_in_word, morpheme, gloss_id, segment_type)
+select $3, $4, $5, coalesce(global_gloss.id, inserted_gloss.id), $6
 from global_gloss
 full outer join inserted_gloss on true
 on conflict (word_id, index_in_word)
   do update set
     morpheme = EXCLUDED.morpheme,
-    gloss_id = EXCLUDED.gloss_id
+    gloss_id = EXCLUDED.gloss_id,
+    segment_type = EXCLUDED.segment_type

--- a/types/queries/upsert_word_segment.sql
+++ b/types/queries/upsert_word_segment.sql
@@ -13,12 +13,11 @@ with global_gloss as (
   returning id
 )
 
-insert into word_segment (word_id, index_in_word, morpheme, gloss_id, followed_by)
-select $3, $4, $5, coalesce(global_gloss.id, inserted_gloss.id), $6
+insert into word_segment (word_id, index_in_word, morpheme, gloss_id)
+select $3, $4, $5, coalesce(global_gloss.id, inserted_gloss.id)
 from global_gloss
 full outer join inserted_gloss on true
 on conflict (word_id, index_in_word)
   do update set
     morpheme = EXCLUDED.morpheme,
-    gloss_id = EXCLUDED.gloss_id,
-    followed_by = EXCLUDED.followed_by
+    gloss_id = EXCLUDED.gloss_id

--- a/types/queries/word_parts.sql
+++ b/types/queries/word_parts.sql
@@ -4,7 +4,7 @@ select distinct on (word_segment.word_id, word_segment.index_in_word)
   word_segment.morpheme,
   word_segment.gloss_id,
   morpheme_gloss.gloss,
-  morpheme_tag.segment_type
+  word_segment.segment_type as "segment_type: SegmentType"
 from word_segment
   inner join morpheme_gloss on morpheme_gloss.id = word_segment.gloss_id
   left join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id

--- a/types/queries/word_parts.sql
+++ b/types/queries/word_parts.sql
@@ -1,10 +1,13 @@
-select
+select distinct on (word_segment.word_id, word_segment.index_in_word)
+  word_segment.index_in_word,
   word_segment.word_id,
   word_segment.morpheme,
   word_segment.gloss_id,
   morpheme_gloss.gloss,
-  word_segment.followed_by as "followed_by: SegmentType"
+  morpheme_tag.segment_type
 from word_segment
   inner join morpheme_gloss on morpheme_gloss.id = word_segment.gloss_id
-where word_id = any($1)
-order by index_in_word
+  left join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id
+  left join morpheme_tag on abstract_morpheme_tag.id = morpheme_tag.abstract_ids[1]
+where word_segment.word_id = any($1)
+order by word_segment.word_id, word_segment.index_in_word

--- a/types/src/cherokee.rs
+++ b/types/src/cherokee.rs
@@ -18,7 +18,7 @@ pub enum CherokeeOrthography {
     /// TODO Option for /qu/ instead of /gw/ or /kw/
     Crg,
     /// Simplified system that uses d/t without tones, a compromise intended for
-    /// language learners.
+    /// language learners. qu and ts
     Learner,
 }
 
@@ -182,7 +182,7 @@ mod tests {
         // Test the learner orthography.
         assert_eq!(
             CherokeeOrthography::Learner.convert(orig),
-            "unadodagwasgv'i"
+            "unadodaquasgv'i"
         );
         // Test the CRG orthography.
         assert_eq!(

--- a/types/src/form.rs
+++ b/types/src/form.rs
@@ -120,7 +120,6 @@ impl AnnotatedForm {
                         .iter()
                         .zip(abstract_segments.iter().skip(curr_index));
                     let is_match = abstract_matches.clone().all(|(a, b)| *a == b.gloss);
-                    println!("matching against {:?}", concrete_tag);
                     if is_match {
                         let corresponding_segments = abstract_segments
                             .iter()
@@ -139,6 +138,7 @@ impl AnnotatedForm {
                             morpheme: corresponding_segments.map(|seg| &seg.morpheme).join(""),
                             gloss: concrete_tag.tag.clone(),
                             gloss_id: None,
+                            matching_tag: Some(concrete_tag.clone()),
                         });
                         curr_index += concrete_tag.internal_tags.len();
                         break;

--- a/types/src/form.rs
+++ b/types/src/form.rs
@@ -122,17 +122,23 @@ impl AnnotatedForm {
                     let is_match = abstract_matches.clone().all(|(a, b)| *a == b.gloss);
                     println!("matching against {:?}", concrete_tag);
                     if is_match {
+                        let corresponding_segments = abstract_segments
+                            .iter()
+                            .skip(curr_index)
+                            .take(concrete_tag.internal_tags.len());
                         concrete_segments.push(MorphemeSegment {
                             system: None,
-                            morpheme: abstract_segments
-                                .iter()
-                                .skip(curr_index)
-                                .take(concrete_tag.internal_tags.len())
-                                .map(|seg| &seg.morpheme)
-                                .join(""),
+                            // Use the segment type of the first abstract one
+                            // unless the concrete segment overrides the segment type.
+                            segment_type: concrete_tag.segment_type.or_else(|| {
+                                corresponding_segments
+                                    .clone()
+                                    .next()
+                                    .and_then(|seg| seg.segment_type)
+                            }),
+                            morpheme: corresponding_segments.map(|seg| &seg.morpheme).join(""),
                             gloss: concrete_tag.tag.clone(),
                             gloss_id: None,
-                            segment_type: Some(concrete_tag.segment_type),
                         });
                         curr_index += concrete_tag.internal_tags.len();
                         break;

--- a/types/src/form.rs
+++ b/types/src/form.rs
@@ -126,7 +126,7 @@ impl AnnotatedForm {
                             .skip(curr_index)
                             .take(concrete_tag.internal_tags.len());
                         concrete_segments.push(MorphemeSegment {
-                            system: None,
+                            system: Some(system),
                             // Use the segment type of the first abstract one
                             // unless the concrete segment overrides the segment type.
                             segment_type: concrete_tag.segment_type.or_else(|| {
@@ -147,7 +147,10 @@ impl AnnotatedForm {
             } else {
                 // If this abstract segment was unmatched (probably a root),
                 // then just use it directly.
-                concrete_segments.push(abstract_segment.clone());
+                concrete_segments.push(MorphemeSegment {
+                    system: Some(system),
+                    ..abstract_segment.clone()
+                });
                 curr_index += 1;
             }
             // if !success {

--- a/types/src/gloss.rs
+++ b/types/src/gloss.rs
@@ -11,7 +11,7 @@ use nom::{
 
 struct GlossSegment<'a> {
     tag: &'a [u8],
-    followed_by: Option<SegmentType>,
+    segment_type: Option<SegmentType>,
 }
 
 const SEPARATORS: &str = "-=~\\";
@@ -31,7 +31,7 @@ pub fn parse_gloss_layers<'a>(
                     String::from_utf8_lossy(morpheme.tag).trim().to_owned(),
                     String::from_utf8_lossy(gloss.tag).trim().to_owned(),
                     // The gloss line is most likely to have the correct separator.
-                    gloss.followed_by,
+                    gloss.segment_type,
                 )
             })
             .collect(),
@@ -46,9 +46,9 @@ fn gloss_line(input: &[u8]) -> IResult<&[u8], Vec<GlossSegment>> {
 }
 
 fn tailed_morpheme(input: &[u8]) -> IResult<&[u8], GlossSegment> {
-    map(pair(morpheme, opt(morpheme_sep)), |(m, sep)| GlossSegment {
+    map(pair(opt(morpheme_sep), morpheme), |(sep, m)| GlossSegment {
         tag: m,
-        followed_by: sep,
+        segment_type: sep,
     })(input)
 }
 

--- a/types/src/lexical.rs
+++ b/types/src/lexical.rs
@@ -957,7 +957,7 @@ mod tests {
         let id = MorphemeId::parse("DF2018:55");
         assert_ne!(id, None);
         let id = id.unwrap();
-        assert_eq!(id.document_name.as_ref().map(|x| &**x), Some("DF2018"));
+        assert_eq!(id.document_name.as_deref(), Some("DF2018"));
         assert_eq!(id.gloss, "55");
     }
 
@@ -966,7 +966,7 @@ mod tests {
         let id = MorphemeId::parse("IN1861:1-24");
         assert_ne!(id, None);
         let id = id.unwrap();
-        assert_eq!(id.document_name.as_ref().map(|x| &**x), Some("IN1861"));
+        assert_eq!(id.document_name.as_deref(), Some("IN1861"));
         assert_eq!(id.gloss, "1-24");
     }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod annotation;
 mod audio;
+mod cherokee;
 mod database_sql;
 mod date;
 mod document;
@@ -29,7 +30,6 @@ mod gloss;
 pub mod iiif;
 mod lexical;
 mod morpheme;
-mod orthography;
 pub mod page;
 mod person;
 mod tag;
@@ -41,6 +41,7 @@ pub use chrono;
 pub use sqlx::types::Uuid;
 
 pub use audio::*;
+pub use cherokee::*;
 pub use database_sql::*;
 pub use date::*;
 pub use document::*;
@@ -49,7 +50,6 @@ pub use geometry::*;
 pub use gloss::*;
 pub use lexical::*;
 pub use morpheme::*;
-pub use orthography::*;
 pub use person::*;
 pub use tag::*;
 pub use translation::*;

--- a/types/src/morpheme.rs
+++ b/types/src/morpheme.rs
@@ -20,6 +20,7 @@ pub struct MorphemeSegment {
     /// This field determines what character should separate this segment from
     /// the next one when reconstituting the full segmentation string.
     pub segment_type: Option<SegmentType>,
+    pub matching_tag: Option<TagForm>,
 }
 
 /// The kind of segment that a particular sequence of characters in a morphemic
@@ -48,6 +49,7 @@ impl MorphemeSegment {
             // migration code to create this data structure.
             gloss_id: None,
             segment_type,
+            matching_tag: None,
         }
     }
 
@@ -115,16 +117,16 @@ impl MorphemeSegment {
     async fn matching_tag(
         &self,
         context: &async_graphql::Context<'_>,
-        // TODO make this non-optional
-        system: Option<CherokeeOrthography>,
     ) -> FieldResult<Option<TagForm>> {
         use async_graphql::dataloader::*;
-        if let Some(gloss_id) = self.gloss_id {
+        if let Some(matching_tag) = &self.matching_tag {
+            Ok(Some(matching_tag.clone()))
+        } else if let Some(gloss_id) = self.gloss_id {
             Ok(context
                 .data::<DataLoader<Database>>()?
                 .load_one(TagForMorpheme(
                     gloss_id,
-                    system.unwrap_or(CherokeeOrthography::Taoc),
+                    self.system.unwrap_or(CherokeeOrthography::Taoc),
                 ))
                 .await?)
         } else {

--- a/types/src/morpheme.rs
+++ b/types/src/morpheme.rs
@@ -104,10 +104,13 @@ impl MorphemeSegment {
         &self.gloss
     }
 
-    /// What kind of thing is the next segment?
-    ///
+    /// What kind of thing is this segment?
+    async fn segment_type(&self) -> Option<SegmentType> {
+        self.segment_type
+    }
+
     /// This field determines what character should separate this segment from
-    /// the next one when reconstituting the full segmentation string.
+    /// the previous one when reconstituting the full segmentation string.
     async fn previous_separator(&self) -> Option<&str> {
         self.get_previous_separator()
     }

--- a/types/src/morpheme.rs
+++ b/types/src/morpheme.rs
@@ -84,8 +84,8 @@ impl MorphemeSegment {
 
     /// Convert the source representation of this segment into the given
     /// phonemic writing system.
-    pub fn get_morpheme(&self, system: Option<CherokeeOrthography>) -> Cow<'_, str> {
-        match system {
+    pub fn get_morpheme(&self) -> Cow<'_, str> {
+        match self.system {
             Some(orthography) => Cow::Owned(orthography.convert(&self.morpheme)),
             _ => Cow::Borrowed(&*self.morpheme),
         }
@@ -95,8 +95,8 @@ impl MorphemeSegment {
 #[async_graphql::Object]
 impl MorphemeSegment {
     /// Phonemic representation of the morpheme
-    async fn morpheme(&self, system: Option<CherokeeOrthography>) -> Cow<'_, str> {
-        self.get_morpheme(system)
+    async fn morpheme(&self) -> Cow<'_, str> {
+        self.get_morpheme()
     }
 
     /// English gloss in standard DAILP format that refers to a lexical item

--- a/types/src/tag.rs
+++ b/types/src/tag.rs
@@ -1,3 +1,4 @@
+use crate::SegmentType;
 use serde::{Deserialize, Serialize};
 
 /// Represents a morphological gloss tag without committing to a single representation.
@@ -10,15 +11,6 @@ pub struct MorphemeTag {
     /// interlinear glosses of a word containing this morpheme.
     /// Standard annotation tag for this morpheme, defined by DAILP.
     pub id: String,
-    /// The "learner" representation of this morpheme, a compromise between no
-    /// interlinear glossing and standard linguistic terms.
-    pub learner: Option<TagForm>,
-    /// Representation of this morpheme that closely aligns with _Tone and
-    /// Accent in Oklahoma Cherokee_.
-    pub taoc: Option<TagForm>,
-    /// Representation of this morpheme that closely aligns with _Cherokee
-    /// Reference Grammar_.
-    pub crg: Option<TagForm>,
     /// What kind of functional morpheme is this?
     /// A few examples: "Prepronominal Prefix", "Clitic"
     pub morpheme_type: String,
@@ -28,6 +20,7 @@ pub struct MorphemeTag {
 #[derive(async_graphql::SimpleObject, Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TagForm {
+    pub internal_tags: Vec<String>,
     /// How this morpheme is represented in a gloss
     pub tag: String,
     /// Plain English title of the morpheme tag
@@ -40,4 +33,5 @@ pub struct TagForm {
     /// context.
     pub definition: String,
     pub morpheme_type: String,
+    pub segment_type: SegmentType,
 }

--- a/types/src/tag.rs
+++ b/types/src/tag.rs
@@ -33,5 +33,6 @@ pub struct TagForm {
     /// context.
     pub definition: String,
     pub morpheme_type: String,
-    pub segment_type: SegmentType,
+    /// Overrides the segment type of instances of this tag.
+    pub segment_type: Option<SegmentType>,
 }

--- a/website/src/cwkw/theme.css.ts
+++ b/website/src/cwkw/theme.css.ts
@@ -1,9 +1,8 @@
-import { createTheme, createThemeContract, style } from "@vanilla-extract/css";
-import { createSprinkles, defineProperties } from "@vanilla-extract/sprinkles";
-import { lighten } from "polished";
-import { colors, rootFontSize, theme } from "src/sprinkles.css";
-import { marginX, paddingX, paddingY } from "src/style-utils";
-
+import { createTheme, createThemeContract, style } from "@vanilla-extract/css"
+import { createSprinkles, defineProperties } from "@vanilla-extract/sprinkles"
+import { lighten } from "polished"
+import { colors, rootFontSize, theme } from "src/sprinkles.css"
+import { marginX, paddingX, paddingY } from "src/style-utils"
 
 export const themeClass = createTheme(theme, {
   fontSizes: {

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -132,10 +132,18 @@ export type AnnotatedForm = {
   readonly segments: ReadonlyArray<MorphemeSegment>
   /** All other observed words with the same root morpheme as this word. */
   readonly similarForms: ReadonlyArray<AnnotatedForm>
-  /** Romanized version of the word for simple phonetic pronunciation */
-  readonly simplePhonetics: Maybe<Scalars["String"]>
   /** Original source text */
   readonly source: Scalars["String"]
+}
+
+/**
+ * A single word in an annotated document.
+ * One word contains several layers of interpretation, including the original
+ * source text, multiple layers of linguistic annotation, and annotator notes.
+ * TODO Split into two types, one for migration and one for SQL + GraphQL
+ */
+export type AnnotatedFormRomanizedSourceArgs = {
+  system: CherokeeOrthography
 }
 
 /**
@@ -185,7 +193,7 @@ export enum CherokeeOrthography {
   Crg = "CRG",
   /**
    * Simplified system that uses d/t without tones, a compromise intended for
-   * language learners.
+   * language learners. qu and ts
    */
   Learner = "LEARNER",
   /**
@@ -380,10 +388,6 @@ export type MorphemeSegment = {
    * the next one when reconstituting the full segmentation string.
    */
   readonly previousSeparator: Maybe<Scalars["String"]>
-}
-
-export type MorphemeSegmentMorphemeArgs = {
-  system: InputMaybe<CherokeeOrthography>
 }
 
 export type Mutation = {
@@ -710,7 +714,6 @@ export type DocumentContentsQuery = { readonly __typename?: "Query" } & {
                           | "index"
                           | "source"
                           | "romanizedSource"
-                          | "simplePhonetics"
                           | "phonemic"
                           | "englishGloss"
                           | "commentary"
@@ -753,7 +756,6 @@ export type DocumentContentsQuery = { readonly __typename?: "Query" } & {
           | "index"
           | "source"
           | "romanizedSource"
-          | "simplePhonetics"
           | "phonemic"
           | "englishGloss"
           | "commentary"
@@ -790,7 +792,6 @@ export type FormFieldsFragment = {
   | "index"
   | "source"
   | "romanizedSource"
-  | "simplePhonetics"
   | "phonemic"
   | "englishGloss"
   | "commentary"
@@ -845,7 +846,7 @@ export type WordSearchQuery = { readonly __typename?: "Query" } & {
       AnnotatedForm,
       | "source"
       | "normalizedSource"
-      | "simplePhonetics"
+      | "romanizedSource"
       | "englishGloss"
       | "index"
     > & {
@@ -906,7 +907,7 @@ export type TimelineQuery = { readonly __typename?: "Query" } & {
           AnnotatedForm,
           | "source"
           | "normalizedSource"
-          | "simplePhonetics"
+          | "romanizedSource"
           | "phonemic"
           | "documentId"
           | "englishGloss"
@@ -1021,8 +1022,7 @@ export const FormFieldsFragmentDoc = gql`
   fragment FormFields on AnnotatedForm {
     index
     source
-    romanizedSource
-    simplePhonetics
+    romanizedSource(system: $morphemeSystem)
     phonemic
     segments(system: $morphemeSystem) {
       morpheme
@@ -1184,7 +1184,7 @@ export const WordSearchDocument = gql`
     wordSearch(query: $query) {
       source
       normalizedSource
-      simplePhonetics
+      romanizedSource(system: LEARNER)
       englishGloss
       index
       document {
@@ -1257,7 +1257,7 @@ export const TimelineDocument = gql`
       forms {
         source
         normalizedSource
-        simplePhonetics
+        romanizedSource(system: LEARNER)
         phonemic
         documentId
         englishGloss

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -382,12 +382,12 @@ export type MorphemeSegment = {
   /** Phonemic representation of the morpheme */
   readonly morpheme: Scalars["String"]
   /**
-   * What kind of thing is the next segment?
-   *
    * This field determines what character should separate this segment from
-   * the next one when reconstituting the full segmentation string.
+   * the previous one when reconstituting the full segmentation string.
    */
   readonly previousSeparator: Maybe<Scalars["String"]>
+  /** What kind of thing is this segment? */
+  readonly segmentType: Maybe<SegmentType>
 }
 
 export type Mutation = {
@@ -723,7 +723,10 @@ export type DocumentContentsQuery = { readonly __typename?: "Query" } & {
                                 readonly __typename?: "MorphemeSegment"
                               } & Pick<
                                 MorphemeSegment,
-                                "morpheme" | "gloss" | "previousSeparator"
+                                | "morpheme"
+                                | "gloss"
+                                | "segmentType"
+                                | "previousSeparator"
                               > & {
                                   readonly matchingTag: Maybe<
                                     { readonly __typename?: "TagForm" } & Pick<
@@ -763,7 +766,7 @@ export type DocumentContentsQuery = { readonly __typename?: "Query" } & {
             readonly segments: ReadonlyArray<
               { readonly __typename?: "MorphemeSegment" } & Pick<
                 MorphemeSegment,
-                "morpheme" | "gloss" | "previousSeparator"
+                "morpheme" | "gloss" | "segmentType" | "previousSeparator"
               > & {
                   readonly matchingTag: Maybe<
                     { readonly __typename?: "TagForm" } & Pick<
@@ -799,7 +802,7 @@ export type FormFieldsFragment = {
     readonly segments: ReadonlyArray<
       { readonly __typename?: "MorphemeSegment" } & Pick<
         MorphemeSegment,
-        "morpheme" | "gloss" | "previousSeparator"
+        "morpheme" | "gloss" | "segmentType" | "previousSeparator"
       > & {
           readonly matchingTag: Maybe<
             { readonly __typename?: "TagForm" } & Pick<TagForm, "tag" | "title">
@@ -1031,6 +1034,7 @@ export const FormFieldsFragmentDoc = gql`
         tag
         title
       }
+      segmentType
       previousSeparator
     }
     englishGloss

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -382,10 +382,6 @@ export type MorphemeSegment = {
   readonly previousSeparator: Maybe<Scalars["String"]>
 }
 
-export type MorphemeSegmentMatchingTagArgs = {
-  system: InputMaybe<CherokeeOrthography>
-}
-
 export type MorphemeSegmentMorphemeArgs = {
   system: InputMaybe<CherokeeOrthography>
 }
@@ -591,7 +587,8 @@ export type TagForm = {
   readonly detailsUrl: Maybe<Scalars["String"]>
   readonly internalTags: ReadonlyArray<Scalars["String"]>
   readonly morphemeType: Scalars["String"]
-  readonly segmentType: SegmentType
+  /** Overrides the segment type of instances of this tag. */
+  readonly segmentType: Maybe<SegmentType>
   /** How this morpheme looks in original language data */
   readonly shape: Maybe<Scalars["String"]>
   /** How this morpheme is represented in a gloss */

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -71,8 +71,7 @@ query DocumentContents(
 fragment FormFields on AnnotatedForm {
   index
   source
-  romanizedSource
-  simplePhonetics
+  romanizedSource(system: $morphemeSystem)
   phonemic
   segments(system: $morphemeSystem) {
     morpheme
@@ -112,7 +111,7 @@ query WordSearch($query: String!) {
   wordSearch(query: $query) {
     source
     normalizedSource
-    simplePhonetics
+    romanizedSource(system: LEARNER)
     englishGloss
     index
     document {
@@ -158,7 +157,7 @@ query Timeline($gloss: String!) {
     forms {
       source
       normalizedSource
-      simplePhonetics
+      romanizedSource(system: LEARNER)
       phonemic
       documentId
       englishGloss

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -45,7 +45,7 @@ query AnnotatedDocument($slug: String!) {
 
 query DocumentContents(
   $slug: String!
-  $morphemeSystem: CherokeeOrthography
+  $morphemeSystem: CherokeeOrthography!
   $isReference: Boolean!
 ) {
   document(slug: $slug) {
@@ -74,14 +74,14 @@ fragment FormFields on AnnotatedForm {
   romanizedSource
   simplePhonetics
   phonemic
-  segments {
-    morpheme(system: $morphemeSystem)
+  segments(system: $morphemeSystem) {
+    morpheme
     gloss
-    matchingTag(system: $morphemeSystem) {
+    matchingTag {
       tag
       title
     }
-    nextSeparator
+    previousSeparator
   }
   englishGloss
   commentary

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -80,6 +80,7 @@ fragment FormFields on AnnotatedForm {
       tag
       title
     }
+    segmentType
     previousSeparator
   }
   englishGloss

--- a/website/src/mode.tsx
+++ b/website/src/mode.tsx
@@ -19,7 +19,6 @@ import * as css from "./mode.css"
 import { usePreferences } from "./preferences-context"
 import { ViewMode } from "./types"
 
-const notNumber = (l: any) => isNaN(Number(l))
 export const levelNameMapping = {
   [ViewMode.Story]: {
     label: "Story",
@@ -38,20 +37,20 @@ export const levelNameMapping = {
 export const modeDetails = (mode: ViewMode) => levelNameMapping[mode]
 
 const linguisticSystemMapping = {
-  [Dailp.CherokeeOrthography.Crg]: {
-    label: "CRG",
-    details:
-      "Linguistic analysis using terms from Cherokee Reference Grammar (CRG). In romanizations uses kw, gw, and j.",
-  },
-  [Dailp.CherokeeOrthography.Taoc]: {
-    label: "TAOC",
-    details:
-      "Linguistic analysis using terms from Tone and Accent in Oklahoma Cherokee (TAOC). In romanizations uses kw, gw, and j.",
-  },
   [Dailp.CherokeeOrthography.Learner]: {
     label: "Learner",
     details:
       "A more traditional phonetics view, aligned with the Worcester syllabary. Uses qu and ts.",
+  },
+  [Dailp.CherokeeOrthography.Crg]: {
+    label: "Cherokee Reference Grammar",
+    details:
+      "Linguistic analysis using terms from Cherokee Reference Grammar (CRG). In romanizations uses kw, gw, and j.",
+  },
+  [Dailp.CherokeeOrthography.Taoc]: {
+    label: "Tone and Accent in Oklahoma Cherokee",
+    details:
+      "Linguistic analysis using terms from Tone and Accent in Oklahoma Cherokee (TAOC). In romanizations uses kw, gw, and j.",
   },
 }
 
@@ -91,16 +90,11 @@ export const ExperiencePicker = (p: {
       value={value}
       onChange={(e) => setValue(Number.parseInt(e.target.value))}
     >
-      {Object.keys(ViewMode)
-        .filter(notNumber)
-        .map(function (mode: string) {
-          const selectedMode = ViewMode[mode as keyof typeof ViewMode]
-          return (
-            <option value={selectedMode} key={selectedMode}>
-              {modeDetails(selectedMode).label}
-            </option>
-          )
-        })}
+      {Object.entries(levelNameMapping).map(([viewMode, details]) => (
+        <option value={viewMode} key={viewMode}>
+          {details.label}
+        </option>
+      ))}
     </select>
   )
 }
@@ -125,19 +119,11 @@ export const PhoneticsPicker = (p: {
       onChange={(e) => setValue(e.target.value as Dailp.CherokeeOrthography)}
       aria-label="Romanization"
     >
-      {Object.keys(Dailp.CherokeeOrthography)
-        .filter(notNumber)
-        .map(function (representation: string) {
-          const selectedSystem =
-            Dailp.CherokeeOrthography[
-              representation as keyof typeof Dailp.CherokeeOrthography
-            ]
-          return (
-            <option value={selectedSystem} key={selectedSystem}>
-              {linguisticSystemDetails(selectedSystem).label}
-            </option>
-          )
-        })}
+      {Object.entries(linguisticSystemMapping).map(([system, details]) => (
+        <option value={system} key={system}>
+          {details.label}
+        </option>
+      ))}
     </select>
   )
 }
@@ -155,7 +141,7 @@ export const PrefPanel = () => {
         {levelNameMapping[preferences.viewMode].details}
       </p>
 
-      <label>Romanization System:</label>
+      <label>Linguistic System:</label>
       <PhoneticsPicker
         aria-described-by={"Selected-Phonetics"}
         onSelect={preferences.setLinguisticSystem}

--- a/website/src/mode.tsx
+++ b/website/src/mode.tsx
@@ -17,6 +17,7 @@ import {
   useRadioState,
 } from "reakit/Radio"
 import { std } from "src/sprinkles.css"
+import * as Dailp from "./graphql/dailp"
 import * as css from "./mode.css"
 import { usePreferences } from "./preferences-context"
 import {
@@ -100,6 +101,21 @@ export const selectedMode = () =>
 
 export const selectedPhonetics = () =>
   Number.parseInt(Cookies.get("phonetics") ?? "0") as PhoneticRepresentation
+
+export const romanizationFromSystem = (
+  system: PhoneticRepresentation,
+  word: Pick<Dailp.AnnotatedForm, "romanizedSource" | "simplePhonetics">
+) => {
+  if (system == PhoneticRepresentation.Dailp && word.simplePhonetics) {
+    return word.simplePhonetics
+  } else if (
+    system == PhoneticRepresentation.Worcester &&
+    word.romanizedSource
+  ) {
+    return word.romanizedSource
+  }
+  return null
+}
 
 export const ExperiencePicker = (p: {
   onSelect: (mode: ViewMode) => void

--- a/website/src/mode.tsx
+++ b/website/src/mode.tsx
@@ -70,21 +70,6 @@ export const selectedLinguisticSystem = (): Dailp.CherokeeOrthography =>
   (Cookies.get(LINGUISTIC_SYSTEM_KEY) as Dailp.CherokeeOrthography) ??
   Dailp.CherokeeOrthography.Learner
 
-export const romanizationFromSystem = (
-  system: Dailp.CherokeeOrthography,
-  word: Pick<Dailp.AnnotatedForm, "romanizedSource" | "simplePhonetics">
-) => {
-  if (system != Dailp.CherokeeOrthography.Learner && word.simplePhonetics) {
-    return word.simplePhonetics
-  } else if (
-    system == Dailp.CherokeeOrthography.Learner &&
-    word.romanizedSource
-  ) {
-    return word.romanizedSource
-  }
-  return null
-}
-
 export const ExperiencePicker = (p: {
   onSelect: (mode: ViewMode) => void
   id?: string

--- a/website/src/mode.tsx
+++ b/website/src/mode.tsx
@@ -1,5 +1,4 @@
-import Cookies from "js-cookie"
-import React, { useEffect, useState } from "react"
+import React, { useEffect } from "react"
 import { MdClose, MdSettings } from "react-icons/md"
 import { Button } from "reakit/Button"
 import {
@@ -36,7 +35,7 @@ export const levelNameMapping = {
 
 export const modeDetails = (mode: ViewMode) => levelNameMapping[mode]
 
-const linguisticSystemMapping = {
+const cherokeeRepresentationMapping = {
   [Dailp.CherokeeOrthography.Learner]: {
     label: "Learner",
     details:
@@ -54,34 +53,19 @@ const linguisticSystemMapping = {
   },
 }
 
-export const linguisticSystemDetails = (system: Dailp.CherokeeOrthography) =>
-  linguisticSystemMapping[system]
-
-// Avoid changing these keys at all costs, because that will essentially reset
-// saved user preferences.
-const VIEW_MODE_KEY = "experienceLevel"
-const LINGUISTIC_SYSTEM_KEY = "cherokeeSystem"
-
-export const selectedViewMode = () =>
-  Number.parseInt(Cookies.get(VIEW_MODE_KEY) ?? "1") as ViewMode
-
-export const selectedLinguisticSystem = (): Dailp.CherokeeOrthography =>
-  (Cookies.get(LINGUISTIC_SYSTEM_KEY) as Dailp.CherokeeOrthography) ??
-  Dailp.CherokeeOrthography.Learner
+export const cherokeeRepresentationDetails = (
+  system: Dailp.CherokeeOrthography
+) => cherokeeRepresentationMapping[system]
 
 export const ExperiencePicker = (p: {
   onSelect: (mode: ViewMode) => void
   id?: string
 }) => {
-  const [value, setValue] = useState(selectedViewMode())
+  const { viewMode: value, setViewMode: setValue } = usePreferences()
 
   // Save the selected view mode throughout the session.
   useEffect(() => {
-    Cookies.set(VIEW_MODE_KEY, value.toString(), {
-      sameSite: "strict",
-      secure: true,
-    })
-    p.onSelect(value as ViewMode)
+    p.onSelect(value)
   }, [value])
   return (
     <select
@@ -102,14 +86,11 @@ export const ExperiencePicker = (p: {
 export const PhoneticsPicker = (p: {
   onSelect: (phonetics: Dailp.CherokeeOrthography) => void
 }) => {
-  const [value, setValue] = useState(selectedLinguisticSystem())
+  const { cherokeeRepresentation: value, setCherokeeRepresentation: setValue } =
+    usePreferences()
 
   // Save the selected representation throughout the session.
   useEffect(() => {
-    Cookies.set(LINGUISTIC_SYSTEM_KEY, value.toString(), {
-      sameSite: "strict",
-      secure: true,
-    })
     p.onSelect(value)
   }, [value])
   return (
@@ -119,11 +100,13 @@ export const PhoneticsPicker = (p: {
       onChange={(e) => setValue(e.target.value as Dailp.CherokeeOrthography)}
       aria-label="Romanization"
     >
-      {Object.entries(linguisticSystemMapping).map(([system, details]) => (
-        <option value={system} key={system}>
-          {details.label}
-        </option>
-      ))}
+      {Object.entries(cherokeeRepresentationMapping).map(
+        ([system, details]) => (
+          <option value={system} key={system}>
+            {details.label}
+          </option>
+        )
+      )}
     </select>
   )
 }
@@ -138,16 +121,19 @@ export const PrefPanel = () => {
         onSelect={preferences.setViewMode}
       />
       <p id={"Selected-ViewMode"}>
-        {levelNameMapping[preferences.viewMode].details}
+        {modeDetails(preferences.viewMode).details}
       </p>
 
       <label>Linguistic System:</label>
       <PhoneticsPicker
         aria-described-by={"Selected-Phonetics"}
-        onSelect={preferences.setLinguisticSystem}
+        onSelect={preferences.setCherokeeRepresentation}
       />
       <p id={"Selected-Phonetics"}>
-        {linguisticSystemMapping[preferences.linguisticSystem].details}
+        {
+          cherokeeRepresentationDetails(preferences.cherokeeRepresentation)
+            .details
+        }
       </p>
     </div>
   )

--- a/website/src/morpheme.tsx
+++ b/website/src/morpheme.tsx
@@ -7,7 +7,6 @@ import Link from "src/components/link"
 import * as Dailp from "src/graphql/dailp"
 import * as css from "./morpheme.css"
 import { documentWordPath, glossaryRoute } from "./routes"
-import { TagSet, morphemeDisplayTag, orthographyForTagSet } from "./types"
 
 type BasicMorphemeSegment = NonNullable<Dailp.FormFieldsFragment["segments"]>[0]
 
@@ -15,7 +14,7 @@ type BasicMorphemeSegment = NonNullable<Dailp.FormFieldsFragment["segments"]>[0]
 export const MorphemeDetails = (props: {
   documentId: string
   segment: BasicMorphemeSegment
-  tagSet: TagSet
+  linguisticSystem: Dailp.CherokeeOrthography
   hideDialog: () => void
 }) => {
   // Use the right tag name from the jump.
@@ -29,7 +28,7 @@ export const MorphemeDetails = (props: {
     pause: !props.segment.gloss,
     variables: {
       gloss: props.segment.gloss,
-      system: orthographyForTagSet(props.tagSet),
+      system: props.linguisticSystem,
     },
   })
 

--- a/website/src/morpheme.tsx
+++ b/website/src/morpheme.tsx
@@ -14,7 +14,7 @@ type BasicMorphemeSegment = NonNullable<Dailp.FormFieldsFragment["segments"]>[0]
 export const MorphemeDetails = (props: {
   documentId: string
   segment: BasicMorphemeSegment
-  linguisticSystem: Dailp.CherokeeOrthography
+  cherokeeRepresentation: Dailp.CherokeeOrthography
   hideDialog: () => void
 }) => {
   // Use the right tag name from the jump.
@@ -28,7 +28,7 @@ export const MorphemeDetails = (props: {
     pause: !props.segment.gloss,
     variables: {
       gloss: props.segment.gloss,
-      system: props.linguisticSystem,
+      system: props.cherokeeRepresentation,
     },
   })
 

--- a/website/src/pages/documents/document.page.tsx
+++ b/website/src/pages/documents/document.page.tsx
@@ -150,7 +150,7 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
     setCurrContents: selectAndShowWord,
   }
 
-  const { viewMode, linguisticSystem } = usePreferences()
+  const { viewMode, cherokeeRepresentation } = usePreferences()
 
   return (
     <>
@@ -168,7 +168,7 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
               documentId={doc.id}
               segment={selectedMorpheme}
               hideDialog={closeDialog}
-              linguisticSystem={linguisticSystem}
+              cherokeeRepresentation={cherokeeRepresentation}
             />
           ) : null}
         </DialogContent>
@@ -205,7 +205,7 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
               viewMode: viewMode,
               doc,
               openDetails,
-              linguisticSystem,
+              cherokeeRepresentation,
               wordPanelDetails: wordPanelInfo,
             }}
           />
@@ -228,12 +228,12 @@ const DocumentContents = ({
   viewMode,
   doc,
   openDetails,
-  linguisticSystem,
+  cherokeeRepresentation,
   wordPanelDetails,
 }: {
   doc: Document
   viewMode: ViewMode
-  linguisticSystem: Dailp.CherokeeOrthography
+  cherokeeRepresentation: Dailp.CherokeeOrthography
   openDetails: (morpheme: any) => void
   wordPanelDetails: WordPanelDetails
 }) => {
@@ -241,7 +241,7 @@ const DocumentContents = ({
     variables: {
       slug: doc.slug,
       isReference: doc.isReference,
-      morphemeSystem: linguisticSystem,
+      morphemeSystem: cherokeeRepresentation,
     },
   })
   const docContents = data?.document
@@ -256,7 +256,7 @@ const DocumentContents = ({
           segment={seg}
           onOpenDetails={openDetails}
           viewMode={viewMode}
-          linguisticSystem={linguisticSystem}
+          cherokeeRepresentation={cherokeeRepresentation}
           pageImages={
             doc.translatedPages
               ?.filter((p) => !!p.image)
@@ -271,7 +271,7 @@ const DocumentContents = ({
           segment={form}
           onOpenDetails={openDetails}
           viewMode={viewMode}
-          linguisticSystem={linguisticSystem}
+          cherokeeRepresentation={cherokeeRepresentation}
           pageImages={[]}
           wordPanelDetails={wordPanelDetails}
         />

--- a/website/src/pages/documents/document.page.tsx
+++ b/website/src/pages/documents/document.page.tsx
@@ -22,13 +22,7 @@ import {
 } from "src/routes"
 import { useScrollableTabState } from "src/scrollable-tabs"
 import { AnnotatedForm, DocumentPage, Segment } from "src/segment"
-import {
-  BasicMorphemeSegment,
-  PhoneticRepresentation,
-  TagSet,
-  ViewMode,
-  tagSetForMode,
-} from "src/types"
+import { BasicMorphemeSegment, ViewMode } from "src/types"
 import { WordPanel, WordPanelDetails } from "src/word-panel"
 import PageImages from "../../page-image"
 import * as css from "./document.css"
@@ -156,9 +150,7 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
     setCurrContents: selectAndShowWord,
   }
 
-  const { viewMode, phoneticRepresentation } = usePreferences()
-
-  const tagSet = tagSetForMode(viewMode)
+  const { viewMode, linguisticSystem } = usePreferences()
 
   return (
     <>
@@ -176,12 +168,11 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
               documentId={doc.id}
               segment={selectedMorpheme}
               hideDialog={closeDialog}
-              tagSet={tagSet}
+              linguisticSystem={linguisticSystem}
             />
           ) : null}
         </DialogContent>
       </DialogOverlay>
-
       <DialogBackdrop {...dialog} className={drawerBg}>
         <Dialog
           {...dialog}
@@ -195,11 +186,9 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
             segment={wordPanelInfo.currContents}
             setContent={wordPanelInfo.setCurrContents}
             onOpenDetails={openDetails}
-            tagSet={tagSet}
           />
         </Dialog>
       </DialogBackdrop>
-
       <div className={css.contentContainer}>
         <article className={css.annotationContents}>
           <p className={css.topMargin}>
@@ -213,11 +202,10 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
           </p>
           <DocumentContents
             {...{
-              experienceLevel: viewMode,
+              viewMode: viewMode,
               doc,
               openDetails,
-              tagSet,
-              phoneticRepresentation,
+              linguisticSystem,
               wordPanelDetails: wordPanelInfo,
             }}
           />
@@ -228,7 +216,6 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
               segment={wordPanelInfo.currContents}
               setContent={wordPanelInfo.setCurrContents}
               onOpenDetails={openDetails}
-              tagSet={tagSet}
             />
           </div>
         ) : null}
@@ -238,29 +225,24 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
 }
 
 const DocumentContents = ({
-  experienceLevel,
+  viewMode,
   doc,
   openDetails,
-  tagSet,
-  phoneticRepresentation,
+  linguisticSystem,
   wordPanelDetails,
 }: {
   doc: Document
-  experienceLevel: ViewMode
-  tagSet: TagSet
+  viewMode: ViewMode
+  linguisticSystem: Dailp.CherokeeOrthography
   openDetails: (morpheme: any) => void
-  phoneticRepresentation: PhoneticRepresentation
   wordPanelDetails: WordPanelDetails
 }) => {
-  let morphemeSystem = Dailp.CherokeeOrthography.Learner
-  if (experienceLevel === ViewMode.AnalysisDt) {
-    morphemeSystem = Dailp.CherokeeOrthography.Crg
-  } else if (experienceLevel === ViewMode.AnalysisTth) {
-    morphemeSystem = Dailp.CherokeeOrthography.Taoc
-  }
-
   const [{ data }] = Dailp.useDocumentContentsQuery({
-    variables: { slug: doc.slug, isReference: doc.isReference, morphemeSystem },
+    variables: {
+      slug: doc.slug,
+      isReference: doc.isReference,
+      morphemeSystem: linguisticSystem,
+    },
   })
   const docContents = data?.document
   if (!docContents) {
@@ -273,14 +255,13 @@ const DocumentContents = ({
           key={i}
           segment={seg}
           onOpenDetails={openDetails}
-          viewMode={experienceLevel}
-          tagSet={tagSet}
+          viewMode={viewMode}
+          linguisticSystem={linguisticSystem}
           pageImages={
             doc.translatedPages
               ?.filter((p) => !!p.image)
               .map((p) => p.image!.url) ?? []
           }
-          phoneticRepresentation={phoneticRepresentation}
           wordPanelDetails={wordPanelDetails}
         />
       ))}
@@ -289,9 +270,8 @@ const DocumentContents = ({
           key={i}
           segment={form}
           onOpenDetails={openDetails}
-          viewMode={experienceLevel}
-          tagSet={tagSet}
-          phoneticRepresentation={phoneticRepresentation}
+          viewMode={viewMode}
+          linguisticSystem={linguisticSystem}
           pageImages={[]}
           wordPanelDetails={wordPanelDetails}
         />

--- a/website/src/pages/documents/document.page.tsx
+++ b/website/src/pages/documents/document.page.tsx
@@ -194,7 +194,6 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
           <WordPanel
             segment={wordPanelInfo.currContents}
             setContent={wordPanelInfo.setCurrContents}
-            viewMode={viewMode}
             onOpenDetails={openDetails}
             tagSet={tagSet}
           />
@@ -228,7 +227,6 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
             <WordPanel
               segment={wordPanelInfo.currContents}
               setContent={wordPanelInfo.setCurrContents}
-              viewMode={viewMode}
               onOpenDetails={openDetails}
               tagSet={tagSet}
             />

--- a/website/src/pages/glossary.page.tsx
+++ b/website/src/pages/glossary.page.tsx
@@ -17,9 +17,9 @@ import Layout from "../layout"
 import { glossarySectionId, morphemeTagId } from "../routes"
 
 const GlossaryPage = () => {
-  const { linguisticSystem } = usePreferences()
+  const { cherokeeRepresentation } = usePreferences()
   const [{ data }] = Dailp.useGlossaryQuery({
-    variables: { system: linguisticSystem },
+    variables: { system: cherokeeRepresentation },
   })
   const tags = data?.allTags
   // Group the tags by type.

--- a/website/src/pages/glossary.page.tsx
+++ b/website/src/pages/glossary.page.tsx
@@ -1,7 +1,7 @@
 import cx from "classnames"
 import { groupBy } from "lodash"
 import pluralize from "pluralize"
-import React, { useState } from "react"
+import React from "react"
 import { Helmet } from "react-helmet"
 import Link from "src/components/link"
 import * as Dailp from "src/graphql/dailp"
@@ -15,20 +15,12 @@ import {
 } from "src/sprinkles.css"
 import Layout from "../layout"
 import { glossarySectionId, morphemeTagId } from "../routes"
-import { TagSet, tagSetForMode } from "../types"
 
 const GlossaryPage = () => {
-  const { viewMode } = usePreferences()
-  const tagSet = tagSetForMode(viewMode)
-  let system = Dailp.CherokeeOrthography.Taoc
-  if (tagSet === TagSet.Crg) {
-    system = Dailp.CherokeeOrthography.Crg
-  } else if (tagSet === TagSet.Taoc) {
-    system = Dailp.CherokeeOrthography.Taoc
-  } else if (tagSet === TagSet.Learner) {
-    system = Dailp.CherokeeOrthography.Learner
-  }
-  const [{ data }] = Dailp.useGlossaryQuery({ variables: { system } })
+  const { linguisticSystem } = usePreferences()
+  const [{ data }] = Dailp.useGlossaryQuery({
+    variables: { system: linguisticSystem },
+  })
   const tags = data?.allTags
   // Group the tags by type.
   const groupedTags = groupBy(tags, (t) => t.morphemeType)

--- a/website/src/pages/search.page.tsx
+++ b/website/src/pages/search.page.tsx
@@ -98,7 +98,7 @@ const Timeline = (p: { gloss: string }) => {
             ) : null}
             <div>{form.source}</div>
             <div>{form.normalizedSource}</div>
-            <div>{form.simplePhonetics}</div>
+            <div>{form.romanizedSource}</div>
             <div>{form.englishGloss.join(", ")}</div>
           </div>
         ))}

--- a/website/src/pages/timeline.page.tsx
+++ b/website/src/pages/timeline.page.tsx
@@ -71,13 +71,13 @@ const Timeline = (p: { gloss: string }) => {
                   <div key={idx} className={wordRow}>
                     <div>{form.documentId}</div>
                     <div>{form.source}</div>
-                    <div>{form.simplePhonetics}</div>
+                    <div>{form.romanizedSource}</div>
                     <div>{form.englishGloss.join(", ")}</div>
                   </div>
                 )
               } else {
-                const simplePhonetics = forms.find(
-                  (w) => w.simplePhonetics?.length
+                const wordWithRomanization = forms.find(
+                  (w) => w.romanizedSource?.length
                 )
                 const englishGloss = forms.find((w) => w.englishGloss?.length)
                 const docIds = uniq(forms.map((w) => w.documentId))
@@ -86,7 +86,7 @@ const Timeline = (p: { gloss: string }) => {
                     <div>{docIds.join(", ")}</div>
                     <div>{key}</div>
                     <div />
-                    <div>{simplePhonetics?.simplePhonetics}</div>
+                    <div>{wordWithRomanization?.romanizedSource}</div>
                     <div>{englishGloss?.englishGloss.join(", ")}</div>
                   </div>
                 )

--- a/website/src/preferences-context.tsx
+++ b/website/src/preferences-context.tsx
@@ -1,29 +1,34 @@
+import Cookies from "js-cookie"
 import React, { useContext, useState } from "react"
 import * as Dailp from "src/graphql/dailp"
-import { selectedLinguisticSystem, selectedViewMode } from "./mode"
 import { ViewMode } from "./types"
 
 // Set up context for preferences
 const PreferencesContext = React.createContext({
   viewMode: ViewMode.Pronunciation,
   setViewMode: (p: ViewMode) => {},
-  linguisticSystem: Dailp.CherokeeOrthography.Learner,
-  setLinguisticSystem: (p: Dailp.CherokeeOrthography) => {},
+  cherokeeRepresentation: Dailp.CherokeeOrthography.Learner,
+  setCherokeeRepresentation: (p: Dailp.CherokeeOrthography) => {},
 })
+
+export const usePreferences = () => useContext(PreferencesContext)
 
 export const PreferencesProvider = (props: any) => {
   // Some preferences hooks setup
-  const [viewMode, setViewMode] = useState(selectedViewMode())
-  const [linguisticSystem, setLinguisticSystem] = useState(
-    selectedLinguisticSystem()
+  const [viewMode, setViewMode] = useState(savedViewMode())
+  const [cherokeeRepresentation, setCherokeeRepresentation] = useState(
+    savedCherokeeRepresentation()
   )
   return (
     <PreferencesContext.Provider
       value={{
         viewMode,
-        setViewMode,
-        linguisticSystem,
-        setLinguisticSystem,
+        setViewMode: persistLocally(VIEW_MODE_KEY, setViewMode),
+        cherokeeRepresentation,
+        setCherokeeRepresentation: persistLocally(
+          CHEROKEE_REPRESENTATION_KEY,
+          setCherokeeRepresentation
+        ),
       }}
     >
       {props.children}
@@ -31,4 +36,27 @@ export const PreferencesProvider = (props: any) => {
   )
 }
 
-export const usePreferences = () => useContext(PreferencesContext)
+function persistLocally<T extends { toString: () => string }>(
+  key: string,
+  setValue: (value: T) => void
+) {
+  return function (value: T) {
+    Cookies.set(key, value.toString(), {
+      sameSite: "strict",
+      secure: true,
+    })
+    return setValue(value)
+  }
+}
+
+// Avoid changing these keys at all costs, because that will essentially reset
+// saved user preferences.
+const VIEW_MODE_KEY = "experienceLevel"
+const CHEROKEE_REPRESENTATION_KEY = "cherokeeSystem"
+
+const savedViewMode = () =>
+  Number.parseInt(Cookies.get(VIEW_MODE_KEY) ?? "1") as ViewMode
+
+const savedCherokeeRepresentation = (): Dailp.CherokeeOrthography =>
+  (Cookies.get(CHEROKEE_REPRESENTATION_KEY) as Dailp.CherokeeOrthography) ??
+  Dailp.CherokeeOrthography.Learner

--- a/website/src/preferences-context.tsx
+++ b/website/src/preferences-context.tsx
@@ -1,29 +1,31 @@
 import React, { useContext, useState } from "react"
-import { selectedMode, selectedPhonetics } from "./mode"
-import { PhoneticRepresentation, ViewMode } from "./types"
+import * as Dailp from "src/graphql/dailp"
+import { selectedLinguisticSystem, selectedViewMode } from "./mode"
+import { ViewMode } from "./types"
 
 // Set up context for preferences
 const PreferencesContext = React.createContext({
-  viewMode: ViewMode.Story,
+  viewMode: ViewMode.Pronunciation,
   setViewMode: (p: ViewMode) => {},
-  phoneticRepresentation: PhoneticRepresentation.Dailp,
-  setPhoneticRepresentation: (p: PhoneticRepresentation) => {},
+  linguisticSystem: Dailp.CherokeeOrthography.Learner,
+  setLinguisticSystem: (p: Dailp.CherokeeOrthography) => {},
 })
 
 export const PreferencesProvider = (props: any) => {
   // Some preferences hooks setup
-  const [viewMode, setViewMode] = useState(selectedMode())
-  const [phoneticRepresentation, setPhoneticRepresentation] = useState(
-    selectedPhonetics()
+  const [viewMode, setViewMode] = useState(selectedViewMode())
+  const [linguisticSystem, setLinguisticSystem] = useState(
+    selectedLinguisticSystem()
   )
-  const prefPack = {
-    viewMode: viewMode,
-    setViewMode: setViewMode,
-    phoneticRepresentation: phoneticRepresentation,
-    setPhoneticRepresentation: setPhoneticRepresentation,
-  }
   return (
-    <PreferencesContext.Provider value={prefPack}>
+    <PreferencesContext.Provider
+      value={{
+        viewMode,
+        setViewMode,
+        linguisticSystem,
+        setLinguisticSystem,
+      }}
+    >
       {props.children}
     </PreferencesContext.Provider>
   )

--- a/website/src/segment.css.ts
+++ b/website/src/segment.css.ts
@@ -10,7 +10,7 @@ import {
   thickness,
   vspace,
 } from "src/sprinkles.css"
-import { marginY, paddingY } from "./style-utils"
+import { marginY, paddingX, paddingY } from "./style-utils"
 
 export const pageBreak = style({
   display: "block",
@@ -45,14 +45,37 @@ export const morphemeButton = styleVariants({
   functional: [morphemeBase, std.smallCaps],
 })
 
-export const wordGroup = style([
-  marginY(vspace.half),
+const wordShared = style([
   paddingY(vspace.half),
+  paddingX(hspace.halfEdge),
+  {
+    borderWidth: thickness.thick,
+    borderColor: "transparent",
+    borderStyle: "solid",
+    "@media": {
+      [mediaQueries.print]: {
+        display: "inline-block",
+        border: "none",
+        ...margin(0, "3.5rem", vspace[1.5], 0),
+      },
+      [mediaQueries.medium]: margin(vspace.half, "2.5rem", vspace.one, 0),
+    },
+  },
+])
+
+export const wordGroupInline = style([
+  wordShared,
+  margin(vspace.half, "1.5rem", vspace.half, 0),
+  {
+    display: "inline-block",
+  },
+])
+
+export const wordGroup = style([
+  wordShared,
+  marginY(vspace.half),
   {
     display: "block",
-    padding: hspace.halfEdge,
-    borderWidth: thickness.thick,
-    borderStyle: "solid",
     borderColor: colors.borders,
     borderRadius: radii.medium,
     lineHeight: vspace.one,
@@ -62,35 +85,20 @@ export const wordGroup = style([
     "@media": {
       [mediaQueries.medium]: {
         display: "inline-block",
-        ...margin(vspace.half, "3rem", vspace.one, 0),
+        borderColor: "transparent",
       },
     },
   },
 ])
 
-export const wordGroupSelection = styleVariants({
-  unselected: [
-    wordGroup,
-    {
-      "@media": {
-        [mediaQueries.medium]: {
-          borderColor: "transparent",
-        },
-        [mediaQueries.print]: {
-          display: "inline-block",
-          border: "none",
-          ...margin(0, "3.5rem", vspace[1.5], 0),
-        },
-      },
-    },
-  ],
-  selected: [
-    wordGroup,
-    {
+export const selectedWord = style({
+  borderColor: "black",
+  backgroundColor: colors.header,
+  "@media": {
+    [mediaQueries.medium]: {
       borderColor: "black",
-      backgroundColor: colors.header,
     },
-  ],
+  },
 })
 
 export const syllabaryLayer = style({
@@ -131,8 +139,8 @@ const documentBlockBase = style({
   },
 })
 
-const borderedBase: StyleRule = {
-  borderBottom: `1px solid ${theme.colors.text}`,
+const bordered = style({
+  borderBottom: `${thickness.thin} solid ${colors.text}`,
   selectors: {
     "&:last-of-type": {
       borderBottom: "none",
@@ -140,13 +148,8 @@ const borderedBase: StyleRule = {
       paddingBottom: 0,
     },
   },
-}
-
-export const bordered = style({
   "@media": {
-    [mediaQueries.medium]: borderedBase,
     [mediaQueries.print]: {
-      ...borderedBase,
       borderBottom: "1px solid black",
     },
   },
@@ -164,28 +167,27 @@ export const inlineBlock = style({
   },
 })
 
-export const storySection = style({
+const annotationSectionBase = style({
   display: "flex",
   flexFlow: "row wrap",
+  width: "100%",
+  position: "relative",
+  marginBottom: vspace.half,
 })
 
-const annotationSectionBase = style([
-  {
-    width: "100%",
-    position: "relative",
-    marginBottom: vspace.half,
-    "@media": {
-      [mediaQueries.medium]: {
-        display: "flex",
-        flexFlow: "row wrap",
+export const annotationSection = styleVariants({
+  story: [annotationSectionBase],
+  wordParts: [
+    annotationSectionBase,
+    {
+      flexFlow: "column nowrap",
+      "@media": {
+        [mediaQueries.medium]: {
+          flexFlow: "row wrap",
+        },
       },
     },
-  },
-])
-
-export const annotationSection = styleVariants({
-  story: [annotationSectionBase, storySection],
-  wordByWord: [annotationSectionBase],
+  ],
 })
 
 export const audioContainer = style({ paddingLeft: "40%" })

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -20,7 +20,7 @@ interface Props {
   segment: Segment
   onOpenDetails: (morpheme: BasicMorphemeSegment) => void
   viewMode: ViewMode
-  linguisticSystem: Dailp.CherokeeOrthography
+  cherokeeRepresentation: Dailp.CherokeeOrthography
   pageImages: readonly string[]
   wordPanelDetails: WordPanelDetails
 }
@@ -55,7 +55,7 @@ export const DocumentParagraph = (
           segment={seg as Segment}
           onOpenDetails={p.onOpenDetails}
           viewMode={p.viewMode}
-          linguisticSystem={p.linguisticSystem}
+          cherokeeRepresentation={p.cherokeeRepresentation}
           pageImages={p.pageImages}
           wordPanelDetails={p.wordPanelDetails}
         />
@@ -144,7 +144,7 @@ export const AnnotatedForm = (
             segments={p.segment.segments}
             onOpenDetails={p.onOpenDetails}
             viewMode={p.viewMode}
-            linguisticSystem={p.linguisticSystem}
+            cherokeeRepresentation={p.cherokeeRepresentation}
           />
         ) : null}
         {translation.length ? (
@@ -195,7 +195,7 @@ const FillerLine = () => (
  */
 export const MorphemicSegmentation = (p: {
   segments: Dailp.FormFieldsFragment["segments"]
-  linguisticSystem: Dailp.CherokeeOrthography
+  cherokeeRepresentation: Dailp.CherokeeOrthography
   onOpenDetails: Props["onOpenDetails"]
   viewMode: ViewMode
 }) => {
@@ -233,7 +233,7 @@ export const MorphemicSegmentation = (p: {
               {i > 0 && segment.previousSeparator}
               <MorphemeSegment
                 segment={segment}
-                linguisticSystem={p.linguisticSystem}
+                cherokeeRepresentation={p.cherokeeRepresentation}
                 onOpenDetails={p.onOpenDetails}
               />
             </React.Fragment>
@@ -247,7 +247,7 @@ export const MorphemicSegmentation = (p: {
 /** One morpheme that can be clicked to see further details. */
 const MorphemeSegment = (p: {
   segment: BasicMorphemeSegment
-  linguisticSystem: Dailp.CherokeeOrthography
+  cherokeeRepresentation: Dailp.CherokeeOrthography
   onOpenDetails: Props["onOpenDetails"]
 }) => {
   const matchingTag = p.segment.matchingTag

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -6,7 +6,6 @@ import { MdCircle, MdInfoOutline } from "react-icons/md"
 import * as Dailp from "src/graphql/dailp"
 import { DocumentContents } from "src/pages/documents/document.page"
 import { CleanButton } from "./components"
-import { romanizationFromSystem } from "./mode"
 import * as css from "./segment.css"
 import { std } from "./sprinkles.css"
 import { BasicMorphemeSegment, ViewMode } from "./types"
@@ -100,8 +99,6 @@ export const AnnotatedForm = (
     ) /* This makes sure the word panel updates for changes to the word panel*/
   }
 
-  const romanization = romanizationFromSystem(p.linguisticSystem, p.segment)
-
   if (showAnything) {
     const showSegments = p.viewMode >= ViewMode.Segmentation
     const translation = p.segment.englishGloss.join(", ")
@@ -121,9 +118,9 @@ export const AnnotatedForm = (
             )}
           </CleanButton>
         </div>
-        {romanization ? (
+        {p.segment.romanizedSource ? (
           <>
-            <div>{romanization}</div>
+            <div>{p.segment.romanizedSource}</div>
             <div>
               {p.segment.phonemic && p.viewMode >= ViewMode.Pronunciation && (
                 <div />

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -1,5 +1,6 @@
 import { Tooltip } from "@reach/tooltip"
 import "@reach/tooltip/styles.css"
+import cx from "classnames"
 import { Howl } from "howler"
 import React from "react"
 import { MdCircle, MdInfoOutline } from "react-icons/md"
@@ -61,10 +62,17 @@ export const DocumentParagraph = (
       )
     }) ?? null
 
-  const variant = p.viewMode > ViewMode.Story ? "wordByWord" : "story"
+  const blockStyle =
+    p.viewMode > ViewMode.Story
+      ? css.documentBlock.wordByWord
+      : css.documentBlock.story
+  const annotationStyle =
+    p.viewMode > ViewMode.Pronunciation
+      ? css.annotationSection.wordParts
+      : css.annotationSection.story
   return (
-    <section className={css.documentBlock[variant]}>
-      <div className={css.annotationSection[variant]}>{children}</div>
+    <section className={blockStyle}>
+      <div className={annotationStyle}>{children}</div>
       <p className={css.inlineBlock}>{p.segment.translation ?? null}</p>
       {/*<SegmentAudio/>*/}
     </section>
@@ -88,20 +96,21 @@ export const AnnotatedForm = (
     return null
   }
   const showAnything = p.viewMode > ViewMode.Story
-  const isSelected =
-    p.wordPanelDetails.currContents?.source === p.segment.source &&
-    p.wordPanelDetails.currContents?.index === p.segment.index
-  let wordCSS = css.wordGroupSelection.unselected
-  if (isSelected) {
-    wordCSS = css.wordGroupSelection.selected
-    p.wordPanelDetails.setCurrContents(
-      p.segment
-    ) /* This makes sure the word panel updates for changes to the word panel*/
-  }
-
   if (showAnything) {
     const showSegments = p.viewMode >= ViewMode.Segmentation
     const translation = p.segment.englishGloss.join(", ")
+
+    const isSelected =
+      p.wordPanelDetails.currContents?.source === p.segment.source &&
+      p.wordPanelDetails.currContents?.index === p.segment.index
+
+    let wordCSS = showSegments ? css.wordGroup : css.wordGroupInline
+    if (isSelected) {
+      wordCSS = cx(wordCSS, css.selectedWord)
+      p.wordPanelDetails.setCurrContents(
+        p.segment
+      ) /* This makes sure the word panel updates for changes to the word panel*/
+    }
 
     return (
       <div className={wordCSS} id={`w${p.segment.index}`}>

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -259,10 +259,11 @@ export const MorphemicSegmentation = (p: {
   // Adapt the segment shape to the chosen experience level.
   let segmentation = ""
   for (const seg of p.segments) {
-    segmentation += seg.morpheme
-    if (seg.nextSeparator) {
-      segmentation += seg.nextSeparator
+    // TODO Use more robust check than looking for ":"
+    if (seg.previousSeparator && segmentation.length > 0 && seg.previousSeparator !== ":") {
+      segmentation += seg.previousSeparator
     }
+    segmentation += seg.morpheme
   }
 
   return (
@@ -272,12 +273,12 @@ export const MorphemicSegmentation = (p: {
         {p.segments.map(function (segment, i) {
           return (
             <React.Fragment key={i}>
+              {i > 0 && segment.previousSeparator}
               <MorphemeSegment
                 segment={segment}
                 tagSet={p.tagSet}
                 onOpenDetails={p.onOpenDetails}
               />
-              {segment.nextSeparator}
             </React.Fragment>
           )
         })}

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -204,11 +204,10 @@ export const MorphemicSegmentation = (p: {
   // Adapt the segment shape to the chosen experience level.
   let segmentation = ""
   for (const seg of p.segments) {
-    // TODO Use more robust check than looking for ":"
     if (
-      seg.previousSeparator &&
       segmentation.length > 0 &&
-      seg.previousSeparator !== ":"
+      seg.segmentType &&
+      seg.segmentType !== Dailp.SegmentType.Combine
     ) {
       segmentation += seg.previousSeparator
     }

--- a/website/src/segment.tsx
+++ b/website/src/segment.tsx
@@ -7,6 +7,7 @@ import * as Dailp from "src/graphql/dailp"
 import { DocumentContents } from "src/pages/documents/document.page"
 import { FormAudio } from "./audio-player"
 import { CleanButton, IconButton } from "./components"
+import { romanizationFromSystem } from "./mode"
 import * as css from "./segment.css"
 import { std } from "./sprinkles.css"
 import {
@@ -109,18 +110,11 @@ export const AnnotatedForm = (
       p.segment
     ) /* This makes sure the word panel updates for changes to the word panel*/
   }
-  let romanization = null
-  if (
-    p.phoneticRepresentation == PhoneticRepresentation.Dailp &&
-    p.segment.simplePhonetics
-  ) {
-    romanization = p.segment.simplePhonetics
-  } else if (
-    p.phoneticRepresentation == PhoneticRepresentation.Worcester &&
-    p.segment.romanizedSource
-  ) {
-    romanization = p.segment.romanizedSource
-  }
+
+  const romanization = romanizationFromSystem(
+    p.phoneticRepresentation,
+    p.segment
+  )
 
   if (showAnything) {
     const showSegments = p.viewMode >= ViewMode.Segmentation
@@ -239,7 +233,11 @@ export const MorphemicSegmentation = (p: {
   let segmentation = ""
   for (const seg of p.segments) {
     // TODO Use more robust check than looking for ":"
-    if (seg.previousSeparator && segmentation.length > 0 && seg.previousSeparator !== ":") {
+    if (
+      seg.previousSeparator &&
+      segmentation.length > 0 &&
+      seg.previousSeparator !== ":"
+    ) {
       segmentation += seg.previousSeparator
     }
     segmentation += seg.morpheme

--- a/website/src/sprinkles.css.ts
+++ b/website/src/sprinkles.css.ts
@@ -72,6 +72,7 @@ export const radii = {
   none: 0,
   small: "1px",
   medium: "2px",
+  large: "4px",
 }
 
 export const thickness = {
@@ -343,14 +344,13 @@ export const iconButton = style([
   },
 ])
 
-export const cleanButton = style(  {
-    padding: space.small,
-    background: "none",
-    border: "none",
-    outline: "none",
-    cursor: "pointer",
-    margin: 0,
-  },
-)
+export const cleanButton = style({
+  padding: space.small,
+  background: "none",
+  border: "none",
+  outline: "none",
+  cursor: "pointer",
+  margin: 0,
+})
 
 export const paddedCenterColumn = style([edgePadded, centeredColumn])

--- a/website/src/sprinkles.css.ts
+++ b/website/src/sprinkles.css.ts
@@ -99,6 +99,7 @@ export const hspace = {
 
 export const vspace = {
   ...space,
+  eighth: rhythm(1 / 8),
   quarter: rhythm(1 / 4),
   half: rhythm(1 / 2),
   one: rhythm(1),

--- a/website/src/types.ts
+++ b/website/src/types.ts
@@ -4,67 +4,10 @@ export enum ViewMode {
   Story = 0,
   Pronunciation = 1,
   Segmentation = 2,
-  AnalysisDt = 3,
-  AnalysisTth = 4,
 }
 
-export enum TagSet {
-  Dailp,
-  Taoc,
-  Learner,
-  Crg,
-}
-
-export enum PhoneticRepresentation {
-  Dailp,
-  Worcester,
-  //Ipa,
-}
 export type BasicMorphemeSegment = NonNullable<
   Dailp.FormFieldsFragment["segments"]
 >[0]
 
 export type BasicMorphemeTag = BasicMorphemeSegment["matchingTag"]
-
-export function morphemeDisplayTag<T>(
-  tag: { readonly taoc: T; readonly crg: T; readonly learner: T } | null,
-  tagSet: TagSet
-): T | null {
-  let matchingTag = tag?.taoc
-  if (tag) {
-    if (tagSet === TagSet.Learner) {
-      matchingTag = tag.learner || tag.crg
-    } else if (tagSet === TagSet.Taoc) {
-      matchingTag = tag.taoc
-    } else if (tagSet === TagSet.Crg) {
-      matchingTag = tag.crg
-    }
-  }
-  return matchingTag ?? null
-}
-
-export function orthographyForTagSet(
-  tagSet: TagSet
-): Dailp.CherokeeOrthography {
-  let system = Dailp.CherokeeOrthography.Taoc
-  if (tagSet === TagSet.Crg) {
-    system = Dailp.CherokeeOrthography.Crg
-  } else if (tagSet === TagSet.Taoc) {
-    system = Dailp.CherokeeOrthography.Taoc
-  } else if (tagSet === TagSet.Learner) {
-    system = Dailp.CherokeeOrthography.Learner
-  }
-  return system
-}
-
-export const tagSetForMode = (experienceLevel: ViewMode) => {
-  let tagSet = TagSet.Dailp
-  if (experienceLevel === ViewMode.AnalysisTth) {
-    tagSet = TagSet.Taoc
-  } else if (experienceLevel === ViewMode.AnalysisDt) {
-    tagSet = TagSet.Crg
-  } else if (experienceLevel <= ViewMode.Segmentation) {
-    tagSet = TagSet.Learner
-  }
-  return tagSet
-}

--- a/website/src/word-panel.css.ts
+++ b/website/src/word-panel.css.ts
@@ -15,10 +15,11 @@ const wordPanelPadding = "8px"
 
 export const cherHeader = style({
   fontFamily: theme.fonts.cherokee,
+  marginBottom: vspace.eighth,
 })
 
 export const noSpaceBelow = style({
-  marginBottom: vspace.half,
+  marginBottom: vspace.quarter,
 })
 
 export const wordPanelButton = styleVariants({

--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -9,6 +9,7 @@ import sprinkles, {
   thickness,
   vspace,
 } from "./sprinkles.css"
+import { paddingX, paddingY } from "./style-utils"
 
 const wordPanelPadding = "8px"
 
@@ -94,17 +95,28 @@ export const tableContainer = style({
   marginBottom: vspace.quarter,
 })
 
-export const tableCells = style({
-  border: "none",
-  fontFamily: theme.fonts.body,
-  padding: hspace.small,
-  paddingRight: hspace.medium,
-  wordWrap: "break-word",
-})
+const tableCells = style([
+  paddingY(vspace.eighth),
+  paddingX(0),
+  {
+    border: "none",
+    fontFamily: theme.fonts.body,
+    wordWrap: "break-word",
+  },
+])
+
+export const glossCell = style([
+  tableCells,
+  {
+    width: "100%",
+    paddingLeft: hspace.halfEdge,
+  },
+])
 
 export const morphemeCell = style([
   tableCells,
   {
     fontStyle: "italic",
+    paddingRight: hspace.halfEdge,
   },
 ])

--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -66,14 +66,15 @@ export const collPanel = style({
 export const wordPanelContent = style({
   fontFamily: theme.fonts.body,
   position: "sticky",
-  top: 50,
+  top: 58,
   border: "none",
-  borderRadius: "4px",
+  borderRadius: radii.large,
+  marginTop: 8,
   "@media": {
     [mediaQueries.medium]: {
       width: 350,
       border: "1px solid #ddd",
-      height: "calc(100vh - 50px)",
+      height: "calc(100vh - 66px)",
     },
   },
   overflowX: "hidden",
@@ -90,6 +91,7 @@ export const audioContainer = style({ paddingLeft: "40%" })
 export const tableContainer = style({
   border: "none",
   margin: 0,
+  marginBottom: vspace.quarter,
 })
 
 export const tableCells = style({

--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -66,15 +66,17 @@ export const collPanel = style({
 export const wordPanelContent = style({
   fontFamily: theme.fonts.body,
   position: "sticky",
-  top: 101,
+  top: 50,
   border: "none",
   borderRadius: "4px",
   "@media": {
     [mediaQueries.medium]: {
+      width: 350,
       border: "1px solid #ddd",
-      height: "calc(100vh - 125px)",
+      height: "calc(100vh - 50px)",
     },
   },
+  overflowX: "hidden",
   overflowY: "auto",
 })
 
@@ -86,15 +88,21 @@ export const wordPanelHeader = style({
 export const audioContainer = style({ paddingLeft: "40%" })
 
 export const tableContainer = style({
-  border: "0px solid transparent",
-  width: "max-content",
-  margin: "0px",
+  border: "none",
+  margin: 0,
 })
 
 export const tableCells = style({
-  border: "4px solid transparent",
+  border: "none",
   fontFamily: theme.fonts.body,
-  padding: "0px",
-  paddingRight: "3px",
+  padding: hspace.small,
+  paddingRight: hspace.medium,
   wordWrap: "break-word",
 })
+
+export const morphemeCell = style([
+  tableCells,
+  {
+    fontStyle: "italic",
+  },
+])

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -10,7 +10,6 @@ import {
 } from "reakit/Disclosure"
 import * as Dailp from "src/graphql/dailp"
 import { FormAudio } from "./audio-player"
-import { romanizationFromSystem } from "./mode"
 import { usePreferences } from "./preferences-context"
 import { BasicMorphemeSegment } from "./types"
 import * as css from "./word-panel.css"
@@ -31,7 +30,6 @@ export const WordPanel = (p: {
   }
 
   const translation = p.segment.englishGloss.join(", ")
-  const romanization = romanizationFromSystem(linguisticSystem, p.segment)
 
   return (
     <div className={css.wordPanelContent}>
@@ -47,10 +45,10 @@ export const WordPanel = (p: {
         <h2 className={css.cherHeader}>{p.segment.source}</h2>
       </header>
       <AudioPanel segment={p.segment} />
-      {romanization ? (
+      {p.segment.romanizedSource ? (
         <CollapsiblePanel
           title={"Phonetics"}
-          content={<div>{romanization}</div>}
+          content={<div>{p.segment.romanizedSource}</div>}
           icon={
             <MdRecordVoiceOver
               size={24}

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -47,7 +47,7 @@ export const WordPanel = (p: {
       <AudioPanel segment={p.segment} />
       {p.segment.romanizedSource ? (
         <CollapsiblePanel
-          title={"Phonetics"}
+          title={"Simple Phonetics"}
           content={<div>{p.segment.romanizedSource}</div>}
           icon={
             <MdRecordVoiceOver

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -124,7 +124,7 @@ export const VerticalMorphemicSegmentation = (p: {
       <table className={css.tableContainer}>
         {p.segments.map((segment, index) => (
           <tr>
-            <td className={css.tableCells}>
+            <td className={css.morphemeCell}>
               {index > 0 ? segment.previousSeparator : null}
               {segment.morpheme}
               {index < segmentCount - 1 ? p.segments[index + 1]!.previousSeparator : null}

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react"
+import React, { ReactNode } from "react"
 import { AiFillCaretDown, AiFillCaretUp, AiFillSound } from "react-icons/ai"
 import { IoEllipsisHorizontalCircle } from "react-icons/io5"
 import { MdClose, MdNotes, MdRecordVoiceOver } from "react-icons/md"
@@ -10,13 +10,9 @@ import {
 } from "reakit/Disclosure"
 import * as Dailp from "src/graphql/dailp"
 import { FormAudio } from "./audio-player"
-import { MorphemicSegmentation } from "./segment"
-import {
-  BasicMorphemeSegment,
-  TagSet,
-  ViewMode,
-  morphemeDisplayTag,
-} from "./types"
+import { romanizationFromSystem } from "./mode"
+import { usePreferences } from "./preferences-context"
+import { BasicMorphemeSegment, TagSet } from "./types"
 import * as css from "./word-panel.css"
 
 export interface WordPanelDetails {
@@ -27,27 +23,16 @@ export interface WordPanelDetails {
 export const WordPanel = (p: {
   segment: Dailp.FormFieldsFragment | null
   setContent: (content: Dailp.FormFieldsFragment | null) => void
-  viewMode: ViewMode
   onOpenDetails: (morpheme: BasicMorphemeSegment) => void
   tagSet: TagSet
 }) => {
+  const { phoneticRepresentation } = usePreferences()
   if (!p.segment) {
     return <p>No word has been selected</p>
   }
 
   const translation = p.segment.englishGloss.join(", ")
-  let phonetics = null
-
-  if (p.segment.simplePhonetics) {
-    phonetics = (
-      <>
-        {p.segment.simplePhonetics !== p.segment.romanizedSource ? (
-          <div>{p.segment.romanizedSource}</div>
-        ) : null}
-        <div>{p.segment.simplePhonetics}</div>
-      </>
-    )
-  }
+  const romanization = romanizationFromSystem(phoneticRepresentation, p.segment)
 
   return (
     <div className={css.wordPanelContent}>
@@ -63,10 +48,10 @@ export const WordPanel = (p: {
         <h2 className={css.cherHeader}>{p.segment.source}</h2>
       </header>
       <AudioPanel segment={p.segment} />
-      {phonetics ? (
+      {romanization ? (
         <CollapsiblePanel
           title={"Phonetics"}
-          content={phonetics}
+          content={<div>{romanization}</div>}
           icon={
             <MdRecordVoiceOver
               size={24}

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -24,7 +24,7 @@ export const WordPanel = (p: {
   setContent: (content: Dailp.FormFieldsFragment | null) => void
   onOpenDetails: (morpheme: BasicMorphemeSegment) => void
 }) => {
-  const { linguisticSystem } = usePreferences()
+  const { cherokeeRepresentation } = usePreferences()
   if (!p.segment) {
     return <p>No word has been selected</p>
   }
@@ -65,7 +65,7 @@ export const WordPanel = (p: {
             <>
               <VerticalMorphemicSegmentation
                 segments={p.segment.segments}
-                linguisticSystem={linguisticSystem}
+                cherokeeRepresentation={cherokeeRepresentation}
               />
 
               {translation.length ? (
@@ -96,7 +96,7 @@ type Writeable<T> = { -readonly [P in keyof T]: T[P] }
 
 export const VerticalMorphemicSegmentation = (p: {
   segments: Dailp.FormFieldsFragment["segments"]
-  linguisticSystem: Dailp.CherokeeOrthography
+  cherokeeRepresentation: Dailp.CherokeeOrthography
 }) => {
   if (!p.segments) {
     return null

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -105,7 +105,7 @@ export const VerticalMorphemicSegmentation = (p: {
     // Combine certain morphemes.
     const combinedSegments: typeof p.segments = p.segments.reduce(
       (result, segment) => {
-        if (segment.previousSeparator === ":") {
+        if (segment.segmentType === Dailp.SegmentType.Combine) {
           const lastSegment = result[result.length - 1]!
           result[result.length - 1] = {
             ...lastSegment,

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -145,7 +145,7 @@ export const VerticalMorphemicSegmentation = (p: {
                   ? p.segments[index + 1]!.previousSeparator
                   : null}
               </td>
-              <td className={css.tableCells}>
+              <td className={css.glossCell}>
                 {segment.matchingTag
                   ? segment.matchingTag.title
                   : segment.gloss.replaceAll(".", " ")}

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -12,7 +12,7 @@ import * as Dailp from "src/graphql/dailp"
 import { FormAudio } from "./audio-player"
 import { romanizationFromSystem } from "./mode"
 import { usePreferences } from "./preferences-context"
-import { BasicMorphemeSegment, TagSet } from "./types"
+import { BasicMorphemeSegment } from "./types"
 import * as css from "./word-panel.css"
 
 export interface WordPanelDetails {
@@ -24,15 +24,14 @@ export const WordPanel = (p: {
   segment: Dailp.FormFieldsFragment | null
   setContent: (content: Dailp.FormFieldsFragment | null) => void
   onOpenDetails: (morpheme: BasicMorphemeSegment) => void
-  tagSet: TagSet
 }) => {
-  const { phoneticRepresentation } = usePreferences()
+  const { linguisticSystem } = usePreferences()
   if (!p.segment) {
     return <p>No word has been selected</p>
   }
 
   const translation = p.segment.englishGloss.join(", ")
-  const romanization = romanizationFromSystem(phoneticRepresentation, p.segment)
+  const romanization = romanizationFromSystem(linguisticSystem, p.segment)
 
   return (
     <div className={css.wordPanelContent}>
@@ -68,7 +67,7 @@ export const WordPanel = (p: {
             <>
               <VerticalMorphemicSegmentation
                 segments={p.segment.segments}
-                tagSet={p.tagSet}
+                linguisticSystem={linguisticSystem}
               />
 
               {translation.length ? (
@@ -99,7 +98,7 @@ type Writeable<T> = { -readonly [P in keyof T]: T[P] }
 
 export const VerticalMorphemicSegmentation = (p: {
   segments: Dailp.FormFieldsFragment["segments"]
-  tagSet: TagSet
+  linguisticSystem: Dailp.CherokeeOrthography
 }) => {
   if (!p.segments) {
     return null

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -140,16 +140,16 @@ export const VerticalMorphemicSegmentation = (p: {
     return null
   }
   if (p.segments) {
-    let segmentCount = p.segments.length
+    const segmentCount = p.segments.length
 
     return (
       <table className={css.tableContainer}>
         {p.segments.map((segment, index) => (
           <tr>
             <td className={css.tableCells}>
-              {index > 0 ? "-" : null}
+              {index > 0 ? segment.previousSeparator : null}
               {segment.morpheme}
-              {index !== segmentCount - 1 ? segment.nextSeparator : null}
+              {index < segmentCount - 1 ? p.segments[index + 1]!.previousSeparator : null}
             </td>
             <td className={css.tableCells}>
               {segment.matchingTag ? segment.matchingTag.title : segment.gloss}


### PR DESCRIPTION
- Adds support for mapping a sequence of internal morpheme tags into one output tag.
- Adds support for marking output tags as type `Combine` which means they will merge with the previous morpheme on the front-end, displaying /a-b/ X-Y as /ab/ X:Y