### PR TITLE
[DP - 146] initial database structure for the edited collections

### DIFF
--- a/types/migrations/20220205042039_init.sql
+++ b/types/migrations/20220205042039_init.sql
@@ -3,8 +3,6 @@
 
 create extension if not exists "uuid-ossp";
 
-create extension if not exists "ltree";
-
 create domain autouuid uuid default uuid_generate_v4 ();
 
 -- Base website: Language > Group > Document
@@ -37,16 +35,6 @@ create table document (
   is_reference boolean not null,
   written_at date,
   audio_slice_id uuid references media_slice (id) on delete set null
-);
-
-create table chapter (
-  id autouuid primary key,
-  chapter_title text not null,
-  document_title text,
-  author text,
-  document_id text,
-  wordpress_id bigint,
-  collection_path ltree not null,
 );
 
 create table iiif_source (

--- a/types/migrations/20220205042039_init.sql
+++ b/types/migrations/20220205042039_init.sql
@@ -42,12 +42,12 @@ create table document (
 create table chapter (
   id autouuid primary key,
   chapter_title text not null,
-  document_title text not null,
-  author text not null,
-  document_id bigint,
+  document_title text,
+  author text,
+  document_id text,
   wordpress_id bigint,
   collection_path ltree not null,
-)
+);
 
 create table iiif_source (
   id autouuid primary key,

--- a/types/migrations/20220205042039_init.sql
+++ b/types/migrations/20220205042039_init.sql
@@ -3,6 +3,8 @@
 
 create extension if not exists "uuid-ossp";
 
+create extension if not exists "ltree";
+
 create domain autouuid uuid default uuid_generate_v4 ();
 
 -- Base website: Language > Group > Document
@@ -36,6 +38,16 @@ create table document (
   written_at date,
   audio_slice_id uuid references media_slice (id) on delete set null
 );
+
+create table chapter (
+  id autouuid primary key,
+  chapter_title text not null,
+  document_title text not null,
+  author text not null,
+  document_id bigint,
+  wordpress_id bigint,
+  collection_path ltree not null,
+)
 
 create table iiif_source (
   id autouuid primary key,

--- a/types/migrations/20220518174701_edited_collections.sql
+++ b/types/migrations/20220518174701_edited_collections.sql
@@ -16,7 +16,7 @@ create table chapter (
   title text not null,
   document_id uuid references document(id),
   wordpress_id bigint,
-  index_tree ltree not null,
+  index_tree ltree not null unique,
   slug text not null
 );
 

--- a/types/migrations/20220518174701_edited_collections.sql
+++ b/types/migrations/20220518174701_edited_collections.sql
@@ -7,8 +7,8 @@ create extension if not exists "ltree";
 create table edited_collection (
   id autouuid primary key,
   title text not null,
-  wordpress_menu_id bigint;
-  slug ltree not null unique -- keep it the same type as chapter ltree
+  wordpress_menu_id bigint,
+  slug text not null unique -- keep it the same type as chapter ltree
 );
 
 create table collection_chapter (
@@ -16,8 +16,8 @@ create table collection_chapter (
   title text not null,
   document_id uuid references document(id),
   wordpress_id bigint,
-  index_tree ltree not null unique,
-  slug text not null
+  index_in_parent bigint not null ,
+  slug_tree ltree not null
 );
 
 create table collection_chapter_attribution (

--- a/types/migrations/20220518174701_edited_collections.sql
+++ b/types/migrations/20220518174701_edited_collections.sql
@@ -26,8 +26,3 @@ create table chapter_attribution (
   contribution_role text not null,
   primary key (chapter_id, contributor_id)
 );
-
-create table index_trees (
-  title text not null,
-  index_tree ltree not null
-)

--- a/types/migrations/20220518174701_edited_collections.sql
+++ b/types/migrations/20220518174701_edited_collections.sql
@@ -4,12 +4,20 @@
 
 create extension if not exists "ltree";
 
+create table collections (
+  id autouuid primary key,
+  collection_name text not null,
+  collection_desc text,
+  slug ltree not null unique -- keep it the same type as chapter ltree
+);
+
 create table chapter (
   id autouuid primary key,
   title text not null,
   document_id uuid references document(id),
   wordpress_id bigint,
-  collection_path ltree not null,
+  index_tree ltree not null,
+  slug text not null
 );
 
 create table chapter_attribution (
@@ -18,3 +26,8 @@ create table chapter_attribution (
   contribution_role text not null,
   primary key (chapter_id, contributor_id)
 );
+
+create table index_trees (
+  title text not null,
+  index_tree ltree not null
+)

--- a/types/migrations/20220518174701_edited_collections.sql
+++ b/types/migrations/20220518174701_edited_collections.sql
@@ -17,7 +17,7 @@ create table collection_chapter (
   document_id uuid references document(id),
   wordpress_id bigint,
   index_in_parent bigint not null ,
-  slug_tree ltree not null
+  chapter_path ltree not null
 );
 
 create table collection_chapter_attribution (

--- a/types/migrations/20220518174701_edited_collections.sql
+++ b/types/migrations/20220518174701_edited_collections.sql
@@ -1,0 +1,20 @@
+-- Add migration script here
+
+-- A file for collections and chapters
+
+create extension if not exists "ltree";
+
+create table chapter (
+  id autouuid primary key,
+  title text not null,
+  document_id uuid references document(id),
+  wordpress_id bigint,
+  collection_path ltree not null,
+);
+
+create table chapter_attribution (
+  chapter_id uuid not null references chapter (id) on delete cascade,
+  contributor_id uuid not null references contributor (id) on delete cascade,
+  contribution_role text not null,
+  primary key (chapter_id, contributor_id)
+);

--- a/types/migrations/20220518174701_edited_collections.sql
+++ b/types/migrations/20220518174701_edited_collections.sql
@@ -1,17 +1,16 @@
 -- Add migration script here
 
--- A file for collections and chapters
+-- A file for collection and chapters
 
 create extension if not exists "ltree";
 
-create table collections (
+create table edited_collection (
   id autouuid primary key,
-  collection_name text not null,
-  collection_desc text,
+  title text not null,
   slug ltree not null unique -- keep it the same type as chapter ltree
 );
 
-create table chapter (
+create table collection_chapter (
   id autouuid primary key,
   title text not null,
   document_id uuid references document(id),
@@ -20,8 +19,8 @@ create table chapter (
   slug text not null
 );
 
-create table chapter_attribution (
-  chapter_id uuid not null references chapter (id) on delete cascade,
+create table collection_chapter_attribution (
+  chapter_id uuid not null references collection_chapter (id) on delete cascade,
   contributor_id uuid not null references contributor (id) on delete cascade,
   contribution_role text not null,
   primary key (chapter_id, contributor_id)

--- a/types/migrations/20220518174701_edited_collections.sql
+++ b/types/migrations/20220518174701_edited_collections.sql
@@ -7,6 +7,7 @@ create extension if not exists "ltree";
 create table edited_collection (
   id autouuid primary key,
   title text not null,
+  wordpress_menu_id bigint;
   slug ltree not null unique -- keep it the same type as chapter ltree
 );
 

--- a/types/queries/collection_contents.sql
+++ b/types/queries/collection_contents.sql
@@ -1,8 +1,5 @@
-/* Will return information on chapters in their proper order,
-      like a table of contents
-$1:collection id
-*/
-select *
-from collection_chapter 
-where subpath(index_tree, 0, 1)=(select slug from edited_collection where id=$1)
-order by string_to_array(subpath(index_tree, 1)::text, '.')::int[];
+select * from collection_chapter 
+where slug_tree <@ (
+      select slug from edited_collection where id=$1
+)::ltree 
+order by nlevel(slug_tree);

--- a/types/queries/collection_contents.sql
+++ b/types/queries/collection_contents.sql
@@ -1,5 +1,5 @@
 select * from collection_chapter 
-where slug_tree <@ (
+where chapter_path <@ (
       select slug from edited_collection where id=$1
 )::ltree 
-order by nlevel(slug_tree);
+order by nlevel(chapter_path);

--- a/types/queries/collection_contents.sql
+++ b/types/queries/collection_contents.sql
@@ -3,6 +3,6 @@
 $1:collection id
 */
 select *
-from chapter 
-where subpath(index_tree, 0, 1)=(select slug from collections where id=$1)
+from collection_chapter 
+where subpath(index_tree, 0, 1)=(select slug from edited_collection where id=$1)
 order by string_to_array(subpath(index_tree, 1)::text, '.')::int[];

--- a/types/queries/collection_contents.sql
+++ b/types/queries/collection_contents.sql
@@ -1,0 +1,8 @@
+/* Will return information on chapters in their proper order,
+      like a table of contents
+$1:collection id
+*/
+select *
+from chapter 
+where subpath(index_tree, 0, 1)=(select slug from collections where id=$1)
+order by string_to_array(subpath(index_tree, 1)::text, '.')::int[];

--- a/types/queries/fetch_subchapters.sql
+++ b/types/queries/fetch_subchapters.sql
@@ -3,8 +3,8 @@ select
     collection_chapter.title
     collection_chapter.document_id
     collection_chapter.wordpress_id
-    collection_chapter.slug
+    collection_chapter.slug_tree
 from 
     collection_chapter
 where
-    (select index_tree from collection_chapter where id=$1) @> collection_chapter.collection_path
+    (select slug_tree from collection_chapter where id=$1) @> collection_chapter.slug_tree

--- a/types/queries/fetch_subchapters.sql
+++ b/types/queries/fetch_subchapters.sql
@@ -1,0 +1,12 @@
+select 
+    chapter.id
+    chapter.chapter_title
+    chapter.document_title
+    chapter.author
+    chapter.document_id
+    chapter.wordpress_id
+    chapter.collection_path
+from 
+    chapter
+where
+    $1 @> chapter.collection_path

--- a/types/queries/fetch_subchapters.sql
+++ b/types/queries/fetch_subchapters.sql
@@ -3,8 +3,8 @@ select
     collection_chapter.title
     collection_chapter.document_id
     collection_chapter.wordpress_id
-    collection_chapter.slug_tree
+    collection_chapter.chapter_path
 from 
     collection_chapter
 where
-    (select slug_tree from collection_chapter where id=$1) @> collection_chapter.slug_tree
+    (select chapter_path from collection_chapter where id=$1) @> collection_chapter.chapter_path

--- a/types/queries/fetch_subchapters.sql
+++ b/types/queries/fetch_subchapters.sql
@@ -1,8 +1,6 @@
 select 
     chapter.id
-    chapter.chapter_title
-    chapter.document_title
-    chapter.author
+    chapter.title
     chapter.document_id
     chapter.wordpress_id
     chapter.collection_path

--- a/types/queries/fetch_subchapters.sql
+++ b/types/queries/fetch_subchapters.sql
@@ -1,10 +1,10 @@
 select 
-    chapter.id
-    chapter.title
-    chapter.document_id
-    chapter.wordpress_id
-    chapter.collection_path
+    collection_chapter.id
+    collection_chapter.title
+    collection_chapter.document_id
+    collection_chapter.wordpress_id
+    collection_chapter.slug
 from 
-    chapter
+    collection_chapter
 where
-    $1 @> chapter.collection_path
+    (select index_tree from collection_chapter where id=$1) @> collection_chapter.collection_path

--- a/types/queries/insert_chapter.sql
+++ b/types/queries/insert_chapter.sql
@@ -1,4 +1,2 @@
-insert into chapter (chapter_title, document_title, author, document_id, wordpress_id, collection_path)
-values ($1, $2, $3, $4, $5, $6)
-on conflict (chapter_title, document_title)
-do nothing
+insert into chapter (title, document_id, wordpress_id, collection_path)
+values ($1, $2, $3, $4)

--- a/types/queries/insert_chapter.sql
+++ b/types/queries/insert_chapter.sql
@@ -8,18 +8,18 @@ $6: ref parent_id
 */
 with 
 new_index_tree as (
-    select (select index_tree from collection_chapter where id=$6
+    select (select slug_tree from collection_chapter where id=$6
     union
-    select slug from edited_collection where id=$6)||$4::text)
-insert into chapter (
+    select slug::ltree from edited_collection where id=$6)||$5)
+insert into collection_chapter (
     title, 
     document_id, 
     wordpress_id, 
-    index_tree,
-    slug)
+    index_in_parent,
+    slug_tree)
 select 
     $1,
     $2, 
     $3,
-    cast ((select concat from new_index_tree) as ltree),
-    $5;
+    $4,
+    (select * from new_index_tree)

--- a/types/queries/insert_chapter.sql
+++ b/types/queries/insert_chapter.sql
@@ -1,2 +1,25 @@
-insert into chapter (title, document_id, wordpress_id, collection_path)
-values ($1, $2, $3, $4)
+/*
+$1: str title
+$2: ref doc_id
+$3: int wp_id
+$4: int index
+$5: str slug
+$6: ref parent_id
+*/
+with 
+new_index_tree as (
+    select (select index_tree from chapter where id=$6
+    union
+    select slug from collections where id=$6)||$4)
+insert into chapter (
+    title, 
+    document_id, 
+    wordpress_id, 
+    index_tree,
+    slug)
+select 
+    $1,
+    $2, 
+    $3,
+    cast ((select concat from new_index_tree) as ltree),
+    $5;

--- a/types/queries/insert_chapter.sql
+++ b/types/queries/insert_chapter.sql
@@ -8,9 +8,9 @@ $6: ref parent_id
 */
 with 
 new_index_tree as (
-    select (select index_tree from chapter where id=$6
+    select (select index_tree from collection_chapter where id=$6
     union
-    select slug from collections where id=$6)||$4::text)
+    select slug from edited_collection where id=$6)||$4::text)
 insert into chapter (
     title, 
     document_id, 

--- a/types/queries/insert_chapter.sql
+++ b/types/queries/insert_chapter.sql
@@ -10,7 +10,7 @@ with
 new_index_tree as (
     select (select index_tree from chapter where id=$6
     union
-    select slug from collections where id=$6)||$4)
+    select slug from collections where id=$6)||$4::text)
 insert into chapter (
     title, 
     document_id, 

--- a/types/queries/insert_chapter.sql
+++ b/types/queries/insert_chapter.sql
@@ -8,7 +8,7 @@ $6: ref parent_id
 */
 with 
 new_index_tree as (
-    select (select slug_tree from collection_chapter where id=$6
+    select (select chapter_path from collection_chapter where id=$6
     union
     select slug::ltree from edited_collection where id=$6)||$5)
 insert into collection_chapter (
@@ -16,7 +16,7 @@ insert into collection_chapter (
     document_id, 
     wordpress_id, 
     index_in_parent,
-    slug_tree)
+    chapter_path)
 select 
     $1,
     $2, 

--- a/types/queries/insert_chapter.sql
+++ b/types/queries/insert_chapter.sql
@@ -1,0 +1,4 @@
+insert into chapter (chapter_title, document_title, author, document_id, wordpress_id, collection_path)
+values ($1, $2, $3, $4, $5, $6)
+on conflict (chapter_title, document_title)
+do nothing

--- a/types/queries/insert_collection.sql
+++ b/types/queries/insert_collection.sql
@@ -1,2 +1,2 @@
-insert into collections(collection_name, collection_desc, slug)
-values ($1, $2, $3)
+insert into edited_collection(title, slug)
+values ($1, $2)

--- a/types/queries/insert_collection.sql
+++ b/types/queries/insert_collection.sql
@@ -1,2 +1,2 @@
-insert into edited_collection(title, slug)
-values ($1, $2)
+insert into edited_collection(title, wordpress_menu_id, slug)
+values ($1, $2, $3)

--- a/types/queries/insert_collection.sql
+++ b/types/queries/insert_collection.sql
@@ -1,0 +1,2 @@
+insert into collections(collection_name, collection_desc, slug)
+values ($1, $2, $3)

--- a/types/queries/update_chapter_place.sql
+++ b/types/queries/update_chapter_place.sql
@@ -1,18 +1,18 @@
 /*
 $1: id
-$2: new_index
+$2: new_slug
 $3: parent_id
 */
 with current_tree as (
-    select index_tree from collection_chapter where id=$1
+    select slug_tree from collection_chapter where id=$1
 )
 update collection_chapter set
-index_tree = (
-    select index_tree from collection_chapter where id=$3
+slug_tree = (
+    select slug_tree from collection_chapter where id=$3
     union
-    select slug from edited_collection where id=$3
+    select slug::ltree from edited_collection where id=$3
 ) || subpath ( 
-    $2::text || subpath (index_tree || '0', nlevel((select index_tree from current_tree))), 
+    $2::ltree || subpath (slug_tree || '0', nlevel((select slug_tree from current_tree))), 
     0, -1
 )
-    from collection_chapter where index_tree <@ (select index_tree from current_tree)
+    from collection_chapter where slug_tree <@ (select slug_tree from current_tree)

--- a/types/queries/update_chapter_place.sql
+++ b/types/queries/update_chapter_place.sql
@@ -4,15 +4,15 @@ $2: new_slug
 $3: parent_id
 */
 with current_tree as (
-    select slug_tree from collection_chapter where id=$1
+    select chapter_path from collection_chapter where id=$1
 )
 update collection_chapter set
-slug_tree = (
-    select slug_tree from collection_chapter where id=$3
+chapter_path = (
+    select chapter_path from collection_chapter where id=$3
     union
     select slug::ltree from edited_collection where id=$3
 ) || subpath ( 
-    $2::ltree || subpath (slug_tree || '0', nlevel((select slug_tree from current_tree))), 
+    $2::ltree || subpath (chapter_path || '0', nlevel((select chapter_path from current_tree))), 
     0, -1
 )
-    from collection_chapter where slug_tree <@ (select slug_tree from current_tree)
+    from collection_chapter where chapter_path <@ (select chapter_path from current_tree)

--- a/types/queries/update_chapter_place.sql
+++ b/types/queries/update_chapter_place.sql
@@ -4,15 +4,15 @@ $2: new_index
 $3: parent_id
 */
 with current_tree as (
-    select index_tree from chapter where id=$1
+    select index_tree from collection_chapter where id=$1
 )
-update chapter set
+update collection_chapter set
 index_tree = (
-    select index_tree from chapter where id=$3
+    select index_tree from collection_chapter where id=$3
     union
-    select slug from collections where id=$3
+    select slug from edited_collection where id=$3
 ) || subpath ( 
     $2::text || subpath (index_tree || '0', nlevel((select index_tree from current_tree))), 
     0, -1
 )
-    from chapter where index_tree <@ (select index_tree from current_tree)
+    from collection_chapter where index_tree <@ (select index_tree from current_tree)

--- a/types/queries/update_chapter_place.sql
+++ b/types/queries/update_chapter_place.sql
@@ -1,0 +1,16 @@
+/*
+$1: id
+$2: new_index
+$3: parent_id
+*/
+with current_tree as (
+    select index_tree from chapter where id=$1
+)
+update chapter set
+index_tree = (
+    select index_tree from chapter where id=$3
+    union
+    select slug from collections where id=$3
+) || subpath (
+    index_tree, nlevel((select index_tree from current_tree)) - 1) 
+    from chapter where index_tree <@ (select index_tree from current_tree)

--- a/types/queries/update_chapter_place.sql
+++ b/types/queries/update_chapter_place.sql
@@ -11,6 +11,8 @@ index_tree = (
     select index_tree from chapter where id=$3
     union
     select slug from collections where id=$3
-) || subpath (
-    index_tree, nlevel((select index_tree from current_tree)) - 1) 
+) || subpath ( 
+    $2::text || subpath (index_tree || '0', nlevel((select index_tree from current_tree))), 
+    0, -1
+)
     from chapter where index_tree <@ (select index_tree from current_tree)


### PR DESCRIPTION
Created some new tables/queries in sql to add support for edited collections. 

Namely, added a "chapter" table that will allow chapters in edited collections to be represented, some sample data looking like:
![image](https://user-images.githubusercontent.com/92126390/168925290-ad63b30c-da9b-4516-80a1-4cc99f509450.png)

The ltree field is useful and another query allows groups of chapter to be selected for based on how we want to organize them, which will be helpful, For example:
![image](https://user-images.githubusercontent.com/92126390/168925442-33be10fe-422b-4f2c-8e60-cfb5127e0d7a.png)
For intro chapters. Similarly, different Ltrees can be used for different collections or subcollections. 
