### PR TITLE
Enforce-code-styling

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -31,5 +31,10 @@ if git-staged "website/*" && cd website && ! yarn prettier -c --config package.j
     HOOKS_FAILED=1
 fi
 
+# Require formatting for rust code
+if git-staged "*.rs" && [[ -n "$(cargo fmt --check)" ]]; then
+    printf "Rust code edited but not formatted.\nPlease run 'dev-check'."
+    HOOKS_FAILED=1
+fi
 
 exit $HOOKS_FAILED

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -27,13 +27,13 @@ fi
 
 # Reqire frontend formatting
 if git-staged "website/*" && cd website && ! yarn prettier -c --config package.json src; then
-    printf "Frontend code edited but not formatted.\nPlease run 'dev-check' \nor\n'cd website; prettier -c --config package.json src'."
+    printf "Frontend code edited but not formatted.\nPlease run 'dev-check' \nor\n'cd website; prettier -c --config package.json src'.\n"
     HOOKS_FAILED=1
 fi
 
 # Require formatting for rust code
 if git-staged "*.rs" && [[ -n "$(cargo fmt --check)" ]]; then
-    printf "Rust code edited but not formatted.\nPlease run 'dev-check'."
+    printf "Rust code edited but not formatted.\nPlease run 'dev-check'.\n"
     HOOKS_FAILED=1
 fi
 

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -25,4 +25,8 @@ if git-staged "website/src/graphql/**.graphql" && ! git-staged "website/src/grap
     HOOKS_FAILED=1
 fi
 
+if git-staged "website/*"; then
+    cd website
+    yarn prettier -c --config package.json src
+fi
 exit $HOOKS_FAILED

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -27,7 +27,7 @@ fi
 
 # Reqire frontend formatting
 if git-staged "website/*" && cd website && ! yarn prettier -c --config package.json src; then
-    printf "Frontend code edited but not formatted.\nPlease run 'dev-check' \nor\n'cd website; prettier -c --config package.json src'.\n"
+    printf "Frontend code edited but not formatted.\nPlease run 'dev-check' \nor\n'cd website; prettier -w --config package.json src'.\n"
     HOOKS_FAILED=1
 fi
 

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -25,8 +25,11 @@ if git-staged "website/src/graphql/**.graphql" && ! git-staged "website/src/grap
     HOOKS_FAILED=1
 fi
 
-if git-staged "website/*"; then
-    cd website
-    yarn prettier -c --config package.json src
+# Reqire frontend formatting
+if git-staged "website/*" && cd website && ! yarn prettier -c --config package.json src; then
+    printf "Frontend code edited but not formatted.\nPlease run 'dev-check' \nor\n'cd website; prettier -c --config package.json src'."
+    HOOKS_FAILED=1
 fi
+
+
 exit $HOOKS_FAILED

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Check code quality
         run: |
           echo "::group::Checking Rust format"
-          cargo install rustfmt
           cargofmt="$(cargo fmt --check)"
           if [[ -n $cargofmt ]]; then
             echo $cargofmt

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -40,6 +40,7 @@ jobs:
           echo "::endgroup"
           echo "::group::Checking format for frontend code"
           cd website
+          yarn add prettier --dev
           yarn prettier -c --config package.json src
           echo "::endgroup"
       - name: Configure AWS credentials

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check code quality
         run: |
           echo "::group::Checking Rust format"
-          cargo install cargo-fmt
+          cargo install rustfmt
           cargofmt="$(cargo fmt --check)"
           if [[ -n $cargofmt ]]; then
             echo $cargofmt

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -34,12 +34,9 @@ jobs:
       - name: Check code quality
         run: |
           echo "::group::Checking Rust format"
-          rustfmt = "$(cargo fmt --check)"
+          rustfmt="$(cargo fmt --check)"
           echo $rustfmt
           echo "::endgroup"
