### PR TITLE
Add duration bounds checking to word-for-word audio migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,12 +950,14 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "mp3-duration",
  "pretty_env_logger",
  "rayon",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tera",
  "tokio",
 ]
@@ -1925,6 +1927,15 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "mp3-duration"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348bdc7300502f0801e5b57c448815713cd843b744ef9bda252a2698fdf90a0f"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -15,10 +15,13 @@ path = "src/validate.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = {version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tera = "1.15"
-reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.11", features = [
+    "json",
+    "rustls-tls",
+], default-features = false }
 tokio = { version = "1.20", features = ["full", "time"] }
 anyhow = "1.0"
 itertools = "0.10"
@@ -31,5 +34,7 @@ base64 = "0.13"
 log = "0.4"
 pretty_env_logger = "0.4"
 csv = "1.1"
+mp3-duration = "0.1.10"
+tempfile = "*"
 
-dailp = {path = "../types"}
+dailp = { path = "../types" }

--- a/migration/src/spreadsheets.rs
+++ b/migration/src/spreadsheets.rs
@@ -462,7 +462,7 @@ impl SheetResult {
                 Some(
                     AudioRes::new(audio_files.get(1).unwrap(), audio_files.get(2))
                         .await?
-                        .into_document_audio(),
+                        .into_document_audio()?,
                 )
             },
             order_index,


### PR DESCRIPTION
# Goal
The purpose of this PR is to catch mismatched annotations and audio files at migration time.


## Checks
- [x] Annotations do not reference audio outside of the bounds of the audio file's duration
   - Sadly this involved downloading the audio to tmp files and doing the duration check on disk, which is not ideal for the long run. I'd like to find a rust crate that will do the metadata read over the network, but I couldn't find one quickly and moved on. I consider this a quick fix and diagnostic while we are still getting to the bottom of things.
- [ ] Some kind of check which can handle when a **smaller annotation** file is used. Eg. more than 10 seconds between the last annotation `end_time` and the duration of the file. For false positives, we would probably want to trim the end of the audio file anyway. Removing silence at the end of a track wouldn't affect alignment.
- [ ] There are the same number of annotations and words in a document


## Counting words / annotations and ensuring they match
I couldn't find a clean place to add a sanity check on `num_words == num_annotations` but here is the code for it. I originally wrote this inside `AnnotatedLine::many_from_semantic` [source](https://github.com/NEU-DSG/dailp-encoding/blob/cm/audio-bounds-checking/migration/src/spreadsheets.rs#L577-L689) but since that goes line by line, this would typically fail, since there are fewer words in a line than in the whole document.

```rust

                // Our code will error if there are fewer annotations than
                // words, but continue silently if there are leftover
                // annotations.
                if let (Some(num_annotations), Ok(num_words)) = (
                    meta.audio_recording
                        .as_ref()
                        .and_then(|audio| audio.annotations.as_ref())
                        .map(|annotations| annotations.len()),
                    words.as_ref().map(|w| w.len()),
                ) {
                    anyhow::ensure!(
                        num_annotations == num_words,
                        "If we have word-for-word annotations, we must have one for each word."
                    )
                }
```