### PR TITLE
Database migrations for contributor audio and curation

### DIFF
--- a/doc/database/media.md
+++ b/doc/database/media.md
@@ -5,12 +5,12 @@
 A timed media resource like video or audio, from an external source.
 The main use case is audio recordings of each document.
 
-| column        | type            | description                                                                                  |
-| ------------- | --------------- | -------------------------------------------------------------------------------------------- |
-| `id`          | `uuid`          | Primary key                                                                                  |
-| `url`         | `text`          | Full URL for this media resource                                                             |
-| `recorded_at` | `date?`         | Date and time this resource was created                                                      |
-| `recorded_by` | `uuid? -> user` | The user that recorded this audio, if the audio was recorded by a Contributor on the website |
+| column        | type                  | description                                                                                  |
+| ------------- | --------------------- | -------------------------------------------------------------------------------------------- |
+| `id`          | `uuid`                | Primary key                                                                                  |
+| `url`         | `text`                | Full URL for this media resource                                                             |
+| `recorded_at` | `date?`               | Date and time this resource was created                                                      |
+| `recorded_by` | `uuid? -> dailp_user` | The user that recorded this audio, if the audio was recorded by a Contributor on the website |
 
 - Deleting also deletes all `media_slice` rows that reference it
 

--- a/doc/database/media.md
+++ b/doc/database/media.md
@@ -5,11 +5,12 @@
 A timed media resource like video or audio, from an external source.
 The main use case is audio recordings of each document.
 
-| column        | type    | description                             |
-| ------------- | ------- | --------------------------------------- |
-| `id`          | `uuid`  | Primary key                             |
-| `url`         | `text`  | Full URL for this media resource        |
-| `recorded_at` | `date?` | Date and time this resource was created |
+| column        | type            | description                                                                                 |
+| ------------- | --------------- | ------------------------------------------------------------------------------------------- |
+| `id`          | `uuid`          | Primary key                                                                                 |
+| `url`         | `text`          | Full URL for this media resource                                                            |
+| `recorded_at` | `date?`         | Date and time this resource was created                                                     |
+| `recorded_by` | `uuid? -> user` | Unique ID of the user that recorded this audio, if the audio was recorded by a contributor. |
 
 - Deleting also deletes all `media_slice` rows that reference it
 

--- a/doc/database/media.md
+++ b/doc/database/media.md
@@ -5,12 +5,12 @@
 A timed media resource like video or audio, from an external source.
 The main use case is audio recordings of each document.
 
-| column        | type            | description                                                                                 |
-| ------------- | --------------- | ------------------------------------------------------------------------------------------- |
-| `id`          | `uuid`          | Primary key                                                                                 |
-| `url`         | `text`          | Full URL for this media resource                                                            |
-| `recorded_at` | `date?`         | Date and time this resource was created                                                     |
-| `recorded_by` | `uuid? -> user` | Unique ID of the user that recorded this audio, if the audio was recorded by a contributor. |
+| column        | type            | description                                                                                  |
+| ------------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `id`          | `uuid`          | Primary key                                                                                  |
+| `url`         | `text`          | Full URL for this media resource                                                             |
+| `recorded_at` | `date?`         | Date and time this resource was created                                                      |
+| `recorded_by` | `uuid? -> user` | The user that recorded this audio, if the audio was recorded by a Contributor on the website |
 
 - Deleting also deletes all `media_slice` rows that reference it
 

--- a/doc/database/readme.md
+++ b/doc/database/readme.md
@@ -4,6 +4,19 @@ The docs here describe every single one of our database tables and columns.
 If you write a database schema migration, you should change the corresponding docs in this folder to match the new shape of the database.
 If you work with database tables that aren't sufficiently documented here, please add!
 
