### PR TITLE
Convert front-end collection slugs to be lowercase with hyphens

### DIFF
--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -1,6 +1,6 @@
 //! This piece of the project exposes a GraphQL endpoint that allows one to access DAILP data in a federated manner with specific queries.
 
-use dailp::{CollectionChapter, Uuid};
+use dailp::{slugify_ltree, CollectionChapter, Uuid};
 use itertools::Itertools;
 
 use {
@@ -36,6 +36,7 @@ impl Query {
         context: &Context<'_>,
         slug: String,
     ) -> FieldResult<Option<EditedCollection>> {
+        let slug = slugify_ltree(slug);
         Ok(context
             .data::<DataLoader<Database>>()?
             .load_one(dailp::EditedCollectionDetails(slug))
@@ -52,7 +53,7 @@ impl Query {
         Ok(context
             .data::<DataLoader<Database>>()?
             .loader()
-            .chapter(collection_slug, chapter_slug)
+            .chapter(slugify_ltree(collection_slug), slugify_ltree(chapter_slug))
             .await?)
     }
 

--- a/migration/src/spreadsheets.rs
+++ b/migration/src/spreadsheets.rs
@@ -12,9 +12,9 @@ use dailp::collection::CollectionSection::Intro;
 use dailp::raw::CollectionChapter;
 use dailp::raw::EditedCollection;
 use dailp::{
-    convert_udb, root_noun_surface_forms, root_verb_surface_forms, AnnotatedDoc, AnnotatedForm,
-    AnnotatedSeg, AudioSlice, Contributor, Database, Date, DocumentId, DocumentMetadata,
-    LexicalConnection, LineBreak, MorphemeId, PageBreak, Uuid, WordSegment,
+    convert_udb, root_noun_surface_forms, root_verb_surface_forms, slugify_ltree, AnnotatedDoc,
+    AnnotatedForm, AnnotatedSeg, AudioSlice, Contributor, Database, Date, DocumentId,
+    DocumentMetadata, LexicalConnection, LineBreak, MorphemeId, PageBreak, Uuid, WordSegment,
 };
 use dailp::{PositionInDocument, SourceAttribution};
 use itertools::Itertools;
@@ -188,7 +188,7 @@ impl SheetResult {
 
                 let new_chapter = dailp::raw::CollectionChapter {
                     index_in_parent: index_i64,
-                    url_slug: chapter_url_slug.to_ascii_lowercase(),
+                    url_slug: slugify_ltree(chapter_url_slug),
                     chapter_name: cur_chapter_name,
                     document_short_name: doc_string,
                     id: None,

--- a/types/src/document.rs
+++ b/types/src/document.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AnnotatedForm, AudioSlice, Contributor, Database, Date, SourceAttribution, Translation,
-    TranslationBlock,
+    slugify, AnnotatedForm, AudioSlice, Contributor, Database, Date, SourceAttribution,
+    Translation, TranslationBlock,
 };
 use async_graphql::{dataloader::DataLoader, FieldResult, MaybeUndefined};
 use serde::{Deserialize, Serialize};
@@ -516,8 +516,8 @@ impl DocumentCollection {
     }
 
     /// URL-ready slug for this collection, generated from the name
-    async fn slug(&self) -> &str {
-        &self.slug
+    async fn slug(&self) -> String {
+        slugify(&self.slug)
     }
 
     /// All documents that are part of this collection

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -34,6 +34,7 @@ mod morpheme;
 pub mod page;
 mod person;
 pub mod raw;
+mod slugs;
 mod tag;
 mod translation;
 
@@ -54,5 +55,6 @@ pub use gloss::*;
 pub use lexical::*;
 pub use morpheme::*;
 pub use person::*;
+pub use slugs::*;
 pub use tag::*;
 pub use translation::*;

--- a/types/src/slugs.rs
+++ b/types/src/slugs.rs
@@ -1,0 +1,6 @@
+pub use slug::slugify;
+
+/// Turns a string into an ltree-friendly slug with underscores.
+pub fn slugify_ltree(s: impl AsRef<str>) -> String {
+    slug::slugify(s).replace("-", "_")
+}


### PR DESCRIPTION
- Collection slugs in the database (in an ltree) use underscores as a separator, and technically allow upper or lower case letters.
- On the website, we want all URL path segments to be lowercase with hyphens
- This change converts back and forth in the GraphQL layer