### PR TITLE
Provision AWS S3 bucket for media storage

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -19,39 +19,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:c079f98be9b8456e6eae6c07c5dcb84ecbcbb70b2f361f1c6f9c3ba90366d905",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/external" {
-  version = "2.1.1"
-  hashes = [
-    "h1:FfNpxpf69z2GW1sPLBY75JRvbPMKHVf2P9km9Ikn0ls=",
-    "zh:2726dcef652c01c718b6400ac22e598e7d296baa91ab5ea6d85bd94d1db229d9",
-    "zh:3923daa6deb847f88f0b1bf1481066f9d61f49557108945be7e2960cb1b61d0d",
-    "zh:3d8e894d60b362cb7fbdf22889d69f3c96a3c98ed2fec492dca28f52e07254e7",
-    "zh:43f1501519e2ee0dfa35c827cd2b24b4940a11d0348e77b20ad2d77bb22d9b11",
-    "zh:52e75f6c880ca5aa1175f288396101b625eb227ca8b89f31ff9be30e4280cfba",
-    "zh:6b0f7951cc9f4a7b06f399505d590fed637d07eacbae7781a7fab81dc6e26f99",
-    "zh:8d7103552cadda26c01230722184c0a7489515cfa8d1fabfc1aa95aecb5490f6",
-    "zh:962df74629cfefe8119b2dc23abc34bebd4bd0da506062732edca8dc4427c130",
-    "zh:b66e41a41140f5e1b960345fc91670dea12a9e1d23ea9dc2ad456cf9224e199d",
-    "zh:c4df3d6ea9dc6d8803f00400f4e075a43fa6ae9dac160b46c9de4b8714428f3d",
-    "zh:cab80dca018c63619fa7a9f71be329bb43f174a2b07f65ba608d59146a487a35",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/null" {
-  version = "3.1.0"
-  hashes = [
-    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
-    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
-    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
-    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
-    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
-    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
-    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
-    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
-    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
-    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
-    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
-    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
-  ]
-}

--- a/terraform/bootstrap.nix
+++ b/terraform/bootstrap.nix
@@ -5,6 +5,7 @@ with lib; {
       bucket = mkOption { type = str; };
       table = mkOption { type = str; };
     };
+    access_log_bucket = mkOption { type = str; };
     stage = mkOption { type = enum [ "dev" "prod" ]; };
     vpc = mkOption { type = str; };
     subnets = mkOption { type = attrsOf str; };
@@ -29,11 +30,7 @@ with lib; {
       tags = { "Terraform" = "true"; } // config.setup.global_tags;
       lifecycle.prevent_destroy = true;
       logging = {
-        # These logging buckets are externally managed.
-        target_bucket = if config.setup.stage == "dev" then
-          "s3-server-access-logs-783177801354"
-        else
-          "s3-server-access-logs-363539660090";
+        target_bucket = config.setup.access_log_bucket;
         target_prefix = "/${config.setup.state.bucket}";
       };
     };

--- a/terraform/main.nix
+++ b/terraform/main.nix
@@ -23,6 +23,7 @@ in {
     ./nu-tags.nix
     ./database-sql.nix
     ./bastion-host.nix
+    ./media-storage.nix
   ];
 
   # Gives all modules access to which stage we're deploying to, while also
@@ -95,4 +96,10 @@ in {
     availability_zone = getEnv "AWS_ZONE_PRIMARY";
     security_group_ids = [ "\${aws_security_group.nixos_test.id}" ];
   };
+
+  # These logging buckets are externally managed.
+  setup.access_log_bucket = if config.setup.stage == "dev" then
+    "s3-server-access-logs-783177801354"
+  else
+    "s3-server-access-logs-363539660090";
 }

--- a/terraform/media-storage.nix
+++ b/terraform/media-storage.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }: {
+  # Provision a bucket dedicated to media storage, especially audio files.
+  config.resource.aws_s3_bucket.media_storage = {
+    bucket = "dailp-${config.setup.stage}-media-storage";
+    tags = config.setup.global_tags;
+    acl = "private";
+    lifecycle.prevent_destroy = true;
+    # We don't need S3 to retain old versions of our media files, especially
+    # since NU takes backups anyway (I think).
+    versioning.enabled = false;
+
+    # Copied the rest from the bootstrap bucket.
+    logging = {
+      target_bucket = config.setup.access_log_bucket;
+      target_prefix = "/dailp-${config.setup.stage}-media-storage";
+    };
+    server_side_encryption_configuration.rule.apply_server_side_encryption_by_default =
+      {
+        sse_algorithm = "AES256";
+      };
+  };
+}


