### PR TITLE
Resolve-staging-resource-conflicts

### DIFF
--- a/terraform/auth.nix
+++ b/terraform/auth.nix
@@ -3,14 +3,14 @@
 {
   config.resource = {
     aws_cognito_user_pool.main = {
-      name = "dailp-user-pool";
+      name = prefixName "user-pool";
       username_attributes = [ "email" ];
       auto_verified_attributes = [ "email" ];
       admin_create_user_config.allow_admin_create_user_only = true;
     };
 
     aws_cognito_user_pool_client.main = {
-      name = "dailp-user-pool-client";
+      name = prefixName "user-pool-client";
       user_pool_id = "\${aws_cognito_user_pool.main.id}";
       allowed_oauth_flows = [ "implicit" ];
       allowed_oauth_flows_user_pool_client = true;

--- a/terraform/auth.nix
+++ b/terraform/auth.nix
@@ -1,6 +1,8 @@
 { config, lib, pkgs, ... }:
-
-{
+let 
+  utils = import ./utils.nix;
+  prefixName = utils.prefixName;
+in {
   config.resource = {
     aws_cognito_user_pool.main = {
       name = prefixName "user-pool";

--- a/terraform/auth.nix
+++ b/terraform/auth.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 let 
-  prefixName = import ./utils.nix stage;
+  prefixName = import ./utils.nix config.setup.stage;
 in {
   config.resource = {
     aws_cognito_user_pool.main = {

--- a/terraform/auth.nix
+++ b/terraform/auth.nix
@@ -1,7 +1,6 @@
 { config, lib, pkgs, ... }:
 let 
-  utils = import ./utils.nix;
-  prefixName = utils.prefixName;
+  prefixName = import ./utils.nix stage;
 in {
   config.resource = {
     aws_cognito_user_pool.main = {

--- a/terraform/database-sql.nix
+++ b/terraform/database-sql.nix
@@ -1,7 +1,6 @@
 { config, lib, pkgs, ... }: 
 let 
-  utils = import ./utils.nix;
-  prefixName = utils.prefixName;
+  prefixName = import ./utils.nix stage;
 in {
   options.servers.database = with lib;
     with types; {

--- a/terraform/database-sql.nix
+++ b/terraform/database-sql.nix
@@ -1,4 +1,8 @@
-{ config, lib, pkgs, ... }: {
+{ config, lib, pkgs, ... }: 
+let 
+  utils = import ./utils.nix;
+  prefixName = utils.prefixName;
+in {
   options.servers.database = with lib;
     with types; {
       availability_zone = mkOption { type = str; };

--- a/terraform/database-sql.nix
+++ b/terraform/database-sql.nix
@@ -7,7 +7,7 @@
       tags = mkOption { type = attrsOf str; };
     };
 
-  config.resource = let name = "dailp-database";
+  config.resource = let name = prefixName "database";
   in {
     aws_db_subnet_group.sql_database = {
       name = name;
@@ -53,14 +53,14 @@
     };
 
     aws_security_group.nixos_test = {
-      name = "dailp-nixos-test";
+      name = prefixName "nixos-test";
       vpc_id = config.setup.vpc;
       description = "MongoDB on NixOS test";
       lifecycle.create_before_destroy = true;
     };
 
     aws_security_group.mongodb_access = {
-      name = "dailp-mongodb-access";
+      name = prefixName "mongodb-access";
       vpc_id = config.setup.vpc;
       description = "Access DAILP MongoDB servers";
       ingress = [ ];

--- a/terraform/database-sql.nix
+++ b/terraform/database-sql.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }: 
 let 
-  prefixName = import ./utils.nix stage;
+  prefixName = import ./utils.nix config.setup.stage;
 in {
   options.servers.database = with lib;
     with types; {

--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 let 
-  prefixName = import ./utils.nix stage;
+  prefixName = import ./utils.nix config.setup.stage;
 in {
   config.resource = {
     aws_iam_role.lambda_exec = {

--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -3,7 +3,7 @@
 {
   config.resource = {
     aws_iam_role.lambda_exec = {
-      name = "dailp-lambda-execution";
+      name = prefixName "lambda-execution";
       managed_policy_arns = [
         "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
       ];
@@ -27,7 +27,7 @@
 
     # The "REST API" is the container for all of the other API Gateway objects you will create.
     aws_api_gateway_rest_api.functions_api = {
-      name = "dailp-api";
+      name = prefixName "api";
       description = "DAILP API for GraphQL endpoints and REST endpoints";
       lifecycle.prevent_destroy = true;
     };

--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -1,6 +1,8 @@
 { config, lib, pkgs, ... }:
-
-{
+let 
+  utils = import ./utils.nix;
+  prefixName = utils.prefixName;
+in {
   config.resource = {
     aws_iam_role.lambda_exec = {
       name = prefixName "lambda-execution";

--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -4,7 +4,8 @@ let
 in {
   config.resource = {
     aws_iam_role.lambda_exec = {
-      name = prefixName "lambda-execution";
+      # name = prefixName "lambda-execution";
+      name = "dailp-lambda-execution";
       managed_policy_arns = [
         "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
       ];

--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -23,7 +23,7 @@ in {
           ]
         }
       '';
-      lifecycle.prevent_destroy = true;
+      # lifecycle.prevent_destroy = true;
     };
 
     # The "REST API" is the container for all of the other API Gateway objects you will create.

--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -23,7 +23,7 @@ in {
           ]
         }
       '';
-      # lifecycle.prevent_destroy = true;
+      lifecycle.prevent_destroy = false;
     };
 
     # The "REST API" is the container for all of the other API Gateway objects you will create.

--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -1,7 +1,6 @@
 { config, lib, pkgs, ... }:
 let 
-  utils = import ./utils.nix;
-  prefixName = utils.prefixName;
+  prefixName = import ./utils.nix stage;
 in {
   config.resource = {
     aws_iam_role.lambda_exec = {

--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -31,7 +31,7 @@ in {
     aws_api_gateway_rest_api.functions_api = {
       name = prefixName "api";
       description = "DAILP API for GraphQL endpoints and REST endpoints";
-      lifecycle.prevent_destroy = true;
+      lifecycle.prevent_destroy = false;
     };
 
     aws_api_gateway_authorizer.functions_api = {

--- a/terraform/functions.nix
+++ b/terraform/functions.nix
@@ -37,7 +37,7 @@ let
     mkMerge [
       {
         aws_lambda_function."${id}" = {
-          lifecycle.prevent_destroy = true;
+          lifecycle.prevent_destroy = false;
           function_name = name;
           filename = "${config.functions.package_path}/${name}.zip";
           runtime = "provided.al2";

--- a/terraform/main.nix
+++ b/terraform/main.nix
@@ -48,9 +48,11 @@ in {
   setup = {
     # Setup the S3 bucket and DynamoDB table that store and manage Terraform state
     # for the current environment.
-    state = {
-      bucket = "dailp-${config.setup.stage}-terraform-state-bucket";
-      table = "dailp-${config.setup.stage}-terraform-state-locks";
+    state = let 
+      prefixName = import ./utils.nix config.setup.stage;
+    in {
+      bucket = prefixName "terraform-state-bucket";
+      table = prefixName "terraform-state-locks";
     };
     vpc = getEnv "AWS_VPC_ID";
     subnets = {
@@ -62,7 +64,7 @@ in {
 
   functions = 
   let 
-    prefixName = import ./utils.nix stage;
+    prefixName = import ./utils.nix config.setup.stage;
   in {
     bucket = "dailp-${config.setup.stage}-functions-bucket";
     security_group_ids = [ "\${aws_security_group.mongodb_access.id}" ];

--- a/terraform/main.nix
+++ b/terraform/main.nix
@@ -14,6 +14,7 @@ let
   stage_var = getEnv "TF_STAGE";
   # Default to the 'dev' environment unless specified.
   stage = if stage_var == "" then "dev" else stage_var;
+  prefixName = base: "dailp-${stage}-${base}";
 in {
   imports = [
     ./bootstrap.nix
@@ -65,7 +66,7 @@ in {
     security_group_ids = [ "\${aws_security_group.mongodb_access.id}" ];
     functions = [{
       id = "graphql";
-      name = "dailp-graphql";
+      name = prefixName "graphql";
       env = {
         VITE_DEPLOYMENT_ENV = config.setup.stage;
         DATABASE_URL =

--- a/terraform/main.nix
+++ b/terraform/main.nix
@@ -16,7 +16,6 @@ let
   stage = if stage_var == "" then "dev" else stage_var;
 in {
   imports = [
-    ./utils.nix
     ./bootstrap.nix
     ./functions.nix
     ./auth.nix
@@ -63,9 +62,8 @@ in {
 
   functions = 
   let 
-  utils = import ./utils.nix;
-  prefixName = utils.prefixName;
-in {
+    prefixName = import ./utils.nix stage;
+  in {
     bucket = "dailp-${config.setup.stage}-functions-bucket";
     security_group_ids = [ "\${aws_security_group.mongodb_access.id}" ];
     functions = [{

--- a/terraform/main.nix
+++ b/terraform/main.nix
@@ -14,9 +14,9 @@ let
   stage_var = getEnv "TF_STAGE";
   # Default to the 'dev' environment unless specified.
   stage = if stage_var == "" then "dev" else stage_var;
-  prefixName = base: "dailp-${stage}-${base}";
 in {
   imports = [
+    ./utils.nix
     ./bootstrap.nix
     ./functions.nix
     ./auth.nix
@@ -61,7 +61,11 @@ in {
     };
   };
 
-  functions = {
+  functions = 
+  let 
+  utils = import ./utils.nix;
+  prefixName = utils.prefixName;
+in {
     bucket = "dailp-${config.setup.stage}-functions-bucket";
     security_group_ids = [ "\${aws_security_group.mongodb_access.id}" ];
     functions = [{

--- a/terraform/media-access.nix
+++ b/terraform/media-access.nix
@@ -1,6 +1,5 @@
 { config, lib, pkgs, ...} : let 
-  utils = import ./utils.nix;
-  prefixName = utils.prefixName;
+  prefixName = import ./utils.nix stage;
 in {
 config.resource = {
   aws_cloudfront_origin_access_control.media_access_control = {

--- a/terraform/media-access.nix
+++ b/terraform/media-access.nix
@@ -1,4 +1,7 @@
-{ config, lib, pkgs, ...} : {
+{ config, lib, pkgs, ...} : let 
+  utils = import ./utils.nix;
+  prefixName = utils.prefixName;
+in {
 config.resource = {
   aws_cloudfront_origin_access_control.media_access_control = {
     name = prefixName "media-storage.s3.${config.provider.aws.region}.amazonaws.com";

--- a/terraform/media-access.nix
+++ b/terraform/media-access.nix
@@ -1,5 +1,5 @@
 { config, lib, pkgs, ...} : let 
-  prefixName = import ./utils.nix stage;
+  prefixName = import ./utils.nix config.setup.stage;
 in {
 config.resource = {
   aws_cloudfront_origin_access_control.media_access_control = {

--- a/terraform/media-access.nix
+++ b/terraform/media-access.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ...} : {
 config.resource = {
   aws_cloudfront_origin_access_control.media_access_control = {
-    name = "dailp-${config.setup.stage}-media-storage.s3.${config.provider.aws.region}.amazonaws.com";
+    name = prefixName "media-storage.s3.${config.provider.aws.region}.amazonaws.com";
     description = "Cloudfront DAILP media access";
     origin_access_control_origin_type = "s3";
     signing_behavior = "always";

--- a/terraform/user-roles.nix
+++ b/terraform/user-roles.nix
@@ -5,8 +5,7 @@ let
  document-audio = "document-audio/*";
  word-annotations = "word-annotations-list/*";
  user-audio = "user-uploaded-audio/*";
-utils = import ./utils.nix;
-prefixName = utils.prefixName;
+ prefixName = import ./utils.nix stage;
 in {
   # Policy Documents
   config.data.aws_iam_policy_document = {

--- a/terraform/user-roles.nix
+++ b/terraform/user-roles.nix
@@ -5,7 +5,7 @@ let
  document-audio = "document-audio/*";
  word-annotations = "word-annotations-list/*";
  user-audio = "user-uploaded-audio/*";
- prefixName = import ./utils.nix stage;
+ prefixName = import ./utils.nix config.setup.stage;
 in {
   # Policy Documents
   config.data.aws_iam_policy_document = {

--- a/terraform/user-roles.nix
+++ b/terraform/user-roles.nix
@@ -5,6 +5,8 @@ let
  document-audio = "document-audio/*";
  word-annotations = "word-annotations-list/*";
  user-audio = "user-uploaded-audio/*";
+utils = import ./utils.nix;
+prefixName = utils.prefixName;
 in {
   # Policy Documents
   config.data.aws_iam_policy_document = {

--- a/terraform/user-roles.nix
+++ b/terraform/user-roles.nix
@@ -22,7 +22,7 @@ in {
         variable = "cognito-identity.amazonaws.com:aud";
         values = [
           # TODO use a reference instead of hard-coding
-          "us-east-1:6d544733-83e2-4d38-baa3-195d3bfdf54b"
+          "us-east-1:6d544733-83e2-4d38-baa3-195d3bfdf54b" # FIXME this should be causing some weird behavior somewhere...
         ];
       };
     };
@@ -78,17 +78,17 @@ in {
     aws_iam_policy = {
       dailp_basic_user_policy = {
         policy = "$\{data.aws_iam_policy_document.basic_user_policy.json}";
-        name = "dailp-basic-user-policy";
+        name = prefixName "basic-user-policy";
         description = "Allows minimal S3 read permissions for unauthenticated users.";
       };
       dailp_editor_policy = {
         policy = "$\{data.aws_iam_policy_document.editor_user_policy.json}";
-        name = "dailp-editor-policy";
+        name = prefixName "editor-policy";
         description = "A policy giving editors permission to read and write to DAILPs S3 media bucket";
       };
       dailp_user_contributor_policy = {
         policy = "$\{data.aws_iam_policy_document.contributor_user_policy.json}";
-        name = "dailp-user-contributor-policy";
+        name = prefixName "user-contributor-policy";
         description = "Permissions for DAILP users at the Contributor level.";
       };
     };
@@ -100,17 +100,17 @@ in {
       dailp_user = {
         assume_role_policy = trust-policy;
         description = "A basic unauthenticated DAILP user";
-        name = "dailp-user";
+        name = prefixName "user";
       };
       dailp_user_contributor = {
         assume_role_policy = trust-policy;
         description = "A DAILP user with basic read/update permissions.";
-        name = "dailp-user-contributor";
+        name = prefixName "user-contributor";
       };
       dailp_user_editor = {
         assume_role_policy = trust-policy;
         description = "A user with editorial permissions on DAILP";
-        name = "dailp-user-editor";
+        name = prefixName "user-editor";
       };
     };
     # Bind policies to roles

--- a/terraform/utils.nix
+++ b/terraform/utils.nix
@@ -1,0 +1,6 @@
+{config}:
+let 
+  stage = config.setup.stage ;
+in {
+  prefixName = base: "dailp-${stage}-${base}";
+}

--- a/terraform/utils.nix
+++ b/terraform/utils.nix
@@ -1,6 +1,2 @@
-{ config, lib, pkgs, ... }:
-let 
-  stage = config.setup.stage ;
-in {
-  prefixName = base: "dailp-${stage}-${base}";
-}
+# For now, this module is a higher order function generating a function that creates
+stage: base: "dailp-${stage}-${base}"

--- a/terraform/utils.nix
+++ b/terraform/utils.nix
@@ -1,4 +1,4 @@
-{config}:
+{ config, lib, pkgs, ... }:
 let 
   stage = config.setup.stage ;
 in {

--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -31,7 +31,7 @@ in {
     aws_amplify_app.dailp =
       let apiUrl = "\${aws_api_gateway_deployment.functions_api.invoke_url}";
       in {
-        lifecycle.prevent_destroy = true;
+        lifecycle.prevent_destroy = false;
         name = "dailp";
         description = "Digital Archive of Indigenous Language Persistence";
         repository = lib.toLower (getEnv "GIT_REPOSITORY_URL");

--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -4,7 +4,7 @@ with lib;
 with builtins; {
   config.resource = {
     aws_iam_role.amplify_role = {
-      name = "dailp-amplify-role";
+      name = prefixName "amplify-role";
       assume_role_policy = toJSON {
         Statement = [{
           Effect = "Allow";

--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -3,8 +3,7 @@
 with lib;
 with builtins; 
 let 
-  utils = import ./utils.nix;
-  prefixName = utils.prefixName;
+  prefixName = import ./utils.nix stage;
 in {
   config.resource = {
     aws_iam_role.amplify_role = {

--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -3,7 +3,7 @@
 with lib;
 with builtins; 
 let 
-  prefixName = import ./utils.nix stage;
+  prefixName = import ./utils.nix config.setup.stage;
 in {
   config.resource = {
     aws_iam_role.amplify_role = {

--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -1,7 +1,11 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-with builtins; {
+with builtins; 
+let 
+  utils = import ./utils.nix;
+  prefixName = utils.prefixName;
+in {
   config.resource = {
     aws_iam_role.amplify_role = {
       name = prefixName "amplify-role";

--- a/website/src/components/audio-player.tsx
+++ b/website/src/components/audio-player.tsx
@@ -12,6 +12,7 @@ interface Props {
 
 export const AudioPlayer = (props: Props) => {
   if (typeof window !== "undefined") {
+    console.log("[Naomi] start: " + props.slices?.start + "; end: " + props.slices?.end)
     return <AudioPlayerImpl {...props} />
   } else {
     return null
@@ -25,9 +26,17 @@ const AudioPlayerImpl = (props: Props) => {
   const [loadStatus, setLoadStatus] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
 
+  //　FIXME Issue: Word audio drifts forward and backward for no apparent reason
+  // Steps (Todo)
+  // - verify [start, end] match incoming data from GQL
+  // - 
+  // Steps (complete)
+  // 
   const [start, end] = props.slices
-    ? [props.slices.start / 1000, props.slices.end / 1000]
-    : [0, audio.duration]
+    ? [props.slices.start / 1000, props.slices.end / 1000] // this does not
+    : [0, audio.duration] // this works fine
+  
+  console.log("[Naomi] calculated start: " + start + "; end: " + end)
 
   const reset = () => {
     audio.currentTime = start


### PR DESCRIPTION
Created nix function `prefixName` to prepend `"dailp-[environment name]-"` to a given string for use in generating unique and consistent AWS data and resource names.

Example:

```
config.resource.aws_iam_policy.sample_policy = {
    name = prefixName "sample-policy";
    ...
};
```

yields the following TF config snippet (assuming production deploy):

```
resource "aws_iam_policy" "sample_policy" {
    name = "dailp-prod-sample-policy"
    ...
}
```

All name variants for this example are detailed in the table below:

| environment name | stage shortname | final resource name |
| --- | --- | --- |
| Local | `dev` | `"dailp-dev-sample-policy"` |
| Development | `dev` | `"dailp-dev-sample-policy"` |
| Staging/UAT | `uat` | `"dailp-uat-sample-policy"` |
| Production | `prod` | `"dailp-prod-sample policy"` |