### PR TITLE
Added compatibility with S3 buckets as audio input sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"

--- a/migration/src/audio.rs
+++ b/migration/src/audio.rs
@@ -1,38 +1,137 @@
+use anyhow::Ok;
 use dailp::{AudioSlice, DocumentAudioId};
-use itertools::Itertools;
 use log::{error, info};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap},
     time::Duration,
 };
 use tokio::time::sleep;
 
-/// The string ID for a DRS item, usu. prefixed with "neu:"
+/// Represents an identifier from Northeastern's Digital Repository Service (DRS)
+/// 
+/// DRS identifiers contain a 9-digit base-36 number prefixed with "neu:".
+/// An ID can refer to any kind of DSG object, including collections,
+/// object containers, and raw data (such as text, audio, or video).
+/// 
+/// Examples:
+/// 
+/// The DRS ID for a collection, ...
+/// ```
+/// let drs_collection_id = DrsId("neu:ww72bh375")
+/// ```
+///
+///  ... for an object container holding audio and metadata, ...
+/// ```
+/// let drs_audio_container_id = DrsId("neu:2r36v5312")
+/// ```
+/// 
+/// ... for raw audio data, ...
+/// ```
+/// let drs_audio_data_id = DrsId("neu:4f17r7213")
+/// ```
+/// 
+/// ... and for raw text data.
+/// ```
+/// let drs_text_data_id = DrsId("neu:bz613v117")
+/// ```
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct DrsId(String);
 
+/// Represents key-value pairs used to structure DRS data.
+/// 
+/// Currently, only supports data in the form `"url": "value"`,
+/// which is used for encoding the canonical object and content objects for a DRS entry.
+/// Note that [ComplexDrsObject]s are a tuple struct wrapping [HashMap].
+/// 
+/// Examples:
+/// 
+/// The following two examples assume an HTTP response with the following JSON snippet:
+/// ```text
+/// {
+///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content": "Audio File"
+/// }
+/// ```
+/// 
+/// Accessing data stored in a DRS Object
+/// ```
+/// # let body = "{'https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content': 'Audio File'}";
+/// # let some_drs_object = ComplexDrsObject(body);
+/// let drs_object_data : HashMap<String, Value> = some_drs_object.0;
+/// ```
+/// 
+/// Accessing a specific entry url
+/// ```
+/// # let body = "{'https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content': 'Audio File'}";
+/// # let drs_object_data = ComplexDrsObject(body).0;
+/// let drs_data_url : String = drs_object_data.keys().next();
+/// println!("{}", drs_data_url);
+/// ```
+/// 
+/// Responses can theoretically have a list of any length that we could want to parse, as shown below.
+/// ```text
+/// {
+///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content": "Audio File",
+///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk948?datastream_id=content": "Master Image"
+/// }
+/// ```
+/// To work with lists of any length, you can use functionality provied by [HashMap] as shown in the second example.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct ComplexDrsObject(HashMap<String, Value>);
 
-/// A file received from the DRS, following the DRS meta format
+impl ComplexDrsObject {
+    /// Returns the persistant identifier for the first entry in this object.
+    ///
+    /// This is most commonly used to retrieve the download url to a canonical resource associated
+    /// with an audio file or annotation file.
+    /// 
+    /// Example:
+    /// 
+    /// ```
+    /// # let body = "{'https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content': 'Audio File'}";
+    /// # let some_drs_object = ComplexDrsObject(body);
+    /// download_url = some_drs_object.get_first_object_pid();
+    /// println!("{}", download_url);
+    /// ```
+    /// 
+    /// Note: the example above demonstrates expected behavior for the JSON 
+    /// ```text
+    /// {
+    ///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content": "Audio File"
+    /// }
+    /// ```
+    /// and
+    /// ```text
+    /// {
+    ///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content": "Audio File",
+    ///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk948?datastream_id=content": "Master Image"
+    /// }
+    fn get_first_object_pid(&self) -> String {
+        self.0.keys().next().unwrap().clone()
+    }
+}
+
+/// Represents info associated with an object from the DRS.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct DrsRes {
     pid: DrsId,