+## How to write a new migration
+
+To create a migration file, use the follow command inside your `nix develop` shell.
+
+```zsh
+cd types
+sqlx migrate add <migration_description>
+```
+
+To test your migration without clearing your database, run `sqlx migrate run`.
+
+Other developers will get your migrations when they run `dev-migrate-schema`.
+
 ## Abbreviations in this Folder
 
 Most of our columns are `not null`, which is long to write so we introduced shorthand for describing database columns.

--- a/doc/database/readme.md
+++ b/doc/database/readme.md
@@ -33,3 +33,4 @@ Most of our columns are `not null`, which is long to write so we introduced shor
 - [collections](./collections.md): Edited collections tables
 - [words](./words.md): Words, word parts, and abbreviation systems
 - [media](./media.md): Audio and image resources
+- [user](./user.md): User account records

--- a/doc/database/user.md
+++ b/doc/database/user.md
@@ -2,7 +2,9 @@
 
 ## `user`
 
-Metadata assocated with a user. `user.id` on this table is equal to `sub` in AWS.
+Metadata assocated with a user. `user.id` on this table is equal to `sub` in
+AWS. Users are not to be confused with `contributor` entires, which are imported
+from Google Sheets.
 
 | column         | type    | description                                        |
 | -------------- | ------- | -------------------------------------------------- |

--- a/doc/database/user.md
+++ b/doc/database/user.md
@@ -1,0 +1,12 @@
+# User
+
+## `user`
+
+Metadata assocated with a user. `user.id` on this table is equal to `sub` in AWS.
+
+| column         | type    | description                                        |
+| -------------- | ------- | -------------------------------------------------- |
+| `id`           | `uuid`  | Primary key, AWS Cognito `sub` claim               |
+| `display_name` | `text`  | How the user's name should be presented in the app |
+| `created_at`   | `date`  | When the user record was created                   |
+| `archived_at`  | `date?` | When the user record was archived, if ever         |

--- a/doc/database/user.md
+++ b/doc/database/user.md
@@ -1,14 +1,13 @@
 # User
 
-## `user`
+## `dailp_user`
 
-Metadata assocated with a user. `user.id` on this table is equal to `sub` in
+Metadata assocated with a user. `dailp_user.id` on this table is equal to `sub` in
 AWS. Users are not to be confused with `contributor` entires, which are imported
 from Google Sheets.
 
-| column         | type    | description                                        |
-| -------------- | ------- | -------------------------------------------------- |
-| `id`           | `uuid`  | Primary key, AWS Cognito `sub` claim               |
-| `display_name` | `text`  | How the user's name should be presented in the app |
-| `created_at`   | `date`  | When the user record was created                   |
-| `archived_at`  | `date?` | When the user record was archived, if ever         |
+| column         | type   | description                                        |
+| -------------- | ------ | -------------------------------------------------- |
+| `id`           | `uuid` | Primary key, AWS Cognito `sub` claim               |
+| `display_name` | `text` | How the user's name should be presented in the app |
+| `created_at`   | `date` | When the user record was created                   |

--- a/doc/database/words.md
+++ b/doc/database/words.md
@@ -11,9 +11,9 @@
 | `english_gloss`          | `text?`                  | English translation                                                                                 |
 | `recorded_at`            | `date?`                  | When this word was written, only specified if it differs from when the document overall was written |
 | `commentary`             | `text?`                  | Linguistic or historical commentary supplied by an annotator                                        |
-| `audio_slice_id`         | `uuid? -> media_slice`   | Audio recording of the word read aloud                                                              |
+| `audio_slice_id`         | `uuid? -> media_slice`   | Audio recording of the word read aloud, as ingested from Google Sheets.                             |
 | `curated_audio_slice_id` | `uuid? -> media_slice`   | A Contributor audio recording of the word read aloud, which has been selected by an Editor          |
-| `audio_curated_by`       | `uuid? -> user`          | The Editor who selected the Contributor audio recording to show, if one has been selected.          |
+| `audio_curated_by`       | `uuid? -> user`          | The Editor who selected the Contributor audio recording to show, if one has been selected           |
 | `document_id`            | `uuid -> document`       | Document the word is in                                                                             |
 | `page_number`            | `text?`                  | Page number, only supplied for documents like dictionaries that may not have `document_page` rows   |
 | `index_in_document`      | `bigint`                 | Position of the word in the whole document                                                          |
