### PR TITLE
Updated the return type of updateParagraph to DocumentParagraph

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -810,7 +810,7 @@ type Mutation {
 	"""
 	Mutation for paragraph and translation editing
 	"""
-	updateParagraph(paragraph: ParagraphUpdate!): UUID!
+	updateParagraph(paragraph: ParagraphUpdate!): DocumentParagraph!
 	updatePage(data: JSON!): Boolean!
 	updateAnnotation(data: JSON!): Boolean!
 	updateWord(word: AnnotatedFormUpdate!): AnnotatedForm!

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -6,7 +6,8 @@ use dailp::{
     user::UserGroup,
     user::UserInfo,
     AnnotatedForm, AttachAudioToWordInput, CollectionChapter, CurateWordAudioInput,
-    DeleteContributorAttribution, DocumentMetadataUpdate, UpdateContributorAttribution, Uuid,
+    DeleteContributorAttribution, DocumentMetadataUpdate, DocumentParagraph,
+    UpdateContributorAttribution, Uuid,
 };
 use itertools::Itertools;
 
@@ -424,7 +425,7 @@ impl Mutation {
         &self,
         context: &Context<'_>,
         paragraph: ParagraphUpdate,
-    ) -> FieldResult<Uuid> {
+    ) -> FieldResult<DocumentParagraph> {
         Ok(context
             .data::<DataLoader<Database>>()?
             .loader()

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -226,6 +226,19 @@
     },
     "query": "-- delete a comment given its ID\ndelete from comment where id = $1 returning id;"
   },
+  "3022824a364c2d9ca5062b985a08744f74e641818f5ee128e24fb2a89a344ce2": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "TextArray"
+        ]
+      }
+    },
+    "query": "update paragraph set\n    english_translation =\n        case\n            when $2::text[] != '{}' and $2[1] is not null then $2[1]\n            else english_translation\n        end\nwhere id = $1;"
+  },
   "32052923a631af8b0a51564e9d08578fc30b5d0e58b1593e8651f53343c91156": {
     "describe": {
       "columns": [
@@ -1022,19 +1035,6 @@
       }
     },
     "query": "select\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number,\n  media_resource.recorded_at as \"audio_recorded_at?\",\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  media_slice.id as \"audio_slice_id?\",\n  contributor.id as \"audio_recorded_by?\",\n  contributor.display_name as \"audio_recorded_by_name?\",\n  word.include_audio_in_edited_collection,\n  editor.id as \"audio_edited_by?\",\n  editor.display_name as \"audio_edited_by_name?\"\nfrom word\n  left join media_slice on media_slice.id = word.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user contributor on contributor.id = media_resource.recorded_by\n  left join dailp_user editor on editor.id = media_resource.recorded_by\nwhere\n  document_id = $1 and (\n    word.index_in_document >= $2 or $2 is null\n  ) and (word.index_in_document < $3 or $3 is null)\norder by index_in_document\n"
-  },
-  "57df2982e788599773dc55b1fc70dfd0739f4dcd6702079f93cd6ff24a992bff": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "TextArray"
-        ]
-      }
-    },
-    "query": "update paragraph set\n    english_translation =\n        case\n            when $2::text[] != '{}' and $2[1] is not null then $2[1]\n            else english_translation\n        end\nwhere id = $1"
   },
   "587e868e1c86816469a9169bf07be80df5add11ef357029f74629e112d88b88e": {
     "describe": {

--- a/types/queries/update_paragraph.sql
+++ b/types/queries/update_paragraph.sql
@@ -4,4 +4,4 @@ update paragraph set
             when $2::text[] != '{}' and $2[1] is not null then $2[1]
             else english_translation
         end
-where id = $1
+where id = $1;

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -711,7 +711,7 @@ impl Database {
         Ok(document.id)
     }
 
-    pub async fn update_paragraph(&self, paragraph: ParagraphUpdate) -> Result<Uuid> {
+    pub async fn update_paragraph(&self, paragraph: ParagraphUpdate) -> Result<DocumentParagraph> {
         let translation = paragraph.translation.into_vec();
 
         query_file!(
@@ -722,7 +722,7 @@ impl Database {
         .execute(&self.client)
         .await?;
 
-        Ok(paragraph.id)
+        Ok(self.paragraph_by_id(&paragraph.id).await?)
     }
 
     pub async fn update_contributor_attribution(

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -655,7 +655,7 @@ export type Mutation = {
   readonly updateDocumentMetadata: Scalars["UUID"]
   readonly updatePage: Scalars["Boolean"]
   /** Mutation for paragraph and translation editing */
-  readonly updateParagraph: Scalars["UUID"]
+  readonly updateParagraph: DocumentParagraph
   readonly updateWord: AnnotatedForm
 }
 
@@ -1976,9 +1976,11 @@ export type UpdateParagraphMutationVariables = Exact<{
   paragraph: ParagraphUpdate
 }>
 
-export type UpdateParagraphMutation = {
-  readonly __typename?: "Mutation"
-} & Pick<Mutation, "updateParagraph">
+export type UpdateParagraphMutation = { readonly __typename?: "Mutation" } & {
+  readonly updateParagraph: {
+    readonly __typename?: "DocumentParagraph"
+  } & Pick<DocumentParagraph, "id" | "translation" | "index">
+}
 
 export type UpdateContributorAttributionMutationVariables = Exact<{
   contribution: UpdateContributorAttribution
@@ -2717,7 +2719,11 @@ export function useRemoveBookmarkMutation() {
 }
 export const UpdateParagraphDocument = gql`
   mutation UpdateParagraph($paragraph: ParagraphUpdate!) {
-    updateParagraph(paragraph: $paragraph)
+    updateParagraph(paragraph: $paragraph) {
+      id
+      translation
+      index
+    }
   }
 `
 

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -479,7 +479,11 @@ mutation RemoveBookmark($documentId: UUID!) {
 }
 
 mutation UpdateParagraph($paragraph: ParagraphUpdate!) {
-  updateParagraph(paragraph: $paragraph)
+  updateParagraph(paragraph: $paragraph) {
+    id
+    translation
+    index
+  }
 }
 
 mutation UpdateContributorAttribution(


### PR DESCRIPTION
Re-used the paragraph_by_id function to return the paragraph object upon success.

I remember @GracefulLemming mentioned about not committing the auto-generated files. I tried that but it just would not let me create a commit, saying I need to run dev-check and/or dev-generate-types, which I ran many times.