### PR TITLE
[DP-63] Add a GraphQL mutation to edit a word

### DIFF
--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use {
     dailp::async_graphql::{self, dataloader::DataLoader, Context, FieldResult, Guard},
     dailp::{
-        AnnotatedDoc, CherokeeOrthography, Database, MorphemeId, MorphemeReference, TagForm,
-        WordsInDocument,
+        AnnotatedDoc, AnnotatedFormUpdate, CherokeeOrthography, Database, MorphemeId,
+        MorphemeReference, TagForm, WordsInDocument,
     },
     serde::{Deserialize, Serialize},
     serde_with::{rust::StringWithSeparator, CommaSeparator},
@@ -287,6 +287,18 @@ impl Mutation {
             .update_annotation(data.0)
             .await?;
         Ok(true)
+    }
+
+    async fn update_word(
+        &self,
+        context: &Context<'_>,
+        annotation_form: AnnotatedFormUpdate,
+    ) -> FieldResult<Uuid> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .update_word(&annotation_form)
+            .await?)
     }
 }
 

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -1,5 +1,6 @@
 //! This piece of the project exposes a GraphQL endpoint that allows one to access DAILP data in a federated manner with specific queries.
 
+use dailp::Uuid;
 use itertools::Itertools;
 
 use {

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -290,15 +290,16 @@ impl Mutation {
         Ok(true)
     }
 
+    #[graphql(guard = "GroupGuard::new(UserGroup::Editor)")]
     async fn update_word(
         &self,
         context: &Context<'_>,
-        annotation_form: AnnotatedFormUpdate,
+        word: AnnotatedFormUpdate,
     ) -> FieldResult<Uuid> {
         Ok(context
             .data::<DataLoader<Database>>()?
             .loader()
-            .update_word(&annotation_form)
+            .update_word(&word)
             .await?)
     }
 }

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -811,6 +811,19 @@
     },
     "query": "select\n  document_group.slug,\n  document_group.title\nfrom document\n  inner join document_group on document_group.id = document.group_id\nwhere document.id = $1\n"
   },
+  "79390aad3432fbd919aba5149bedfa3808fdc6aabc85225f6829694752f956ae": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text"
+        ]
+      }
+    },
+    "query": "update word set source_text = $2 where id = $1\n"
+  },
   "7a6c5fc86cb220cb8e0dcbfbbb994b6288490c39e31cef7bc46a9ccc7e321438": {
     "describe": {
       "columns": [],

--- a/types/queries/update_word.sql
+++ b/types/queries/update_word.sql
@@ -1,0 +1,1 @@
+update word set source_text = $2 where id = $1

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -305,6 +305,14 @@ impl Database {
         todo!("Implement image annotations")
     }
 
+    pub async fn update_word(&self, word: &AnnotatedFormUpdate) -> Result<Uuid> {
+        query_file!("queries/update_word.sql", word.id, word.source.value())
+            .execute(&self.client)
+            .await?;
+
+        Ok(word.id)
+    }
+
     pub async fn all_pages(&self) -> Result<Vec<page::Page>> {
         todo!("Implement content pages")
     }

--- a/types/src/form.rs
+++ b/types/src/form.rs
@@ -2,7 +2,7 @@ use crate::{
     AnnotatedDoc, AudioSlice, Database, Date, DocumentId, MorphemeSegment, PartsOfWord,
     PositionInDocument,
 };
-use async_graphql::{dataloader::DataLoader, FieldResult};
+use async_graphql::{dataloader::DataLoader, FieldResult, MaybeUndefined};
 use serde::{Deserialize, Serialize};
 use sqlx::types::Uuid;
 

--- a/types/src/form.rs
+++ b/types/src/form.rs
@@ -167,3 +167,12 @@ impl AnnotatedForm {
 pub fn is_root_morpheme(s: &str) -> bool {
     s.contains(|c: char| c.is_lowercase())
 }
+
+/// A single word in an annotated document that can be edited.
+#[derive(async_graphql::InputObject)]
+pub struct AnnotatedFormUpdate {
+    /// Unique identifier of the form
+    pub id: Uuid,
+    /// Original source text that can be either undefined or null
+    pub source: MaybeUndefined<String>,
+}

--- a/website/src/pages/login.page.tsx
+++ b/website/src/pages/login.page.tsx
@@ -12,6 +12,7 @@ import {
 import { Popover, PopoverDisclosure, usePopoverState } from "reakit/Popover"
 import { useUser } from "src/auth"
 import { Button, CleanButton, Link } from "src/components"
+import { centeredColumn } from "src/style/utils.css"
 import Layout from "../layout"
 import {
   centeredForm,


### PR DESCRIPTION
### CHANGES

- Defined a new InputObject to use with queries called AnnotationFormInput in `form.rs` that contains a word’s id and source_text 
- Added a new mutation in `query.rs` that takes in an AnnotationFormInput consisting of a word’s id and its new source_text field
- Added SQL call to update source text in `database_sql.rs` and added new SQL query called `update_source.sql` 
- Cleaned up `login.css.ts`, `login.page.tsx`, and `reset-password.page.tsx` styling a little bit