### PR DESCRIPTION
I took the following notes while I wrote this PR in two 25m pomodoros. I'm gonna go ahead and merge this, but @GracefulLemming leaving these notes here for you to read.

## Step 1: Create the S3 bucket

Add a new file, `terraform/media-storage.nix` and use terraform registry documentation to figure out how to add a new S3 bucket.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket

There's a lot there, so I also reference the `terraform/bootstrap.nix` file where we provision a bucket that holds just the terraform state.
I don't reuse that bucket for media storage because we want to have versioning on the terraform state and leave that completely isolated just to avoid messing it up.

Once I feel decent about it, I add `./media-storage.nix` to the list of imports in `terraform/main.nix`:

```nix
imports = [
./bootstrap.nix
./functions.nix
./auth.nix
./website.nix
./nu-tags.nix
./database-sql.nix
./bastion-host.nix
./media-storage.nix
];
```

## Step 2: Test out the config

Since the terraform config is written in nix and converted to JSON to feed terraform, we can't just run plain `terraform plan`.

Before I started, I made sure that in my `.env` file, I had the contents of the deployment key .pem file as `AWS_SSH_KEY`. For example:

```env
AWS_SSH_KEY="------BEGIN....
.....
....-----END RSA...."
```

I'm sure you could load it directly from a file, but I don't know how right now.
Just copy paste.

We have a shortcut prepared, `nix run .#tf-plan`, which is defined in `flake.nix` under `apps.tf-plan`
This isn't as simple a shortcut as `dev-database` because it does a full production build in order to deploy our lambda function(s).
We also have to run it with the `--impure` flag because our terraform config depends on secrets stored in environment variables (which mean the result varies with no changes to the config files, hence "impure").
Anyway, I ran `nix run .#tf-plan --impure` and had to wait a long time for my machine to do a full production build.

## Step 3: Interpret the diff

The output is what resource changes would happen if we ran `terraform apply` immediately in the current environment.
There may be a few changes based on local environment variables being different than our live secrets.
For example, my local `DATABASE_PASSWORD` value is different than the live one, so terraform thinks it needs to update `aws_db_instance.sql_database` right now.

At the end is the important part, where it says `aws_s3_bucket.media_storage` will be created.
This shows the final settings for our bucket.
The first few times I ran "plan", I had misconfigured the bucket, so I changed some values in `media-storage.nix` and re-ran it.
Once it looked pretty good, I was done!

Scrolling up, the output also says that `aws_api_gateway_deployment.functions_api` or `aws_lambda_function.graphql` will be updated.

```sh
# aws_api_gateway_deployment.functions_api must be replaced

-/+ resource "aws_api_gateway_deployment" "functions_api" {
~ created_date = "2023-02-09T21:13:04Z" -> (known after apply)
~ execution_arn = "arn:aws:execute-api:us-east-1:783177801354:twoa7ik1g7/dev" -> (known after apply)
~ id = "154fyv" -> (known after apply)
~ invoke_url = "https://twoa7ik1g7.execute-api.us-east-1.amazonaws.com/dev" -> (known after apply)
~ triggers = { # forces replacement
~ "config" = "118868611e9a8f437f1f10006cb32bfede78463a" -> "510c76049e3e1b093a2d86aa4deb877ea4960602"
~ "functions" = "0fc10299111c94ffa0ab63aa62d23a4633829470" -> "c90b57c486a0e112cbdd71e521b1296186c497e4" # (1 unchanged element hidden)
} # (2 unchanged attributes hidden)
}
```

This is because it built our back-end on a new system, meaning the binary is slightly different than the live deployment.
Again, we can safely ignore this.
However, keep an eye out for suspicious looking diffs that may point to our live resources drifting from our terraform config.

This step was mainly to make sure we wrote an actually valid configuration, and to confirm that the output looks correct.
We can still revise it later if we need to in further PRs.

At this point, I made a branch, pushed it, and made a PR.
The PR check called "plan" will double-check that I wrote something valid.
Plus, if I open the log, it shows me the actual changes that will be made, not just a rough estimate like when I ran plan locally.