### PR TITLE
Add cache invalidation to prerendering

### DIFF
--- a/website/src/graphql.ts
+++ b/website/src/graphql.ts
@@ -30,8 +30,13 @@ export function useWpQuery<Data, Variables extends AnyVariables>(
 }
 
 export const sharedCache = cacheExchange
-// export const sharedSsr = ssrExchange({ isClient: true, initialState: {} })
-export const sharedSsr = null
+export const sharedSsr = ssrExchange({
+  isClient: true,
+  initialState: {},
+  // this let's us rehydrate our pages quickly but still get the most updated
+  // date in a timely manner
+  staleWhileRevalidate: true,
+})
 
 export const serverSideClients = {
   dailp: createClient({
@@ -61,88 +66,3 @@ export const customClient = (
     suspense,
     fetch,
   })
-
-// export const withGraphQL = (component) =>
-//   withUrqlClientBase(
-//     (ssrExchange, ctx) => ({
-//       url: GRAPHQL_URL,
-//       exchanges: [dedupExchange, sharedCache, ssrExchange, fetchExchange],
-//     }),
-//     { ssr: false }
-//   )(component)
-
-// export async function getStaticQueries(
-//   dailpQuery?: (client: Client) => any[],
-//   wpQuery?: (client: Client) => any[]
-// ) {
-//   const ssrCache = ssrExchange({ isClient: false })
-//   if (dailpQuery) {
-//     const dailp = initUrqlClient(
-//       {
-//         url: GRAPHQL_URL,
-//         exchanges: [dedupExchange, sharedCache, ssrCache, fetchExchange],
-//       },
-//       false
-//     )
-//     const qs = dailpQuery(dailp)
-//     for (const q of qs) {
-//       await q.toPromise()
-//     }
-//   }
-
-//   if (wpQuery) {
-//     const wp = initUrqlClient(
-//       {
-//         url: WP_GRAPHQL_URL,
-//         exchanges: [dedupExchange, sharedCache, ssrCache, fetchExchange],
-//       },
-//       false
-//     )
-//     const qs = wpQuery(wp)
-//     for (const q of qs) {
-//       await q.toPromise()
-//     }
-//   }
-
-//   return {
-//     props: {
-//       urqlState: ssrCache.extractData(),
-//     },
-//   }
-// }
-
-// export function getStaticQueriesNew(
-//   makeQueries: (params: any, dailp: Client, wordpress: Client) => Promise<any>
-// ) {
-//   return async ({ params }) => {
-//     if (process.env.NODE_ENV === "development") {
-//       return { props: params || {} }
-//     }
-
-//     const ssrCache = ssrExchange({ isClient: false })
-//     const dailp = initUrqlClient(
-//       {
-//         url: GRAPHQL_URL,
-//         exchanges: [dedupExchange, sharedCache, ssrCache, fetchExchange],
-//       },
-//       false
-//     )
-
-//     const wp = initUrqlClient(
-//       {
-//         url: WP_GRAPHQL_URL,
-//         exchanges: [dedupExchange, sharedCache, ssrCache, fetchExchange],
-//       },
-//       false
-//     )
-
-//     const pageProps = (await makeQueries(params, dailp, wp)) || {}
-
-//     return {
-//       props: {
-//         urqlState: ssrCache.extractData(),
-//         ...pageProps,
-//       },
-//     }
-//   }
-// }

--- a/website/src/graphql.ts
+++ b/website/src/graphql.ts
@@ -33,7 +33,7 @@ export const sharedCache = cacheExchange
 export const sharedSsr = ssrExchange({
   isClient: true,
   initialState: {},
-  // this let's us rehydrate our pages quickly but still get the most updated
+  // this lets us rehydrate our pages quickly but still get the most updated
   // date in a timely manner
   staleWhileRevalidate: true,
 })

--- a/website/src/graphql/client.ts
+++ b/website/src/graphql/client.ts
@@ -8,7 +8,7 @@ export const graphqlClient = (token: string | null) =>
     exchanges: [
       dedupExchange,
       sharedCache,
-      // sharedSsr,
+      sharedSsr,
       ...(token ? [authLink(token)] : []),
       fetchExchange,
     ],

--- a/website/src/renderer/_default.page.client.tsx
+++ b/website/src/renderer/_default.page.client.tsx
@@ -7,19 +7,13 @@ import { PageContext, PageShell, rootElementId } from "./PageShell"
 
 async function getClient() {
   const token = await getCredentials()
-  return customClient(
-    false,
-    [
-      //sharedSsr
-    ],
-    token
-  )
+  return customClient(false, [sharedSsr], token)
 }
 let clientPromise: null | Promise<Client> = null
 
 export async function render(pageContext: PageContext) {
   const { urqlState } = pageContext
-  // sharedSsr.restoreData(urqlState)
+  sharedSsr.restoreData(urqlState)
   const client = clientPromise
     ? await clientPromise
     : await (clientPromise = getClient())


### PR DESCRIPTION
Add `ssrExchange` back with `staleWhileRevalidate` caching.
This reverts commit a75c5eb8ce44504eba6c09d0ebc9f25d168bd376.

This means pages will load with the pre-rendered content immediately, but will fire network requests at the same time to get more update data.