-          if [[ -n $rustfmt ]]; then
-            echo "::error::Rust code does not meet code standards. Please run `cargo fmt` or `dev-check`."
-          fi
           echo "::group::Checking format for frontend code"
           cd website
           yarn prettier -c --config package.json src

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -34,7 +34,13 @@ jobs:
       - name: Check code quality
         run: |
           echo "::group::Checking Rust format"
-          cargo fmt --check
+          cargo install cargo-fmt
+          cargofmt="$(cargo fmt --check)"
+          if [[ -n $cargofmt ]]; then
+            echo $cargofmt
+            echo "Please fix the formatting errors above by running 'cargo fmt'."
+            exit 1
+          fi
           echo "::endgroup"
           echo "::group::Checking format for frontend code"
           cd website

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -33,6 +33,7 @@ jobs:
           pushFilter: "(-dailp$|-dailp-|-terraform-config$|-source$|\\.tar\\.gz$|-output$|-plan$|-apply-now$|-apply$)"
       - name: Check code quality
         run: |
+          nix build --impure -L
           echo "::group::Checking Rust format"
           rustfmt="$(cargo fmt --check)"
           echo $rustfmt

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -33,7 +33,7 @@ jobs:
           pushFilter: "(-dailp$|-dailp-|-terraform-config$|-source$|\\.tar\\.gz$|-output$|-plan$|-apply-now$|-apply$)"
       - name: Check code quality
         run: |
-          nix build --impure -L
+          nix develop --experimental-features 'nix-command flakes'
           echo "::group::Checking Rust format"
           rustfmt="$(cargo fmt --check)"
           echo $rustfmt

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -33,14 +33,12 @@ jobs:
           pushFilter: "(-dailp$|-dailp-|-terraform-config$|-source$|\\.tar\\.gz$|-output$|-plan$|-apply-now$|-apply$)"
       - name: Check code quality
         run: |
-          nix develop --experimental-features 'nix-command flakes'
           echo "::group::Checking Rust format"
-          rustfmt="$(cargo fmt --check)"
-          echo $rustfmt
+          cargo fmt --check
           echo "::endgroup"
           echo "::group::Checking format for frontend code"
           cd website
-          yarn add prettier --dev
+          yarn add prettier@2.1.2 --dev
           yarn prettier -c --config package.json src
           echo "::endgroup"
       - name: Configure AWS credentials

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -31,6 +31,19 @@ jobs:
           # If you chose API tokens for write access OR if you have a private cache
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           pushFilter: "(-dailp$|-dailp-|-terraform-config$|-source$|\\.tar\\.gz$|-output$|-plan$|-apply-now$|-apply$)"
+      - name: Check code quality
+        run: |
+          echo "::group::Checking Rust format"
+          rustfmt = "$(cargo fmt --check)"
+          echo $rustfmt
+          echo "::endgroup"
+          if [[ -n $rustfmt ]]; then
+            echo "::error::Rust code does not meet code standards. Please run `cargo fmt` or `dev-check`."
+          fi
+          echo "::group::Checking format for frontend code"
+          cd website
+          yarn prettier -c --config package.json src
+          echo "::endgroup"
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/check.sh
+++ b/check.sh
@@ -24,7 +24,7 @@ cargo run --bin dailp-graphql-schema &>/dev/null ||
 echo "--- WEBSITE ---"
 cd website
 echo "Formatting TypeScript code..."
-yarn prettier --write src &>/dev/null
+yarn prettier --write --config package.json src &>/dev/null
 echo "Generating Typescript types for GraphQL queries..."
 yarn generate
 echo "Checking website for errors..."


### PR DESCRIPTION
Added formatting checks for rust and typescript code

In the future we may want to enforce:
- Formatting/linting of sql code using `sqlfluff format` or `sqlfluff lint`. Linting would require ignoring certain parsing errors, format would involve upgrading sqlfluff. Both will take a bit of research.
- Formatting of nix code using `nix fmt`
- Adequate documentation of rust (and maybe TS) code. This would resolve _many_ rust build warnings.
