### PR TITLE
Kill database connections after 20 minutes

### DIFF
--- a/graphql/src/lambda.rs
+++ b/graphql/src/lambda.rs
@@ -16,11 +16,11 @@ async fn main() -> Result<(), Error> {
     // This prevents each lambda invocation from creating a new connection to
     // the database.
     let connections = Some(16);
-    let database = dailp::Database::connect(connections).await?;
+    let database = dailp::Database::connect(connections)?;
     let schema = {
         Schema::build(Query, Mutation, EmptySubscription)
             .data(DataLoader::new(
-                dailp::Database::connect(connections).await?,
+                dailp::Database::connect(connections)?,
                 tokio::spawn,
             ))
             .finish()

--- a/graphql/src/server.rs
+++ b/graphql/src/server.rs
@@ -24,14 +24,14 @@ async fn main() -> tide::Result<()> {
     // create schema
     let schema = Schema::build(query::Query, query::Mutation, EmptySubscription)
         .data(DataLoader::new(
-            dailp::Database::connect(None).await?,
+            dailp::Database::connect(None)?,
             tokio::spawn,
         ))
         .finish();
 
     let authed_schema = Schema::build(query::Query, query::Mutation, EmptySubscription)
         .data(DataLoader::new(
-            dailp::Database::connect(None).await?,
+            dailp::Database::connect(None)?,
             tokio::spawn,
         ))
         .data(UserInfo::new_test_admin())

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     println!("Validating manuscript spreadsheets...");
     validate_documents().await?;
 
-    let db = Database::connect(Some(1)).await?;
+    let db = Database::connect(Some(1))?;
 
     println!("Migrating Image Sources...");
     migrate_image_sources(&db).await?;

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -27,7 +27,7 @@ pub struct Database {
     client: sqlx::Pool<sqlx::Postgres>,
 }
 impl Database {
-    pub async fn connect(num_connections: Option<u32>) -> Result<Self> {
+    pub fn connect(num_connections: Option<u32>) -> Result<Self> {
         let db_url = std::env::var("DATABASE_URL")?;
         let conn = PgPoolOptions::new()
             .max_connections(num_connections.unwrap_or_else(|| {
@@ -37,8 +37,7 @@ impl Database {
             .max_lifetime(Duration::from_secs(60 * 20))
             // Disable excessive pings to the database.
             .test_before_acquire(false)
-            .connect_lazy(&db_url)
-            .await?;
+            .connect_lazy(&db_url)?;
         Ok(Database { client: conn })
     }
 

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -34,9 +34,10 @@ impl Database {
                 std::thread::available_parallelism().map_or(2, |x| x.get() as u32)
             }))
             .acquire_timeout(Duration::from_secs(60 * 8))
+            .max_lifetime(Duration::from_secs(60 * 20))
             // Disable excessive pings to the database.
             .test_before_acquire(false)
-            .connect(&db_url)
+            .connect_lazy(&db_url)
             .await?;
         Ok(Database { client: conn })
     }


### PR DESCRIPTION
Kills DB connections after 20 minutes and delays opening DB connections until necessary.
I'm hoping this helps with the database connection pool timing out during data ingestion.