### PR TITLE
If a chapter contains a Wordpress page, link to WP via the modified URL slug

### DIFF
--- a/website/src/pages/edited-collections/chapter.page.tsx
+++ b/website/src/pages/edited-collections/chapter.page.tsx
@@ -37,7 +37,7 @@ const ChapterPage = (props: {
       <main className={util.paddedCenterColumn}>
         <article className={dialog.visible ? css.leftMargin : util.fullWidth}>
           {/* If this chapter contains or is a Wordpress page, display the WP page contents. */}
-          {wordpressId ? (
+          {wordpressId && chapter.slug ? (
             <WordpressPage slug={`/${chapter.slug.replaceAll("_", "-")}`} />
           ) : null}
 

--- a/website/src/pages/edited-collections/chapter.page.tsx
+++ b/website/src/pages/edited-collections/chapter.page.tsx
@@ -38,7 +38,7 @@ const ChapterPage = (props: {
         <article className={dialog.visible ? css.leftMargin : util.fullWidth}>
           {/* If this chapter contains or is a Wordpress page, display the WP page contents. */}
           {wordpressId && chapter.slug ? (
-            <WordpressPage slug={`/${chapter.slug.replaceAll("_", "-")}`} />
+            <WordpressPage slug={`/${chapter.slug.replace(/_/g, "-")}`} />
           ) : null}
 
           {/* If this chapter is a document, display the document contents. */}

--- a/website/src/pages/edited-collections/chapter.page.tsx
+++ b/website/src/pages/edited-collections/chapter.page.tsx
@@ -37,7 +37,9 @@ const ChapterPage = (props: {
       <main className={util.paddedCenterColumn}>
         <article className={dialog.visible ? css.leftMargin : util.fullWidth}>
           {/* If this chapter contains or is a Wordpress page, display the WP page contents. */}
-          {wordpressId ? <WordpressPage slug={`/${chapter.slug}`} /> : null}
+          {wordpressId ? (
+            <WordpressPage slug={`/${chapter.slug.replaceAll("_", "-")}`} />
+          ) : null}
 
           {/* If this chapter is a document, display the document contents. */}
           {document ? (


### PR DESCRIPTION
Just replaces "_" with "-" when linking to a CWKW chapter with Wordpress page content, since the Wordpress slug uses dashes instead of underscores.

I.e. CWKW_acknowledgements -> CWKW-acknowledgements

For the Wordpress prose to appear, its slug text should match the one specified in the CWKW index except with underscores rather than dashes.