### PR TITLE
Update db setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ dev-website
 
 If you run each of these commands in a separate shell, then you'll have a fully operational local test environment.
 If it's your first time running the project locally, your database is probably empty.
-With `dev-database` running, run the command `dev-migrate` to populate it with data from the DAILP spreadsheets.
+With `dev-database` running, run the `dev-migrate-schema` and `dev-migrate-data` commands to structure your database and populate it with data from the DAILP spreadsheets.
 
 ### Cleaning Up
 
@@ -67,6 +67,6 @@ With `dev-database` running, run the command `dev-migrate` to populate it with d
 However, this can take up a lot of disk space if you're making lots of code changes.
 To clean up the nix cache, simply run:
 
-``` sh
+```sh
 $ nix-collect-garbage
 ```


### PR DESCRIPTION
I was doing developer setup today and I think the name of the `dev-migrate` script must have changed at some point. I ran the following and got this error.
```sh
> dev-migrate
bash: dev-migrate: command not found
```

Now, after running `dev-migrate-schema` and `dev-migrate-data`, my local environment is working great, so I updated the README to have these two commands.

I also wanted to test if I could PR with my permissions on GitHub :)