### PR TITLE
Cleaned up TOC bugs

### DIFF
--- a/website/src/components/sidebar.css.ts
+++ b/website/src/components/sidebar.css.ts
@@ -3,7 +3,6 @@ import { padding } from "polished"
 import { navDrawer } from "src/menu.css"
 import {
   colors,
-  hsize,
   hspace,
   layers,
   mediaQueries,
@@ -39,7 +38,6 @@ export const initDrawer = style([
 ])
 
 export const drawer = style([
-  initDrawer,
   {
     "@media": {
       [mediaQueries.medium]: {
@@ -63,14 +61,14 @@ export const header = style([
   },
 ])
 
-export const openNavButton = style([
+export const baseNavButton = style([
   bgColor,
   padding(hspace.halfEdge),
   {
     "@media": {
       [mediaQueries.medium]: {
-        width: `calc(${hsize.xsmall} / 2)`,
-        height: `calc(${hsize.xsmall} / 2)`,
+        width: "3rem",
+        height: "3rem",
         display: "flex",
         justifyContent: "center",
         alignItems: "center",
@@ -92,13 +90,10 @@ export const openNavButton = style([
   },
 ])
 
-export const closeNavButton = style([
-  openNavButton,
-  {
-    "@media": {
-      [mediaQueries.medium]: {
-        transform: `translateX(-${drawerWidth})`,
-      },
+export const closeNavButton = style({
+  "@media": {
+    [mediaQueries.medium]: {
+      transform: `translateX(-${drawerWidth})`,
     },
   },
-])
+})

--- a/website/src/components/sidebar.css.ts
+++ b/website/src/components/sidebar.css.ts
@@ -74,9 +74,10 @@ export const openNavButton = style([
         display: "flex",
         justifyContent: "center",
         alignItems: "center",
-        position: "absolute",
 
-        top: vspace.double,
+        position: "fixed",
+
+        top: vspace.large,
 
         left: drawerWidth,
 

--- a/website/src/components/sidebar.css.ts
+++ b/website/src/components/sidebar.css.ts
@@ -1,8 +1,9 @@
 import { style } from "@vanilla-extract/css"
 import { padding } from "polished"
-import { navButton, navDrawer } from "src/menu.css"
+import { navDrawer } from "src/menu.css"
 import {
   colors,
+  hsize,
   hspace,
   layers,
   mediaQueries,
@@ -14,7 +15,7 @@ export const drawerWidth = "20rem"
 export const bgColor = style({ backgroundColor: "#585858" })
 export const iconSize = "32px"
 
-export const drawer = style([
+export const initDrawer = style([
   navDrawer,
   bgColor,
   padding(vspace.one),
@@ -22,9 +23,33 @@ export const drawer = style([
     zIndex: layers.top,
     overflowY: "auto",
     scrollbarGutter: "stable",
+
     "@media": {
       [mediaQueries.medium]: {
         width: drawerWidth,
+        transform: "none",
+        selectors: {
+          "&[data-enter]": {
+            transform: "none",
+          },
+        },
+      },
+    },
+  },
+])
+
+export const drawer = style([
+  initDrawer,
+  {
+    "@media": {
+      [mediaQueries.medium]: {
+        transition: "transform 0.5s ease-out",
+        transform: `translateX(-${drawerWidth})`,
+        selectors: {
+          "&[data-enter]": {
+            transform: "translateX(0)",
+          },
+        },
       },
     },
   },
@@ -38,31 +63,41 @@ export const header = style([
   },
 ])
 
-export const desktopNav = style([
-  navButton,
+export const openNavButton = style([
   bgColor,
+  padding(hspace.halfEdge),
   {
     "@media": {
       [mediaQueries.medium]: {
-        display: "block",
+        width: `calc(${hsize.xsmall} / 2)`,
+        height: `calc(${hsize.xsmall} / 2)`,
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
         position: "absolute",
+
+        top: vspace.double,
+
+        left: drawerWidth,
+
         color: colors.body,
-        borderRadius: radii.medium,
-        top: vspace.large,
-        left: hspace[0],
+        border: "none",
+        borderRadius: radii.large,
+
+        transition: "transform 0.5s ease-out",
+        transform: `translateX(0)`,
       },
     },
   },
 ])
 
-export const openNav = style([
-  desktopNav,
-  padding(vspace.small),
-  { transform: `translateX(${drawerWidth})` },
-])
-
-export const closedNav = style([
-  desktopNav,
-  padding(vspace.small),
-  { transform: `translateX(${hspace[0]})` },
+export const closeNavButton = style([
+  openNavButton,
+  {
+    "@media": {
+      [mediaQueries.medium]: {
+        transform: `translateX(-${drawerWidth})`,
+      },
+    },
+  },
 ])

--- a/website/src/components/sidebar.tsx
+++ b/website/src/components/sidebar.tsx
@@ -1,9 +1,14 @@
 import "@fontsource/quattrocento-sans/latin.css"
+import cx from "classnames"
 import "normalize.css"
 import { useEffect, useState } from "react"
-import { BsArrowBarLeft, BsArrowBarRight } from "react-icons/bs"
 import { MdMenu } from "react-icons/md"
-import { Dialog, DialogBackdrop, DialogDisclosure } from "reakit/Dialog"
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogDisclosure,
+  useDialogState,
+} from "reakit/Dialog"
 import CollectionTOC from "src/components/toc"
 import { drawerBg, navButton } from "src/menu.css"
 import { useDialog } from "src/pages/edited-collections/edited-collection-context"
@@ -13,15 +18,10 @@ import * as css from "./sidebar.css"
 
 // Renders a sidebar on the left side of the screen containing a drawer.
 export const Sidebar = () => {
-  const dialog = useDialog()
+  // On load, make sure drawer is initially visible and is non-modal for desktop screens.
+  const dialog = useDialogState({ ...useDialog(), visible: true, modal: true })
   // State variable that checks whether this component has loaded in.
   const [loaded, setLoaded] = useState(false)
-
-  // On load, make sure drawer is initially visible and is non-modal for desktop screens.
-  useEffect(() => {
-    dialog.setVisible(true)
-    dialog.setModal(false)
-  }, [])
 
   useEffect(() => {
     // If this sidebar's dialog has already animated, set the loaded state to true.
@@ -35,7 +35,7 @@ export const Sidebar = () => {
       <Dialog
         {...dialog}
         // If the component has already loaded in, display the drawer with transitions.
-        className={loaded ? css.drawer : css.initDrawer}
+        className={cx(css.initDrawer, loaded && css.drawer)}
         as="nav"
         aria-label="Table of Contents"
       >
@@ -43,7 +43,7 @@ export const Sidebar = () => {
       </Dialog>
       <DialogDisclosure
         {...dialog}
-        className={dialog.visible ? css.openNavButton : css.closeNavButton}
+        className={cx(css.baseNavButton, !dialog.visible && css.closeNavButton)}
         aria-label="Open Table of Contents"
       >
         <MdMenu size={css.iconSize} />

--- a/website/src/components/sidebar.tsx
+++ b/website/src/components/sidebar.tsx
@@ -1,6 +1,6 @@
 import "@fontsource/quattrocento-sans/latin.css"
 import "normalize.css"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { BsArrowBarLeft, BsArrowBarRight } from "react-icons/bs"
 import { MdMenu } from "react-icons/md"
 import { Dialog, DialogBackdrop, DialogDisclosure } from "reakit/Dialog"
@@ -14,17 +14,28 @@ import * as css from "./sidebar.css"
 // Renders a sidebar on the left side of the screen containing a drawer.
 export const Sidebar = () => {
   const dialog = useDialog()
+  // State variable that checks whether this component has loaded in.
+  const [loaded, setLoaded] = useState(false)
 
-  // On load, make sure drawer appears for desktop screens.
+  // On load, make sure drawer is initially visible and is non-modal for desktop screens.
   useEffect(() => {
     dialog.setVisible(true)
+    dialog.setModal(false)
   }, [])
+
+  useEffect(() => {
+    // If this sidebar's dialog has already animated, set the loaded state to true.
+    if (dialog.animating) {
+      setLoaded(true)
+    }
+  }, [dialog.visible])
 
   return (
     <>
       <Dialog
         {...dialog}
-        className={css.drawer}
+        // If the component has already loaded in, display the drawer with transitions.
+        className={loaded ? css.drawer : css.initDrawer}
         as="nav"
         aria-label="Table of Contents"
       >
@@ -32,14 +43,10 @@ export const Sidebar = () => {
       </Dialog>
       <DialogDisclosure
         {...dialog}
-        className={css.desktopNav}
+        className={dialog.visible ? css.openNavButton : css.closeNavButton}
         aria-label="Open Table of Contents"
       >
-        {dialog.visible ? (
-          <BsArrowBarLeft size={css.iconSize} className={css.openNav} />
-        ) : (
-          <BsArrowBarRight size={css.iconSize} className={css.closedNav} />
-        )}
+        <MdMenu size={css.iconSize} />
       </DialogDisclosure>
     </>
   )

--- a/website/src/pages/edited-collections/edited-collection-context.tsx
+++ b/website/src/pages/edited-collections/edited-collection-context.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState } from "react"
-import { DialogStateReturn, useDialogState } from "reakit/Dialog"
+import { Dialog, DialogStateReturn, useDialogState } from "reakit/Dialog"
 import * as Dailp from "src/graphql/dailp"
 import { useRouteParams } from "src/renderer/PageShell"
 
@@ -38,7 +38,6 @@ export const CollectionProvider = (props: { children: any }) => {
   // Gets the dialog state for the TOC
   const dialog = useDialogState({
     animated: true,
-    visible: true,
   })
 
   return (

--- a/website/src/pages/edited-collections/edited-collection-context.tsx
+++ b/website/src/pages/edited-collections/edited-collection-context.tsx
@@ -38,6 +38,7 @@ export const CollectionProvider = (props: { children: any }) => {
   // Gets the dialog state for the TOC
   const dialog = useDialogState({
     animated: true,
+    visible: true,
   })
 
   return (


### PR DESCRIPTION
# Changelog
- Fixed TOC bug where loading a chapter from the landing page causes TOC to reload by removing initial transition when the TOC is first loaded in.
- Allow body scroll on chapters while the TOC is open on desktop by making it non-modal.
- Change the menu icon for opening and made it bigger on desktop: 
![image](https://user-images.githubusercontent.com/40529597/207703182-5811d8a3-b567-4ec9-8e12-d60fcbfc8a47.png)