-    // breadcrumbs: ComplexDrsObject,
     parent: DrsId,
     thumbnails: Vec<String>,
     canonical_object: ComplexDrsObject,
-    // content_objects: ComplexDrsObject,
 }
 
 impl DrsRes {
-    // TODO: flatten information held in ComplexDrsObjects
+    /// Creates a new DRS resource
+    /// 
+    /// # Errors
+    /// Fails if a connection with the DRS can not be established in a set number of tries
+    /// or if the response body cannot be deserialized properly.
     pub async fn new(client: &Client, drs_id: &str) -> Result<Self, anyhow::Error> {
         let drs = "https://repository.library.northeastern.edu/api/v1/files/";
         let mut tries = 0;
+        
         Ok(loop {
             let r = client
                 .get(format!("{}{}", drs, drs_id))
@@ -48,8 +147,15 @@ impl DrsRes {
             tries += 1;
         }?)
     }
+    /// Retrieves the content URL associated with a DRS resource
+    fn get_url(&self) -> String {
+        self.canonical_object.get_first_object_pid()
+    }
 }
 
+/// Represents annotation info associated with a single word
+/// 
+/// 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct AudioAnnotationRow {
     layer: Option<String>,
@@ -58,62 +164,93 @@ struct AudioAnnotationRow {
     word: String,
 }
 
-#[non_exhaustive]
-struct AudioLayer;
-
-impl AudioLayer {
-    pub const UNLABELLED: &'static str = "";
-    pub const DOCUMENT: &'static str = "Document";
-    pub const WORD: &'static str = "Syllabary Source";
-}
-
-/// Audio resource information served by the DRS.
+/// Represents an audio resource and its annotations from an online source.
+/// 
+/// At this moment, each [AudioRes] _must_ have annotations present.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AudioRes {
-    /// The URL for a DRS audio resource
+    /// The URL associated with an audio resource.
+    /// 
+    /// Currently, this URL will be from either the DRS or an S3 bucket.
     audio_url: String,
-    /// The raw text for a file marking words within a recording
+
+    /// Text holding start and end times for words contained within an audio file
+    /// 
+    /// Example Contents:
+    /// ```text
+    /// ᏓᎬᏃᎯᏎᎵ  6.26    6.39
+    /// ᎩᏅᏌ     6.48    6.54
+    /// ᎢᏂᏬᏂᏍᎬ  6.59    7.21
+    /// ```
     annotations: String,
 }
 
 impl AudioRes {
-    /// Calls the DRS API and collates the returned metadata
-    pub async fn new(audio_drs_id: &str, annotation_drs_id: &str) -> Result<Self, anyhow::Error> {
-        println!("Creating new Audio Resource...");
-        // Prepare to call the DRS repeatedly
-        let client = Client::new();
-        // Get the DRS object for the audio file, using a provided ID
-        let audio_response = DrsRes::new(&client, audio_drs_id).await?;
-        let annotation_response = DrsRes::new(&client, annotation_drs_id).await?;
+    /// Creates a new Audio Resource from an audio key and an annotaion key.
+    /// 
+    /// Keys should either be a resource string from the DRS or DAILP audio S3 Bucket.
+    /// As of now, both keys must be from the same source (DRS or S3).
 
-        Ok(Self {
-            // Keep the audio file url
-            audio_url: audio_response
-                .canonical_object
-                .0
-                .keys()
-                .next()
-                .unwrap()
-                .clone(),
-            // Dig deeper in the annotations to get the raw TSV text
-            annotations: client
-                .get(
-                    annotation_response
-                        .canonical_object
-                        .0
-                        .keys()
-                        .next()
-                        .unwrap()
-                        .clone(),
-                )
-                .send()
-                .await?
-                .text()
-                .await?,
-        })
+    pub async fn new(audio_ref_key: &str, annotation_ref_key: &str) -> Result<Self, anyhow::Error> {
+        println!("Creating new Audio Resource...");
+        let client = Client::new();
+        let is_drs_key = | test_value: &str| -> bool {
+            println!("{}", test_value);
+
+            return test_value.contains("neu");
+        };
+
+        if is_drs_key(audio_ref_key) || is_drs_key(annotation_ref_key) {
+            println!("Found DRS ID");
+
+            let audio_response = DrsRes::new(&client, audio_ref_key).await?;
+            let annotation_response = DrsRes::new(&client, annotation_ref_key).await?;
+
+            Ok(Self { 
+                audio_url: audio_response.get_url(),
+                annotations: Self::get_http_body(&client, annotation_response.get_url()).await?
+            })
+        } else {
+            println!("Found S3 Location");
+
+            let deploy_env = dotenv::var("VITE_DEPLOYMENT_ENV").unwrap();
+            let s3_location = 
+                format!("https://dailp-{}-media-storage.s3.{}.amazonaws.com",
+                if deploy_env.eq("local") {String::from("dev")} else {deploy_env},
+                dotenv::var("DAILP_AWS_REGION").unwrap());
+
+            println!("{}{}", s3_location, audio_ref_key);
+
+            Ok(Self {
+                audio_url: format!("{}{}", s3_location, audio_ref_key).to_owned(),
+                annotations:
+                Self::get_http_body(&client, format!("{}{}", s3_location, annotation_ref_key)).await?
+            })
+        }
+    }
+    
+    /// Tries to get the body response for a GET request to the provided url
+    /// 
+    /// # Errors
+    /// This method fails when:
+    /// - the URL is malformed
+    /// - no HTTP request could be made
+    /// - no HTTP response body is present
+    /// 
+    /// # Examples
+    /// Failure
+    /// ```
+    /// # let _client = Client::new()
+    /// get_http_body(client, String::new("https://www.examp;e.com/my-resource.csv"))
+    /// ```
+    /// 
+    async fn get_http_body(client: &Client, url: String) -> Result<String, anyhow::Error> {
+        Ok(client.get(url).send().await?.text().await?)
     }
 
-    /// Converts DRS response info to [AudioSlice]s based on segmentations in the annotation file
+    /// Converts this [AudioRes] into an [AudioSlice] representing audio for an entire document
+    /// 
+    /// Note: Documents cannot have parent tracks at this time.
     pub fn into_document_audio(self) -> AudioSlice {
         AudioSlice {
             resource_url: self.audio_url.clone(),
@@ -125,20 +262,23 @@ impl AudioRes {
         }
     }
 
-    /// Converts DRS response info to [AudioSlice]s based on segmentations in the annotation file
+    /// Converts this [AudioRes] to [AudioSlice]s based on segmentations in [AudioRes]' annotation field
+    /// 
+    /// Each row in the annotation field is encoded as one [AudioSlice], representing one word.
+    /// 
+    /// # Errors
+    /// Fails if annotation field does not meet structural requirements or is empty.
     pub fn into_audio_slices(self /*from_layer: String*/) -> Vec<AudioSlice> {
         let mut result: Vec<AudioSlice> = vec![];
-        use csv::{Error, ReaderBuilder};
+        use csv::ReaderBuilder;
+
         // Read in the annotation info
         let mut reader = ReaderBuilder::new()
             .delimiter(b'\t')
             .has_headers(false)
             .from_reader(self.annotations.as_bytes());
 
-        // Structure column info for all audio of the right layer
         for (annotation_line, i) in reader.deserialize::<AudioAnnotationRow>().zip(0..)
-        // TODO: Implement reading of Col 1 labels to assign audio to different "chunks" of documents
-        // .filter(Some(annotation_line.unwrap()) == from_layer)
         {
             if annotation_line.is_err() {
                 error!("Failed to add line {}", i);
@@ -157,7 +297,6 @@ impl AudioRes {
                     parent_track: Some(DocumentAudioId("".to_string())),
                     annotations: None,
                     index: i,
-                    // Perform calculation before converting to retain precision
                     start_time: Some((annotation.start_time * 1000.0) as i32),
                     end_time: Some((annotation.end_time * 1000.0) as i32),
                 });
@@ -173,3 +312,4 @@ impl AudioRes {
         result
     }
 }
+

--- a/migration/src/audio.rs
+++ b/migration/src/audio.rs
@@ -212,9 +212,8 @@ impl AudioRes {
                 .ok()
                 .unwrap_or_else(|| String::from("dev"));
 
-            let aws_region = std::env::var("AWS_ZONE_PRIMARY")
-                .ok()
-                .unwrap_or_else(|| String::from("us-east-1"));
+            // Will this always be us-east-1? If so, modify url base below.
+            let aws_region = String::from("us-east-1");
 
             let s3_location = format!(
                 "https://dailp-{}-media-storage.s3.{}.amazonaws.com",

--- a/migration/src/audio.rs
+++ b/migration/src/audio.rs
@@ -105,8 +105,11 @@ impl ComplexDrsObject {
     ///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content": "Audio File",
     ///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk948?datastream_id=content": "Master Image"
     /// }
-    fn get_first_object_pid(&self) -> String {
-        self.0.keys().next().unwrap().clone()
+    fn get_first_object_pid(&self) -> Option<&String> {
+        self
+        .0
+        .keys()
+        .next()
     }
 }
 
@@ -186,7 +189,11 @@ impl DrsRes {
     }
     /// Retrieves the content URL associated with a DRS resource
     fn get_url(&self) -> String {
-        self.canonical_object.get_first_object_pid()
+        let val = self.canonical_object.get_first_object_pid();
+        if val.is_none() {
+            String::from("")
+        }
+        val.unwrap().clone()
     }
 }
 

--- a/migration/src/audio.rs
+++ b/migration/src/audio.rs
@@ -212,13 +212,13 @@ impl AudioRes {
             })
         } else {
             println!("Found S3 Location");
-
-            let deploy_env = std::env::var("VITE_DEPLOYMENT_ENV")
-                .expect("VITE_DEPLOYMENT_ENV not found");
+            dotenv::dotenv().ok();
+            let deploy_env = std::env::var("VITE_DEPLOYMENT_ENV")?;
+            let aws_region = std::env::var("DAILP_AWS_REGION")?;
             let s3_location = 
                 format!("https://dailp-{}-media-storage.s3.{}.amazonaws.com",
                 if deploy_env.eq("local") {String::from("dev")} else {deploy_env},
-                std::env::var("DAILP_AWS_REGION").expect("DAILP_AWS_REGION not found"));
+                aws_region);
 
             println!("{}{}", s3_location, audio_ref_key);
 

--- a/migration/src/audio.rs
+++ b/migration/src/audio.rs
@@ -213,11 +213,12 @@ impl AudioRes {
         } else {
             println!("Found S3 Location");
 
-            let deploy_env = dotenv::var("VITE_DEPLOYMENT_ENV").unwrap();
+            let deploy_env = std::env::var("VITE_DEPLOYMENT_ENV")
+                .expect("VITE_DEPLOYMENT_ENV not found");
             let s3_location = 
                 format!("https://dailp-{}-media-storage.s3.{}.amazonaws.com",
                 if deploy_env.eq("local") {String::from("dev")} else {deploy_env},
-                dotenv::var("DAILP_AWS_REGION").unwrap());
+                std::env::var("DAILP_AWS_REGION").expect("DAILP_AWS_REGION not found"));
 
             println!("{}{}", s3_location, audio_ref_key);
 

--- a/migration/src/audio.rs
+++ b/migration/src/audio.rs
@@ -111,11 +111,51 @@ impl ComplexDrsObject {
 }
 
 /// Represents info associated with an object from the DRS.
+/// 
+/// # Examples:
+/// The HTTP Response
+/// ```text
+/// {
+///     "pid": "neu:br86b3634",
+///     "parent": "neu:n009w288x",
+///     "thumbnails": [
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_1",
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_2",
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_3",
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_4",
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_5"
+///         ],
+///     "canonical_object": {
+///         "https://repository.library.northeastern.edu/downloads/neu:4f173836n?datastream_id=content": "Audio File"
+///     },
+/// }
+/// ```
+/// becomes
+/// ```
+/// DrsRes {
+///     pid = "neu:br86b3634",
+///     parent = "neu:n009w288x",
+///     thumbnails = vec::new([
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_1",
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_2",
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_3",
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_4",
+///         "https://repository.library.northeastern.edu/downloads/neu:4f1738386?datastream_id=thumbnail_5"
+///     ])
+///     canonical_object: ComplexDrsObject(["https://repository.library.northeastern.edu/downloads/neu:4f173836n?datastream_id=content": "Audio File"])
+/// }
+/// ```
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct DrsRes {
+    /// The PID for a DRS Object. Takes the form "neu:XXXXXXXXX"
     pid: DrsId,
+    /// The PID for the parent collection of this object.
     parent: DrsId,
+    /// A list of URLs leading to this object's thumbnail image.
+    /// 
+    /// Each URL represents a different size of image.
     thumbnails: Vec<String>,
+    /// The primary data associated with this object and its data type.
     canonical_object: ComplexDrsObject,
 }
 
@@ -150,9 +190,10 @@ impl DrsRes {
     }
 }
 
-/// Represents annotation info associated with a single word
+/// Represents one line of an audio annotation table
 ///
-///
+/// One line typically represents one word, structured as
+/// Annotation Layer (optional) | Annotation Start Time | Annotation End Time | Annotation Text
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct AudioAnnotationRow {
     layer: Option<String>,

--- a/migration/src/audio.rs
+++ b/migration/src/audio.rs
@@ -4,20 +4,17 @@ use log::{error, info};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{
-    collections::{HashMap},
-    time::Duration,
-};
+use std::{collections::HashMap, time::Duration};
 use tokio::time::sleep;
 
 /// Represents an identifier from Northeastern's Digital Repository Service (DRS)
-/// 
+///
 /// DRS identifiers contain a 9-digit base-36 number prefixed with "neu:".
 /// An ID can refer to any kind of DSG object, including collections,
 /// object containers, and raw data (such as text, audio, or video).
-/// 
+///
 /// Examples:
-/// 
+///
 /// The DRS ID for a collection, ...
 /// ```
 /// let drs_collection_id = DrsId("neu:ww72bh375")
@@ -27,12 +24,12 @@ use tokio::time::sleep;
 /// ```
 /// let drs_audio_container_id = DrsId("neu:2r36v5312")
 /// ```
-/// 
+///
 /// ... for raw audio data, ...
 /// ```
 /// let drs_audio_data_id = DrsId("neu:4f17r7213")
 /// ```
-/// 
+///
 /// ... and for raw text data.
 /// ```
 /// let drs_text_data_id = DrsId("neu:bz613v117")
@@ -41,27 +38,27 @@ use tokio::time::sleep;
 struct DrsId(String);
 
 /// Represents key-value pairs used to structure DRS data.
-/// 
+///
 /// Currently, only supports data in the form `"url": "value"`,
 /// which is used for encoding the canonical object and content objects for a DRS entry.
 /// Note that [ComplexDrsObject]s are a tuple struct wrapping [HashMap].
-/// 
+///
 /// Examples:
-/// 
+///
 /// The following two examples assume an HTTP response with the following JSON snippet:
 /// ```text
 /// {
 ///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content": "Audio File"
 /// }
 /// ```
-/// 
+///
 /// Accessing data stored in a DRS Object
 /// ```
 /// # let body = "{'https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content': 'Audio File'}";
 /// # let some_drs_object = ComplexDrsObject(body);
 /// let drs_object_data : HashMap<String, Value> = some_drs_object.0;
 /// ```
-/// 
+///
 /// Accessing a specific entry url
 /// ```
 /// # let body = "{'https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content': 'Audio File'}";
@@ -69,7 +66,7 @@ struct DrsId(String);
 /// let drs_data_url : String = drs_object_data.keys().next();
 /// println!("{}", drs_data_url);
 /// ```
-/// 
+///
 /// Responses can theoretically have a list of any length that we could want to parse, as shown below.
 /// ```text
 /// {
@@ -86,17 +83,17 @@ impl ComplexDrsObject {
     ///
     /// This is most commonly used to retrieve the download url to a canonical resource associated
     /// with an audio file or annotation file.
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```
     /// # let body = "{'https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content': 'Audio File'}";
     /// # let some_drs_object = ComplexDrsObject(body);
     /// download_url = some_drs_object.get_first_object_pid();
     /// println!("{}", download_url);
     /// ```
-    /// 
-    /// Note: the example above demonstrates expected behavior for the JSON 
+    ///
+    /// Note: the example above demonstrates expected behavior for the JSON
     /// ```text
     /// {
     ///     "https://repository.library.northeastern.edu/downloads/neu:4f18fk930?datastream_id=content": "Audio File"
@@ -124,14 +121,14 @@ struct DrsRes {
 
 impl DrsRes {
     /// Creates a new DRS resource
-    /// 
+    ///
     /// # Errors
     /// Fails if a connection with the DRS can not be established in a set number of tries
     /// or if the response body cannot be deserialized properly.
     pub async fn new(client: &Client, drs_id: &str) -> Result<Self, anyhow::Error> {
         let drs = "https://repository.library.northeastern.edu/api/v1/files/";
         let mut tries = 0;
-        
+
         Ok(loop {
             let r = client
                 .get(format!("{}{}", drs, drs_id))
@@ -154,8 +151,8 @@ impl DrsRes {
 }
 
 /// Represents annotation info associated with a single word
-/// 
-/// 
+///
+///
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct AudioAnnotationRow {
     layer: Option<String>,
@@ -165,17 +162,17 @@ struct AudioAnnotationRow {
 }
 
 /// Represents an audio resource and its annotations from an online source.
-/// 
+///
 /// At this moment, each [AudioRes] _must_ have annotations present.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AudioRes {
     /// The URL associated with an audio resource.
-    /// 
+    ///
     /// Currently, this URL will be from either the DRS or an S3 bucket.
     audio_url: String,
 
     /// Text holding start and end times for words contained within an audio file
-    /// 
+    ///
     /// Example Contents:
     /// ```text
     /// ᏓᎬᏃᎯᏎᎵ  6.26    6.39
@@ -187,16 +184,14 @@ pub struct AudioRes {
 
 impl AudioRes {
     /// Creates a new Audio Resource from an audio key and an annotaion key.
-    /// 
+    ///
     /// Keys should either be a resource string from the DRS or DAILP audio S3 Bucket.
     /// As of now, both keys must be from the same source (DRS or S3).
 
     pub async fn new(audio_ref_key: &str, annotation_ref_key: &str) -> Result<Self, anyhow::Error> {
         println!("Creating new Audio Resource...");
         let client = Client::new();
-        let is_drs_key = | test_value: &str| -> bool {
-            println!("{}", test_value);
-
+        let is_drs_key = |test_value: &str| -> bool {
             return test_value.contains("neu");
         };
 
@@ -206,51 +201,60 @@ impl AudioRes {
             let audio_response = DrsRes::new(&client, audio_ref_key).await?;
             let annotation_response = DrsRes::new(&client, annotation_ref_key).await?;
 
-            Ok(Self { 
+            Ok(Self {
                 audio_url: audio_response.get_url(),
-                annotations: Self::get_http_body(&client, annotation_response.get_url()).await?
+                annotations: Self::get_http_body(&client, annotation_response.get_url()).await?,
             })
         } else {
             println!("Found S3 Location");
             dotenv::dotenv().ok();
-            let deploy_env = std::env::var("VITE_DEPLOYMENT_ENV")?;
-            let aws_region = std::env::var("DAILP_AWS_REGION")?;
-            let s3_location = 
-                format!("https://dailp-{}-media-storage.s3.{}.amazonaws.com",
-                if deploy_env.eq("local") {String::from("dev")} else {deploy_env},
-                aws_region);
+            let deploy_env = std::env::var("TF_STAGE")
+                .ok()
+                .unwrap_or_else(|| String::from("dev"));
+
+            let aws_region = std::env::var("AWS_ZONE_PRIMARY")
+                .ok()
+                .unwrap_or_else(|| String::from("us-east-1"));
+
+            let s3_location = format!(
+                "https://dailp-{}-media-storage.s3.{}.amazonaws.com",
+                deploy_env, aws_region
+            );
 
             println!("{}{}", s3_location, audio_ref_key);
 
             Ok(Self {
                 audio_url: format!("{}{}", s3_location, audio_ref_key).to_owned(),
-                annotations:
-                Self::get_http_body(&client, format!("{}{}", s3_location, annotation_ref_key)).await?
+                annotations: Self::get_http_body(
+                    &client,
+                    format!("{}{}", s3_location, annotation_ref_key),
+                )
+                .await?,
             })
         }
     }
-    
+
     /// Tries to get the body response for a GET request to the provided url
-    /// 
+    ///
     /// # Errors
     /// This method fails when:
     /// - the URL is malformed
     /// - no HTTP request could be made
     /// - no HTTP response body is present
-    /// 
+    ///
     /// # Examples
     /// Failure
     /// ```
     /// # let _client = Client::new()
     /// get_http_body(client, String::new("https://www.examp;e.com/my-resource.csv"))
     /// ```
-    /// 
+    ///
     async fn get_http_body(client: &Client, url: String) -> Result<String, anyhow::Error> {
         Ok(client.get(url).send().await?.text().await?)
     }
 
     /// Converts this [AudioRes] into an [AudioSlice] representing audio for an entire document
-    /// 
+    ///
     /// Note: Documents cannot have parent tracks at this time.
     pub fn into_document_audio(self) -> AudioSlice {
         AudioSlice {
@@ -264,9 +268,9 @@ impl AudioRes {
     }
 
     /// Converts this [AudioRes] to [AudioSlice]s based on segmentations in [AudioRes]' annotation field
-    /// 
+    ///
     /// Each row in the annotation field is encoded as one [AudioSlice], representing one word.
-    /// 
+    ///
     /// # Errors
     /// Fails if annotation field does not meet structural requirements or is empty.
     pub fn into_audio_slices(self /*from_layer: String*/) -> Vec<AudioSlice> {
@@ -279,8 +283,7 @@ impl AudioRes {
             .has_headers(false)
             .from_reader(self.annotations.as_bytes());
 
-        for (annotation_line, i) in reader.deserialize::<AudioAnnotationRow>().zip(0..)
-        {
+        for (annotation_line, i) in reader.deserialize::<AudioAnnotationRow>().zip(0..) {
             if annotation_line.is_err() {
                 error!("Failed to add line {}", i);
                 result.push(AudioSlice {
@@ -313,4 +316,3 @@ impl AudioRes {
         result
     }
 }
-

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -12,7 +12,7 @@ mod translations;
 
 use anyhow::Result;
 use dailp::{Database, Uuid};
-use log::{error, info};
+use log::{error};
 use std::time::Duration;
 
 pub const METADATA_SHEET_NAME: &str = "Metadata";


### PR DESCRIPTION
Extended data migration to use DAILP's media S3 bucket.
Briefly tested on browser (Safari on Mac) using EFN2 - Child of Igakala as test file.