@@ -22,7 +22,7 @@
 
 - One of `page_id` or `character_range` must be supplied
 
-## `word_contributor_media`
+## `word_user_media`
 
 A join table linking user audio contributions to words in documents. This is a many-to-many relationship, so should be indexed on both keys, with a compound unique constraint. Ie. you cannot link the same audio to the same word multiple times. Additions should be written as upserts.
 

--- a/doc/database/words.md
+++ b/doc/database/words.md
@@ -13,7 +13,7 @@
 | `commentary`             | `text?`                  | Linguistic or historical commentary supplied by an annotator                                        |
 | `audio_slice_id`         | `uuid? -> media_slice`   | Audio recording of the word read aloud, as ingested from Google Sheets.                             |
 | `curated_audio_slice_id` | `uuid? -> media_slice`   | A Contributor audio recording of the word read aloud, which has been selected by an Editor          |
-| `audio_curated_by`       | `uuid? -> user`          | The Editor who selected the Contributor audio recording to show, if one has been selected           |
+| `audio_curated_by`       | `uuid? -> dailp_user`    | The Editor who selected the Contributor audio recording to show, if one has been selected           |
 | `document_id`            | `uuid -> document`       | Document the word is in                                                                             |
 | `page_number`            | `text?`                  | Page number, only supplied for documents like dictionaries that may not have `document_page` rows   |
 | `index_in_document`      | `bigint`                 | Position of the word in the whole document                                                          |

--- a/doc/database/words.md
+++ b/doc/database/words.md
@@ -2,23 +2,34 @@
 
 ## `word`
 
-| column              | type                     | description                                                                                         |
-| ------------------- | ------------------------ | --------------------------------------------------------------------------------------------------- |
-| `id`                | `uuid`                   | Primary key                                                                                         |
-| `source_text`       | `text`                   | Unambiguous transcription of the whole word                                                         |
-| `simple_phonetics`  | `text?`                  | Romanized phonetic spelling                                                                         |
-| `phonemic`          | `text?`                  | Underlying phonemic representation, with more pronunciation details                                 |
-| `english_gloss`     | `text?`                  | English translation                                                                                 |
-| `recorded_at`       | `date?`                  | When this word was written, only specified if it differs from when the document overall was written |
-| `commentary`        | `text?`                  | Linguistic or historical commentary supplied by an annotator                                        |
-| `audio_slice_id`    | `uuid? -> media_slice`   | Audio recording of the word read aloud                                                              |
-| `document_id`       | `uuid -> document`       | Document the word is in                                                                             |
-| `page_number`       | `text?`                  | Page number, only supplied for documents like dictionaries that may not have `document_page` rows   |
-| `index_in_document` | `bigint`                 | Position of the word in the whole document                                                          |
-| `page_id`           | `uuid? -> document_page` | Physical page containing this word                                                                  |
-| `character_range`   | `int8range?`             | Order of words in a paragraph is determined by character indices                                    |
+| column                   | type                     | description                                                                                         |
+| ------------------------ | ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `id`                     | `uuid`                   | Primary key                                                                                         |
+| `source_text`            | `text`                   | Unambiguous transcription of the whole word                                                         |
+| `simple_phonetics`       | `text?`                  | Romanized phonetic spelling                                                                         |
+| `phonemic`               | `text?`                  | Underlying phonemic representation, with more pronunciation details                                 |
+| `english_gloss`          | `text?`                  | English translation                                                                                 |
+| `recorded_at`            | `date?`                  | When this word was written, only specified if it differs from when the document overall was written |
+| `commentary`             | `text?`                  | Linguistic or historical commentary supplied by an annotator                                        |
+| `audio_slice_id`         | `uuid? -> media_slice`   | Audio recording of the word read aloud                                                              |
+| `curated_audio_slice_id` | `uuid? -> media_slice`   | A Contributor audio recording of the word read aloud, which has been selected by an Editor          |
+| `audio_curated_by`       | `uuid? -> user`          | The Editor who selected the Contributor audio recording to show, if one has been selected.          |
+| `document_id`            | `uuid -> document`       | Document the word is in                                                                             |
+| `page_number`            | `text?`                  | Page number, only supplied for documents like dictionaries that may not have `document_page` rows   |
+| `index_in_document`      | `bigint`                 | Position of the word in the whole document                                                          |
+| `page_id`                | `uuid? -> document_page` | Physical page containing this word                                                                  |
+| `character_range`        | `int8range?`             | Order of words in a paragraph is determined by character indices                                    |
 
 - One of `page_id` or `character_range` must be supplied
