### PR TITLE
CWKW TOC Chapters

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -652,6 +652,7 @@ type PositionInDocument {
 }
 
 type Query {
+	allEditedCollections: [EditedCollection!]!
 	editedCollection(slug: String!): EditedCollection
 	"""
 	Retrieves a chapter and its contents by its collection and chapter slug.

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -18,6 +18,18 @@ pub struct Query;
 
 #[async_graphql::Object]
 impl Query {
+    // List of all the edited collections available.
+    async fn all_edited_collections(
+        &self,
+        context: &Context<'_>,
+    ) -> FieldResult<Vec<EditedCollection>> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .all_edited_collections()
+            .await?)
+    }
+
     // query for 1 collection based on slug, and make a collection object with all the stuff in it.
     async fn edited_collection(
         &self,

--- a/migration/src/spreadsheets.rs
+++ b/migration/src/spreadsheets.rs
@@ -7,8 +7,8 @@ use crate::translations::DocResult;
 use anyhow::Result;
 use dailp::collection::CollectionSection;
 use dailp::collection::CollectionSection::Body;
-use dailp::collection::CollectionSection::Intro;
 use dailp::collection::CollectionSection::Credit;
+use dailp::collection::CollectionSection::Intro;
 use dailp::raw::CollectionChapter;
 use dailp::raw::EditedCollection;
 use dailp::{
@@ -178,9 +178,13 @@ impl SheetResult {
                     None
                 };
 
-                let chapter_type_name = if chapter_type == 0 { Intro } 
-                else if chapter_type == 1 { Body } 
-                else { Credit };
+                let chapter_type_name = if chapter_type == 0 {
+                    Intro
+                } else if chapter_type == 1 {
+                    Body
+                } else {
+                    Credit
+                };
 
                 let new_chapter = dailp::raw::CollectionChapter {
                     index_in_parent: index_i64,

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -2207,6 +2207,42 @@
     },
     "query": "select\n  c.id,\n  c.title,\n  c.document_id,\n  c.wordpress_id,\n  c.index_in_parent,\n  c.chapter_path,\n  c.section as \"section: CollectionSection\"\nfrom collection_chapter as c\nwhere c.collection_slug = $1 \n  and c.slug = $2;\n"
   },
+  "f2be609690eadbcc793760011c18927f3a51a9b661319472bbec19b5c89c6d27": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "title",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "wordpress_menu_id",
+          "ordinal": 2,
+          "type_info": "Int8"
+        },
+        {
+          "name": "slug",
+          "ordinal": 3,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "select \n    e.id,\n    e.title,\n    e.wordpress_menu_id,\n    e.slug\nfrom edited_collection as e;"
+  },
   "f86a2f62b58b5b404883e127574947027ff7a38f8ea4058a7dc4e9e68626c164": {
     "describe": {
       "columns": [

--- a/types/queries/edited_collections.sql
+++ b/types/queries/edited_collections.sql
@@ -1,0 +1,6 @@
+select 
+    e.id,
+    e.title,
+    e.wordpress_menu_id,
+    e.slug
+from edited_collection as e;

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -390,6 +390,14 @@ impl Database {
         )
     }
 
+    pub async fn all_edited_collections(&self) -> Result<Vec<EditedCollection>> {
+        Ok(
+            query_file_as!(EditedCollection, "queries/edited_collections.sql")
+                .fetch_all(&self.client)
+                .await?,
+        )
+    }
+
     pub async fn update_annotation(&self, _annote: annotation::Annotation) -> Result<()> {
         todo!("Implement image annotations")
     }

--- a/website/src/components/sidebar.css.ts
+++ b/website/src/components/sidebar.css.ts
@@ -4,6 +4,7 @@ import { navButton, navDrawer } from "src/menu.css"
 import {
   colors,
   hspace,
+  layers,
   mediaQueries,
   radii,
   vspace,
@@ -18,6 +19,7 @@ export const drawer = style([
   bgColor,
   padding(vspace.one),
   {
+    zIndex: layers.top,
     overflowY: "auto",
     scrollbarGutter: "stable",
     "@media": {

--- a/website/src/components/toc.css.ts
+++ b/website/src/components/toc.css.ts
@@ -65,6 +65,11 @@ export const link = style([
   },
 ])
 
+export const selectedLink = style([
+  link,
+  { color: colors.focus, textDecoration: "underline" },
+])
+
 export const divider = style([
   {
     backgroundColor: colors.borders,

--- a/website/src/components/toc.tsx
+++ b/website/src/components/toc.tsx
@@ -63,7 +63,7 @@ const CollectionTOC = () => {
 
 const TOC = ({ section, chapters }: TOCProps) => {
   const { collectionSlug } = useRouteParams()
-  const { onSelect, isSelected } = useFunctions()
+  const { onSelect, isSelected, lastSelected } = useFunctions()
 
   const listStyle =
     section === CollectionSection.Body
@@ -80,7 +80,7 @@ const TOC = ({ section, chapters }: TOCProps) => {
           <li key={item.leaf} className={listItemStyle}>
             <Link
               href={`/${collectionSlug}/chapters/${item.leaf}`}
-              className={css.link}
+              className={lastSelected(item) ? css.selectedLink : css.link}
               onClick={() => onSelect(item)}
             >
               {item.title}

--- a/website/src/components/toc.tsx
+++ b/website/src/components/toc.tsx
@@ -3,7 +3,7 @@ import { CollectionSection } from "src/graphql/dailp"
 import {
   Chapter,
   useChapters,
-  useSelected,
+  useFunctions,
 } from "src/pages/edited-collections/edited-collection-context"
 import { useRouteParams } from "src/renderer/PageShell"
 import * as css from "./toc.css"
@@ -63,7 +63,7 @@ const CollectionTOC = () => {
 
 const TOC = ({ section, chapters }: TOCProps) => {
   const { collectionSlug } = useRouteParams()
-  const { selected, setSelected } = useSelected()
+  const { onSelect, isSelected } = useFunctions()
 
   const listStyle =
     section === CollectionSection.Body
@@ -81,12 +81,12 @@ const TOC = ({ section, chapters }: TOCProps) => {
             <Link
               href={`/${collectionSlug}/chapters/${item.leaf}`}
               className={css.link}
-              onClick={() => setSelected(item)}
+              onClick={() => onSelect(item)}
             >
               {item.title}
             </Link>
-            {/* If this item is selected, show its child chapters if there are any. */}
-            {item.title === selected?.title && item.children ? (
+
+            {isSelected(item) && item.children ? (
               <TOC section={section} chapters={item.children} />
             ) : null}
           </li>

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -579,6 +579,7 @@ export type Query = {
   readonly allCollections: ReadonlyArray<DocumentCollection>
   /** Listing of all documents excluding their contents by default */
   readonly allDocuments: ReadonlyArray<AnnotatedDoc>
+  readonly allEditedCollections: ReadonlyArray<EditedCollection>
   /** List of all content pages */
   readonly allPages: ReadonlyArray<Page>
   /** List of all the functional morpheme tags available */
@@ -958,6 +959,26 @@ export type CollectionQuery = { readonly __typename?: "Query" } & {
           }
       >
     }
+}
+
+export type EditedCollectionsQueryVariables = Exact<{ [key: string]: never }>
+
+export type EditedCollectionsQuery = { readonly __typename?: "Query" } & {
+  readonly allEditedCollections: ReadonlyArray<
+    { readonly __typename?: "EditedCollection" } & Pick<
+      EditedCollection,
+      "title" | "slug"
+    > & {
+        readonly chapters: Maybe<
+          ReadonlyArray<
+            { readonly __typename?: "CollectionChapter" } & Pick<
+              CollectionChapter,
+              "path"
+            >
+          >
+        >
+      }
+  >
 }
 
 export type EditedCollectionQueryVariables = Exact<{
@@ -1431,6 +1452,26 @@ export function useCollectionQuery(
 ) {
   return Urql.useQuery<CollectionQuery>({
     query: CollectionDocument,
+    ...options,
+  })
+}
+export const EditedCollectionsDocument = gql`
+  query EditedCollections {
+    allEditedCollections {
+      title
+      slug
+      chapters {
+        path
+      }
+    }
+  }
+`
+
+export function useEditedCollectionsQuery(
+  options?: Omit<Urql.UseQueryArgs<EditedCollectionsQueryVariables>, "query">
+) {
+  return Urql.useQuery<EditedCollectionsQuery>({
+    query: EditedCollectionsDocument,
     ...options,
   })
 }

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -111,12 +111,11 @@ query Collection($slug: String!) {
   }
 }
 
-query EditedCollection($slug: String!) {
-  editedCollection(slug: $slug) {
+query EditedCollections {
+  allEditedCollections {
+    title
+    slug
     chapters {
-      title
-      indexInParent
-      section
       path
     }
   }

--- a/website/src/layout.css.ts
+++ b/website/src/layout.css.ts
@@ -3,6 +3,7 @@ import {
   colors,
   fonts,
   hspace,
+  layers,
   mediaQueries,
   vspace,
 } from "src/style/constants"
@@ -24,7 +25,7 @@ export const header = style([
     fontFamily: fonts.header,
     position: "sticky",
     top: 0,
-    zIndex: 999,
+    zIndex: layers.second,
     "@media": {
       [mediaQueries.medium]: {
         position: "static",

--- a/website/src/pages/documents/details.page.tsx
+++ b/website/src/pages/documents/details.page.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Helmet } from "react-helmet"
 import { Link } from "src/components"
 import * as Dailp from "src/graphql/dailp"

--- a/website/src/pages/documents/document.css.ts
+++ b/website/src/pages/documents/document.css.ts
@@ -4,6 +4,7 @@ import {
   colors,
   fonts,
   hspace,
+  layers,
   mediaQueries,
   radii,
   thickness,
@@ -41,7 +42,7 @@ export const displayModeArea = style({
   position: "sticky",
   top: `calc(55px + ${vspace[1.75]})`,
   width: "100%",
-  zIndex: 1,
+  zIndex: layers.base,
   paddingTop: vspace.quarter,
   paddingBottom: vspace.quarter,
   "@media": {
@@ -63,7 +64,7 @@ export const wideAndTop = style({
   position: "sticky",
   top: 55,
   width: "100%",
-  zIndex: 1,
+  zIndex: layers.base,
   "@media": {
     [mediaQueries.medium]: {
       top: 0,
@@ -144,7 +145,7 @@ export const morphemeDialog = style([
     transform: "translate(-50%, -50%)",
     maxWidth: "100vw",
     margin: 0,
-    zIndex: 1009,
+    zIndex: layers.top,
   },
 ])
 
@@ -159,7 +160,7 @@ export const morphemeDialogBackdrop = style({
   position: "fixed",
   inset: 0,
   backgroundColor: "rgba(0,0,0,0.2)",
-  zIndex: 1008,
+  zIndex: layers.third,
 })
 
 export const annotatedDocument = style({

--- a/website/src/pages/edited-collections/chapter.page.server.ts
+++ b/website/src/pages/edited-collections/chapter.page.server.ts
@@ -4,8 +4,8 @@ import * as Dailp from "src/graphql/dailp"
 
 export async function prerender() {
   const { data, error } = await client.dailp
-    .query<Dailp.EditedCollectionQuery, Dailp.EditedCollectionQueryVariables>(
-      Dailp.EditedCollectionDocument
+    .query<Dailp.EditedCollectionsQuery, Dailp.EditedCollectionsQueryVariables>(
+      Dailp.EditedCollectionsDocument
     )
     .toPromise()
 
@@ -13,10 +13,11 @@ export async function prerender() {
     throw error
   }
 
-  return flatMap(data?.editedCollection?.chapters, (chapter) => {
-    const collectionSlug = data?.editedCollection
-    const slug = chapter.title
+  return flatMap(data?.allEditedCollections, (collection) => {
+    const collectionSlug = collection.slug
 
-    return [{ url: `/${collectionSlug}/chapters/${slug}` }]
+    return collection.chapters?.map((c) => {
+      url: `/${collectionSlug}/chapters/${c.path[c.path.length - 1]}`
+    })
   })
 }

--- a/website/src/pages/edited-collections/chapter.page.server.ts
+++ b/website/src/pages/edited-collections/chapter.page.server.ts
@@ -1,21 +1,22 @@
 import { flatMap } from "lodash"
+import { client } from "src/graphql"
 import * as Dailp from "src/graphql/dailp"
 
 export async function prerender() {
-  //   const { data, error } = await client.dailp
-  //     .query<Dailp.editedCollectionQuery, Dailp.EditedCollectionQueryVariables>()
-  //     .toPromise()
-
-  const [{ data, error }] = Dailp.useEditedCollectionQuery({
-    variables: { slug: "cwkw" },
-  })
+  const { data, error } = await client.dailp
+    .query<Dailp.EditedCollectionQuery, Dailp.EditedCollectionQueryVariables>(
+      Dailp.EditedCollectionDocument
+    )
+    .toPromise()
 
   if (error) {
     throw error
   }
 
   return flatMap(data?.editedCollection?.chapters, (chapter) => {
-    const slug = chapter.title.toLowerCase()
-    return [{ url: `cwkw/chapters/${slug}` }]
+    const collectionSlug = data?.editedCollection
+    const slug = chapter.title
+
+    return [{ url: `/${collectionSlug}/chapters/${slug}` }]
   })
 }

--- a/website/src/pages/edited-collections/chapter.page.server.ts
+++ b/website/src/pages/edited-collections/chapter.page.server.ts
@@ -1,0 +1,21 @@
+import { flatMap } from "lodash"
+import * as Dailp from "src/graphql/dailp"
+
+export async function prerender() {
+  //   const { data, error } = await client.dailp
+  //     .query<Dailp.editedCollectionQuery, Dailp.EditedCollectionQueryVariables>()
+  //     .toPromise()
+
+  const [{ data, error }] = Dailp.useEditedCollectionQuery({
+    variables: { slug: "cwkw" },
+  })
+
+  if (error) {
+    throw error
+  }
+
+  return flatMap(data?.editedCollection?.chapters, (chapter) => {
+    const slug = chapter.title.toLowerCase()
+    return [{ url: `cwkw/chapters/${slug}` }]
+  })
+}

--- a/website/src/pages/edited-collections/chapter.page.server.ts
+++ b/website/src/pages/edited-collections/chapter.page.server.ts
@@ -18,7 +18,9 @@ export async function prerender() {
 
     return collection.chapters?.map((c) => {
       return {
-        url: `/${collectionSlug}/chapters/${c.path[c.path.length - 1]}`,
+        url: `/${collectionSlug}/chapters/${
+          c.path.length > 0 ? c.path[c.path.length - 1] : ""
+        }`,
       }
     })
   })

--- a/website/src/pages/edited-collections/chapter.page.server.ts
+++ b/website/src/pages/edited-collections/chapter.page.server.ts
@@ -9,15 +9,17 @@ export async function prerender() {
     )
     .toPromise()
 
-  if (error) {
+  if (!data || error) {
     throw error
   }
 
-  return flatMap(data?.allEditedCollections, (collection) => {
+  return flatMap(data.allEditedCollections, (collection) => {
     const collectionSlug = collection.slug
 
     return collection.chapters?.map((c) => {
-      url: `/${collectionSlug}/chapters/${c.path[c.path.length - 1]}`
+      return {
+        url: `/${collectionSlug}/chapters/${c.path[c.path.length - 1]}`,
+      }
     })
   })
 }

--- a/website/src/pages/edited-collections/chapter.page.server.ts
+++ b/website/src/pages/edited-collections/chapter.page.server.ts
@@ -16,7 +16,13 @@ export async function prerender() {
   return flatMap(data.allEditedCollections, (collection) => {
     const collectionSlug = collection.slug
 
-    return collection.chapters?.map((c) => {
+    if (!collection.chapters) {
+      return {
+        url: `/${collectionSlug}/`,
+      }
+    }
+
+    return collection.chapters.map((c) => {
       return {
         url: `/${collectionSlug}/chapters/${
           c.path.length > 0 ? c.path[c.path.length - 1] : ""

--- a/website/src/pages/edited-collections/chapter.page.tsx
+++ b/website/src/pages/edited-collections/chapter.page.tsx
@@ -1,10 +1,11 @@
 import { Helmet } from "react-helmet"
 import { Link, WordpressPage } from "src/components"
 import * as Dailp from "src/graphql/dailp"
-import { fullWidth, paddedCenterColumn } from "src/style/utils.css"
+import * as util from "src/style/utils.css"
 import CWKWLayout from "../cwkw/cwkw-layout"
+import * as css from "../cwkw/cwkw-layout.css"
 import { DocumentTitleHeader, TabSet } from "../documents/document.page"
-import { useSubchapters } from "./edited-collection-context"
+import { useDialog, useSubchapters } from "./edited-collection-context"
 
 const ChapterPage = (props: {
   collectionSlug: string
@@ -16,6 +17,8 @@ const ChapterPage = (props: {
       chapterSlug: props.chapterSlug,
     },
   })
+
+  const dialog = useDialog()
 
   const chapter = data?.chapter
 
@@ -30,8 +33,8 @@ const ChapterPage = (props: {
   return (
     <CWKWLayout>
       <Helmet title={chapter.title} />
-      <main className={paddedCenterColumn}>
-        <article className={fullWidth}>
+      <main className={util.paddedCenterColumn}>
+        <article className={dialog.visible ? css.leftMargin : util.fullWidth}>
           {/* If this chapter contains or is a Wordpress page, display the WP page contents. */}
           {wordpressId ? <WordpressPage slug={wordpressId.toString()} /> : null}
 

--- a/website/src/pages/edited-collections/edited-collection-context.tsx
+++ b/website/src/pages/edited-collections/edited-collection-context.tsx
@@ -52,50 +52,40 @@ export const CollectionProvider = (props: { children: any }) => {
 export const useFunctions = () => {
   const { selected, setSelected } = useContext(CollectionContext)
 
-  // Defines the behavior once selecting a chapter.
-  function onSelect(item: Chapter) {
-    const updated = selected
-    let lastItem = updated[updated.length - 1]
+  function onSelect(chapter: Chapter) {
+    // The last chapter selected is the currentmost selected chapter.
+    let lastChapter = selected[selected.length - 1]
 
-    // If the new item was already selected, remove the existing selected item and all its children.
-    if (isSelected(item)) {
-      const idx = updated.findIndex((chapter) => chapter.title === item.title)
-      updated.splice(idx, 1)
-      setSelected(updated)
-    }
+    if (!lastChapter || chapter.indexInParent === 1) {
+      // If no chapter was last selected, then start a new list of selected chapters.
+      setSelected([chapter])
+    } else if (lastChapter) {
+      const idx = selected.findIndex(
+        (c) => c.indexInParent === chapter.indexInParent
+      )
 
-    // Since there was a chapter last selected, we know the newly selected isn't the top-most level chapter.
-    else if (lastItem) {
-      if (lastItem.indexInParent < item.indexInParent) {
-        updated.push(item)
-        setSelected(updated)
-      } else if (lastItem.indexInParent > item.indexInParent) {
-        if (item.indexInParent === 1) {
-          setSelected([item])
-        } else {
-          while (lastItem && lastItem?.indexInParent > item.indexInParent) {
-            updated.pop()
-            lastItem = updated[updated.length - 1]
-          }
-          updated.push(item)
-          setSelected(updated)
-        }
-      } else if (lastItem.indexInParent === item.indexInParent) {
-        updated[updated.length - 1] = item
-        setSelected(updated)
+      if (idx > 0) {
+        selected.splice(idx, selected.length - idx)
       }
-    } else {
-      // If there was no chapter last selected, this newly selected chapter must be on the top-most level (index = 1).
-      setSelected([item])
+
+      selected.push(chapter)
+      setSelected(selected)
     }
   }
 
   // Returns whether a chapter has been selected or not.
   function isSelected(item: Chapter) {
-    return selected.map((chapter) => chapter.title).includes(item.title)
+    return selected.map((chapter) => chapter.leaf).includes(item.leaf)
   }
 
-  return { onSelect, isSelected }
+  function lastSelected(item: Chapter) {
+    if (selected[selected.length - 1]?.leaf === item.leaf) {
+      return true
+    }
+    return false
+  }
+
+  return { onSelect, isSelected, lastSelected }
 }
 
 export const useChapters = () => {

--- a/website/src/pages/edited-collections/edited-collection-context.tsx
+++ b/website/src/pages/edited-collections/edited-collection-context.tsx
@@ -54,24 +54,34 @@ export const useFunctions = () => {
 
   // Defines the behavior once selecting a chapter.
   function onSelect(item: Chapter) {
-    const lastSelected = selected[selected.length - 1]
+    const updated = selected
+    let lastItem = updated[updated.length - 1]
 
-    // Since there was a chapter last selected, we know this isn't the top-most level chapter.
-    if (lastSelected) {
-      if (isSelected(item)) {
-        const idx = selected.indexOf(item)
-        const updated = selected.slice(0, idx - 1)
-        setSelected(updated)
-      }
-      if (lastSelected.indexInParent === item.indexInParent) {
-        const updated = selected
-        // Replace the most recently selected item with the newly selected, since each chapter selected must be on its own level.
-        updated[updated.length - 1] = item
-        setSelected(updated)
-      } else if (lastSelected.indexInParent < item.indexInParent) {
-        // The newly selected item must be a child of the last selected item, so push the new item onto the list of selected so far.
-        const updated = selected
+    // If the new item was already selected, remove the existing selected item and all its children.
+    if (isSelected(item)) {
+      const idx = updated.findIndex((chapter) => chapter.title === item.title)
+      updated.splice(idx, 1)
+      setSelected(updated)
+    }
+
+    // Since there was a chapter last selected, we know the newly selected isn't the top-most level chapter.
+    else if (lastItem) {
+      if (lastItem.indexInParent < item.indexInParent) {
         updated.push(item)
+        setSelected(updated)
+      } else if (lastItem.indexInParent > item.indexInParent) {
+        if (item.indexInParent === 1) {
+          setSelected([item])
+        } else {
+          while (lastItem && lastItem?.indexInParent > item.indexInParent) {
+            updated.pop()
+            lastItem = updated[updated.length - 1]
+          }
+          updated.push(item)
+          setSelected(updated)
+        }
+      } else if (lastItem.indexInParent === item.indexInParent) {
+        updated[updated.length - 1] = item
         setSelected(updated)
       }
     } else {

--- a/website/src/routes.ts
+++ b/website/src/routes.ts
@@ -8,7 +8,7 @@ export const documentDetailsRoute = (slug: string) =>
 export const collectionRoute = (slug: string) => `/collections/${slug}`
 
 export const chapterRoute = (collectionSlug: string, slug: string) =>
-  `${collectionSlug}/chapters/${slug}`
+  `/${collectionSlug}/chapters/${slug}`
 
 export const redirectDocumentRoute = (path: string[]) => {
   const collectionSlug = path[0]!

--- a/website/src/style/constants.ts
+++ b/website/src/style/constants.ts
@@ -87,7 +87,8 @@ export const selectors = {
 }
 
 export const layers = {
-  top: 3,
-  middle: 2,
+  top: 999,
+  third: 3,
+  second: 2,
   base: 1,
 }

--- a/website/src/style/utils.css.ts
+++ b/website/src/style/utils.css.ts
@@ -5,12 +5,13 @@ import {
   fonts,
   hsize,
   hspace,
+  layers,
   mediaQueries,
   rhythm,
   thickness,
   vspace,
 } from "./constants"
-import { media, paddingX, paddingY } from "./utils"
+import { media, paddingX } from "./utils"
 
 export const hideOnPrint = style(media(mediaQueries.print, { display: "none" }))
 
@@ -22,7 +23,7 @@ export const withBg = style([
     backgroundColor: colors.body,
     borderColor: colors.text,
     borderWidth: thickness.thin,
-    zIndex: 999,
+    zIndex: layers.second,
   },
 ])
 


### PR DESCRIPTION
# Changelog
- Fixed how nested chapters were opening in the CWKW TOC (deeply nested chapters would not appear before when selected).
- Added prerendering for CWKW chapters.
- Added `allEditedCollections` query to get the urls of every chapter within every edited collection and use for the prerendering.
- The currently selected chapter appears as a yellow, underlined link so it's more obvious which is selected.
- Added the constant `layers` to define more consistent `z-index` throughout.

I recorded a video below of it in action:
https://drive.google.com/file/d/1LB0q38bSIyk0l5lNR9eDcxK_rc3HvSKV/view?usp=sharing
