### PR TITLE
[DP - 153] Mixed a scrolling bug on mobile word panels

### DIFF
--- a/website/src/custom-hooks.tsx
+++ b/website/src/custom-hooks.tsx
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react"
+
+export const useMediaQuery = (query: string) => {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const media = window.matchMedia(query)
+    if (media.matches !== matches) {
+      setMatches(media.matches)
+    }
+    const listener = () => setMatches(media.matches)
+    window.addEventListener("resize", listener)
+    return () => window.removeEventListener("resize", listener)
+  }, [matches, query])
+
+  return matches
+}

--- a/website/src/graphql/wordpress/index.ts
+++ b/website/src/graphql/wordpress/index.ts
@@ -7181,8 +7181,6 @@ export enum TimezoneEnum {
   AustraliaBrisbane = "AUSTRALIA_BRISBANE",
   /** Broken Hill */
   AustraliaBrokenHill = "AUSTRALIA_BROKEN_HILL",
-  /** Currie */
-  AustraliaCurrie = "AUSTRALIA_CURRIE",
   /** Darwin */
   AustraliaDarwin = "AUSTRALIA_DARWIN",
   /** Eucla */
@@ -7355,8 +7353,6 @@ export enum TimezoneEnum {
   PacificEaster = "PACIFIC_EASTER",
   /** Efate */
   PacificEfate = "PACIFIC_EFATE",
-  /** Enderbury */
-  PacificEnderbury = "PACIFIC_ENDERBURY",
   /** Fakaofo */
   PacificFakaofo = "PACIFIC_FAKAOFO",
   /** Fiji */
@@ -7373,6 +7369,8 @@ export enum TimezoneEnum {
   PacificGuam = "PACIFIC_GUAM",
   /** Honolulu */
   PacificHonolulu = "PACIFIC_HONOLULU",
+  /** Kanton */
+  PacificKanton = "PACIFIC_KANTON",
   /** Kiritimati */
   PacificKiritimati = "PACIFIC_KIRITIMATI",
   /** Kosrae */

--- a/website/src/pages/documents/document.css.ts
+++ b/website/src/pages/documents/document.css.ts
@@ -182,7 +182,7 @@ export const contentSection2 = style([
   sprinkles({ display: { any: "none", medium: "block" } }),
   {
     flex: 1,
-    maxWidth: "33vw",
+    maxWidth: "20rem",
   },
 ])
 
@@ -198,6 +198,11 @@ export const mobileWordPanel = style([
     selectors: {
       "&[data-enter]": {
         transform: "translateX(0)",
+      },
+    },
+    "@media": {
+      [mediaQueries.medium]: {
+        display: "none",
       },
     },
   },

--- a/website/src/pages/documents/document.css.ts
+++ b/website/src/pages/documents/document.css.ts
@@ -182,6 +182,7 @@ export const contentSection2 = style([
   sprinkles({ display: { any: "none", medium: "block" } }),
   {
     flex: 1,
+    maxWidth: "33vw",
   },
 ])
 

--- a/website/src/pages/documents/document.page.tsx
+++ b/website/src/pages/documents/document.page.tsx
@@ -188,8 +188,6 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
           as="nav"
           className={css.mobileWordPanel}
           aria-label="Word Panel Drawer"
-          preventBodyScroll={false}
-          hideOnClickOutside={false}
         >
           <WordPanel
             segment={wordPanelInfo.currContents}

--- a/website/src/pages/documents/document.page.tsx
+++ b/website/src/pages/documents/document.page.tsx
@@ -10,6 +10,7 @@ import { DocumentAudio } from "src/audio-player"
 import { Breadcrumbs } from "src/breadcrumbs"
 import { Button } from "src/components"
 import Link from "src/components/link"
+import { useMediaQuery } from "src/custom-hooks"
 import * as Dailp from "src/graphql/dailp"
 import Layout from "src/layout"
 import { drawerBg } from "src/menu.css"
@@ -22,6 +23,7 @@ import {
 } from "src/routes"
 import { useScrollableTabState } from "src/scrollable-tabs"
 import { AnnotatedForm, DocumentPage, Segment } from "src/segment"
+import { mediaQueries } from "src/sprinkles.css"
 import {
   BasicMorphemeSegment,
   PhoneticRepresentation,
@@ -160,6 +162,8 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
 
   const tagSet = tagSetForMode(viewMode)
 
+  const isDesktop = useMediaQuery(mediaQueries.medium)
+
   return (
     <>
       <DialogOverlay
@@ -182,22 +186,25 @@ const TranslationTab = ({ doc }: { doc: Document }) => {
         </DialogContent>
       </DialogOverlay>
 
-      <DialogBackdrop {...dialog} className={drawerBg}>
-        <Dialog
-          {...dialog}
-          as="nav"
-          className={css.mobileWordPanel}
-          aria-label="Word Panel Drawer"
-        >
-          <WordPanel
-            segment={wordPanelInfo.currContents}
-            setContent={wordPanelInfo.setCurrContents}
-            viewMode={viewMode}
-            onOpenDetails={openDetails}
-            tagSet={tagSet}
-          />
-        </Dialog>
-      </DialogBackdrop>
+      {!isDesktop ? (
+        <DialogBackdrop {...dialog} className={drawerBg}>
+          <Dialog
+            {...dialog}
+            as="nav"
+            className={css.mobileWordPanel}
+            aria-label="Word Panel Drawer"
+            preventBodyScroll={true}
+          >
+            <WordPanel
+              segment={wordPanelInfo.currContents}
+              setContent={wordPanelInfo.setCurrContents}
+              viewMode={viewMode}
+              onOpenDetails={openDetails}
+              tagSet={tagSet}
+            />
+          </Dialog>
+        </DialogBackdrop>
+      ) : null}
 
       <div className={css.contentContainer}>
         <article className={css.annotationContents}>

--- a/website/src/word-panel.css.tsx
+++ b/website/src/word-panel.css.tsx
@@ -75,6 +75,7 @@ export const wordPanelContent = style({
       height: "calc(100vh - 125px)",
     },
   },
+  height: "100vh",
   overflowY: "auto",
 })
 

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -32,7 +32,7 @@ export const WordPanel = (p: {
   tagSet: TagSet
 }) => {
   if (!p.segment) {
-    return <p>No word has been selected</p>
+    return null
   }
 
   const translation = p.segment.englishGloss.join(", ")


### PR DESCRIPTION
Fixed a bug in the word panels where if content on mobile overflowed, you couldn't scroll the word panel. Now, if you are on mobile and content overflows, you can scroll on either main content or word details depending on where you scroll from.

Also, restricted word panel width on desktop so it wouldn't exceed a certain amount. I thought that had been done before, but apparently not.