### PR TITLE
log groups and roles

### DIFF
--- a/website/src/components/edit-word-audio/index.tsx
+++ b/website/src/components/edit-word-audio/index.tsx
@@ -7,8 +7,10 @@ import { EditorEditWordAudio } from "./editor"
 export const EditWordAudio = (p: {
   word: Dailp.FormFieldsFragment
 }): ReactElement => {
+  const groups = useCognitoUserGroups()
   const userRole = useUserRole()
-  // const userRole = UserRole.CONTRIBUTOR
+
+  console.log("Branching based on", { groups, userRole })
 
   switch (userRole) {
     case UserRole.CONTRIBUTOR:


### PR DESCRIPTION
In dev, we seem to be getting the Contributor view even when signed in as an Editor.
On local, I see the right view based on my user groups / role.

I'm not sure why, so maybe this will help.