+
+## `word_contributor_media`
+
+A join table linking user audio contributions to words in documents. This is a many-to-many relationship, so should be indexed on both keys, with a compound unique constraint. Ie. you cannot link the same audio to the same word multiple times. Additions should be written as upserts.
+
+| column           | type                  | description                              |
+| ---------------- | --------------------- | ---------------------------------------- |
+| `word_id`        | `uuid -> word`        | Word that is assocated with media slice. |
+| `media_slice_id` | `uuid -> media_slice` | Media slice that is assocated with word. |
 
 ## `word_segment`
 

--- a/types/migrations/20230504182127_add_user_audio.sql
+++ b/types/migrations/20230504182127_add_user_audio.sql
@@ -1,0 +1,27 @@
+-- Add migration script here
+
+create table dailp_user (
+  id autouuid primary key,
+  display_name text not null,
+  created_at date not null
+);
+
+alter table media_resource
+    add column recorded_by uuid,
+    add constraint recorded_by_fkey foreign key (recorded_by) references dailp_user (id) on delete set null;
+
+
+alter table word
+    add column curated_audio_slice_id uuid,
+    add constraint curated_audio_slice_id_fkey
+        foreign key (curated_audio_slice_id) references media_slice (id) on delete set null,
+    add column audio_curated_by uuid,
+    add constraint audio_curated_by_fkey
+        foreign key (audio_curated_by) references dailp_user (id) on delete set null;
+
+
+create table word_user_media (
+    word_id uuid not null references word (id) on delete cascade,
+    media_slice_id uuid not null references media_slice (id) on delete cascade,
+    primary key (word_id, media_slice_id)
+);


### PR DESCRIPTION
_**Before anything else, I recommend the rich diff tool for reading the Markdown table changes!**_

# Tracking

This is required to ship these two tickets.
[[DP-186] As a contributor, I want the ability to upload audio to DAILP](https://dailp.atlassian.net/browse/DP-186?atlOrigin=eyJpIjoiNDI2ODY4MzY4YjVkNDk2ZjljNzcxNThjMzdkOGE4ZjYiLCJwIjoiaiJ9)
[[DP-200] As a contributor, I want to be able to see user contributed audio](https://dailp.atlassian.net/browse/DP-200?atlOrigin=eyJpIjoiYjc5NmY4NmJjNGRmNGQ0NGJhM2IzMmZjYzNlM2UzNzMiLCJwIjoiaiJ9)

# Context
We have three main kinds of users _Contributors_, _Editors_, and _Readers_. 

- _Contributors_ should be able to upload their own readings of individual words on the site
- _Contributors_ and _Editors_ should be able to see all other contributor audio
- _Editors_ should be able to select one of the user-contributed audios to be shown to _Readers_
- _Readers_ should only see _curated_ audio
- _Curated_ audio is either selected by an _Editor_ or ingested via the big migration process from Google Sheets

# Related work
I have a frontend PR (#268) going for this stuff, which will eventually include the GQL mutations that touch this stuff. I want to do these DB migrations on their own so that PR doesn't get any bigger.