### PR TITLE
[DP-70] added mutation for paragrpah/translation editing

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -561,6 +561,10 @@ type Mutation {
 	the future.
 	"""
 	apiVersion: String!
+	"""
+	Mutation for paragraph and translation editing
+	"""
+	updateParagraph(paragraph: ParagraphUpdate!): UUID!
 	updatePage(data: JSON!): Boolean!
 	updateAnnotation(data: JSON!): Boolean!
 	updateWord(word: AnnotatedFormUpdate!): UUID!
@@ -589,6 +593,17 @@ type PageImage {
 	The full IIIF url for this image resource
 	"""
 	url: String!
+}
+
+"""
+A paragraph in an annotated document that can be edited.
+"""
+input ParagraphUpdate {
+	"""
+	Unique identifier of the form
+	"""
+	id: UUID!
+	translation: String
 }
 
 """

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -7,7 +7,7 @@ use {
     dailp::async_graphql::{self, dataloader::DataLoader, Context, FieldResult, Guard},
     dailp::{
         AnnotatedDoc, AnnotatedFormUpdate, CherokeeOrthography, Database, EditedCollection,
-        MorphemeId, MorphemeReference, MorphemeTag, WordsInDocument,
+        MorphemeId, MorphemeReference, MorphemeTag, ParagraphUpdate, WordsInDocument,
     },
     serde::{Deserialize, Serialize},
     serde_with::{rust::StringWithSeparator, CommaSeparator},
@@ -273,6 +273,20 @@ impl Mutation {
     /// the future.
     async fn api_version(&self) -> &str {
         "1.0"
+    }
+
+    /// Mutation for paragraph and translation editing
+    #[graphql(guard = "GroupGuard::new(UserGroup::Editor)")]
+    async fn update_paragraph(
+        &self,
+        context: &Context<'_>,
+        paragraph: ParagraphUpdate,
+    ) -> FieldResult<Uuid> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .update_paragraph(paragraph)
+            .await?)
     }
 
     #[graphql(guard = "GroupGuard::new(UserGroup::Editor)")]

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -707,6 +707,19 @@
     },
     "query": "select\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number,\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\"\nfrom word\n  left join media_slice on media_slice.id = word.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\nwhere source_text like any($1)\n"
   },
+  "57df2982e788599773dc55b1fc70dfd0739f4dcd6702079f93cd6ff24a992bff": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "TextArray"
+        ]
+      }
+    },
+    "query": "update paragraph set\n    english_translation =\n        case\n            when $2::text[] != '{}' and $2[1] is not null then $2[1]\n            else english_translation\n        end\nwhere id = $1"
+  },
   "587e868e1c86816469a9169bf07be80df5add11ef357029f74629e112d88b88e": {
     "describe": {
       "columns": [],

--- a/types/queries/update_paragraph.sql
+++ b/types/queries/update_paragraph.sql
@@ -1,0 +1,7 @@
+update paragraph set
+    english_translation =
+        case
+            when $2::text[] != '{}' and $2[1] is not null then $2[1]
+            else english_translation
+        end
+where id = $1

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -408,6 +408,20 @@ impl Database {
         Ok(word.id)
     }
 
+    pub async fn update_paragraph(&self, paragraph: ParagraphUpdate) -> Result<Uuid> {
+        let translation = paragraph.translation.into_vec();
+
+        query_file!(
+            "queries/update_paragraph.sql",
+            paragraph.id,
+            &translation as _
+        )
+        .execute(&self.client)
+        .await?;
+
+        Ok(paragraph.id)
+    }
+
     pub async fn all_pages(&self) -> Result<Vec<page::Page>> {
         todo!("Implement content pages")
     }

--- a/types/src/document.rs
+++ b/types/src/document.rs
@@ -2,7 +2,7 @@ use crate::{
     AnnotatedForm, AudioSlice, Contributor, Database, Date, SourceAttribution, Translation,
     TranslationBlock,
 };
-use async_graphql::{dataloader::DataLoader, FieldResult};
+use async_graphql::{dataloader::DataLoader, FieldResult, MaybeUndefined};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -242,6 +242,14 @@ pub struct DocumentParagraph {
     pub id: Uuid,
     /// English translation of the whole paragraph
     pub translation: String,
+}
+
+/// A paragraph in an annotated document that can be edited.
+#[derive(async_graphql::InputObject)]
+pub struct ParagraphUpdate {
+    /// Unique identifier of the form
+    pub id: Uuid,
+    pub translation: MaybeUndefined<String>,
 }
 
 #[async_graphql::Object]

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -486,6 +486,8 @@ export type Mutation = {
   readonly apiVersion: Scalars["String"]
   readonly updateAnnotation: Scalars["Boolean"]
   readonly updatePage: Scalars["Boolean"]
+  /** Mutation for paragraph and translation editing */
+  readonly updateParagraph: Scalars["UUID"]
   readonly updateWord: Scalars["UUID"]
 }
 
@@ -495,6 +497,10 @@ export type MutationUpdateAnnotationArgs = {
 
 export type MutationUpdatePageArgs = {
   data: Scalars["JSON"]
+}
+
+export type MutationUpdateParagraphArgs = {
+  paragraph: ParagraphUpdate
 }
 
 export type MutationUpdateWordArgs = {
@@ -522,6 +528,13 @@ export type PageImage = {
   readonly source: ImageSource
   /** The full IIIF url for this image resource */
   readonly url: Scalars["String"]
+}
+
+/** A paragraph in an annotated document that can be edited. */
+export type ParagraphUpdate = {
+  /** Unique identifier of the form */
+  readonly id: Scalars["UUID"]
+  readonly translation: InputMaybe<Scalars["String"]>
 }
 
 /** The reference position within a document of one specific form */


### PR DESCRIPTION
Added a function in query.rs under mutation called "update_paragraph". This uses a loader in database_sql.rs called update_paragraph calling to a sql query "update_paragraph" to perform the mutation.

Added a new structure to document.rs called ParagraphUpdate to use as an InputObject.