### PR TITLE
Resolve staging resource conflicts

### DIFF
--- a/terraform/auth.nix
+++ b/terraform/auth.nix
@@ -27,7 +27,7 @@ in {
     let
       toUri = { path }:
       let
-        buildUri = path: "https://${prefixName path}";
+        buildUri = path: "https://${prefixName ("." + path)}";
         cleanUri = uri: builtins.replaceStrings ["-."] ["."] uri;
       in cleanUri (buildUri path);
       cognito-uri = toUri { path = "auth.us-east-1.amazoncognito.com"; };

--- a/terraform/auth.nix
+++ b/terraform/auth.nix
@@ -4,7 +4,7 @@ let
 in {
   config.resource = {
     aws_cognito_user_pool.main = {
-      name = prefixName "user-pool";
+      name = "dailp-user-pool";
       username_attributes = [ "email" ];
       auto_verified_attributes = [ "email" ];
       admin_create_user_config.allow_admin_create_user_only = true;

--- a/terraform/database-sql.nix
+++ b/terraform/database-sql.nix
@@ -16,6 +16,7 @@ in {
       name = name;
       subnet_ids = lib.attrValues config.setup.subnets;
       tags = { Name = "Subnet Group for DAILP"; };
+      lifecycle.create_before_destroy = true;
     };
 
     aws_db_instance.sql_database = {

--- a/terraform/functions.nix
+++ b/terraform/functions.nix
@@ -38,6 +38,7 @@ let
       {
         aws_lambda_function."${id}" = {
           lifecycle.prevent_destroy = false;
+          lifecycle.create_before_destroy = true;
           function_name = name;
           filename = "${config.functions.package_path}/${name}.zip";
           runtime = "provided.al2";


### PR DESCRIPTION
enforce crucial ordering:
1. RDS subnet group should recreate before destroy to free original group from `dailp-database`
2. temporarily undo cognate user pool rename so domain resource can attach in TF to be deleted on next apply
3. Lambda function should recreate before destroy to allow permissions to attach properly 