### PR TITLE
add dailp identity pool to amplify env

### DIFF
--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -61,6 +61,7 @@ with builtins; {
             DAILP_AWS_REGION = config.provider.aws.region;
             DAILP_USER_POOL = "\${aws_cognito_user_pool.main.id}";
             DAILP_USER_POOL_CLIENT = "\${aws_cognito_user_pool_client.main.id}";
+            DAILP_IDENTITY_POOL = getEnv "DAILP_IDENTITY_POOL";
             TF_STAGE = config.setup.stage;
             VITE_DEPLOYMENT_ENV = config.setup.stage;
           };


### PR DESCRIPTION
Env variable values are used here since Identities are not yet managed by TF, although this work is ongoing in another branch.