### PR TITLE
Add /graphql-edit endpoint to local server with fake user

### DIFF
--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -307,6 +307,14 @@ pub struct UserInfo {
     )]
     groups: Vec<UserGroup>,
 }
+impl UserInfo {
+    pub fn new_test_admin() -> Self {
+        Self {
+            email: "test@dailp.northeastern.edu".to_string(),
+            groups: vec![UserGroup::Editor],
+        }
+    }
+}
 
 #[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize, Debug, async_graphql::Enum)]
 enum UserGroup {

--- a/graphql/src/server.rs
+++ b/graphql/src/server.rs
@@ -1,6 +1,7 @@
 mod query;
 
 use {
+    crate::query::UserInfo,
     dailp::async_graphql::{
         dataloader::DataLoader,
         http::{playground_source, GraphQLPlaygroundConfig},
@@ -28,6 +29,14 @@ async fn main() -> tide::Result<()> {
         ))
         .finish();
 
+    let authed_schema = Schema::build(query::Query, query::Mutation, EmptySubscription)
+        .data(DataLoader::new(
+            dailp::Database::connect().await?,
+            tokio::spawn,
+        ))
+        .data(UserInfo::new_test_admin())
+        .finish();
+
     let cors = CorsMiddleware::new()
         .allow_methods("GET, POST, OPTIONS".parse::<HeaderValue>().unwrap())
         .allow_origin(Origin::from("*"))
@@ -37,6 +46,8 @@ async fn main() -> tide::Result<()> {
 
     // add tide endpoint
     app.at("/graphql").post(async_graphql_tide::graphql(schema));
+    app.at("/graphql-edit")
+        .post(async_graphql_tide::graphql(authed_schema));
 
     // enable graphql playground
     app.at("/graphql").get(|_| async move {
@@ -45,6 +56,16 @@ async fn main() -> tide::Result<()> {
                 // note that the playground needs to know
                 // the path to the graphql endpoint
                 GraphQLPlaygroundConfig::new("/graphql"),
+            )))
+            .content_type(mime::HTML)
+            .build())
+    });
+    app.at("/graphql-edit").get(|_| async move {
+        Ok(Response::builder(StatusCode::Ok)
+            .body(Body::from_string(playground_source(
+                // note that the playground needs to know
+                // the path to the graphql endpoint
+                GraphQLPlaygroundConfig::new("/graphql-edit"),
             )))
             .content_type(mime::HTML)
             .build())


### PR DESCRIPTION
- Adds `/graphql-edit` to local server.
- Playground at `http://localhost:8080/graphql-edit`
- Automatically authenticated with fake user with email address `test@dailp.northeastern.edu` for now, since we don't do anything with the email.
- Fake user is in the `Editor` group, which is our only defined user group at the moment