### PR TITLE
Source .env file in devshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,2 @@
 use flake
 eval "$shellHook"
-dotenv

--- a/flake.nix
+++ b/flake.nix
@@ -167,6 +167,7 @@
             shellHook = ''
               export PROJECT_ROOT=$PWD
               export PGDATA=$PROJECT_ROOT/.postgres
+              source $PROJECT_ROOT/.env
             '';
             buildInputs = [
               autoconf

--- a/flake.nix
+++ b/flake.nix
@@ -167,7 +167,7 @@
             shellHook = ''
               export PROJECT_ROOT=$PWD
               export PGDATA=$PROJECT_ROOT/.postgres
-              [ ! -f .env ] || export $(grep -v '^#' $PWD/.env | xargs)
+              eval $(${direnv}/bin/direnv dotenv)
             '';
             buildInputs = [
               autoconf

--- a/flake.nix
+++ b/flake.nix
@@ -167,7 +167,7 @@
             shellHook = ''
               export PROJECT_ROOT=$PWD
               export PGDATA=$PROJECT_ROOT/.postgres
-              source $PROJECT_ROOT/.env
+              [ ! -f .env ] || export $(grep -v '^#' $PWD/.env | xargs)
             '';
             buildInputs = [
               autoconf


### PR DESCRIPTION
Instead of loading the `.env` file through `direnv`, load it directly in the `nix develop` shell. This allows devs to use `nix develop` subshells instead of being required to use direnv.