### PR TITLE
[DP-276] Comments Viewing FrontEnd

### DIFF
--- a/website/src/components/comment-section.css.ts
+++ b/website/src/components/comment-section.css.ts
@@ -1,9 +1,7 @@
-import { style } from "@vanilla-extract/css"
-import { withSSRContext } from "aws-amplify"
-import { borderWidth, margin } from "polished"
+import { style, styleVariants } from "@vanilla-extract/css"
+import { margin } from "polished"
 import {
   colors,
-  fonts,
   hspace,
   mediaQueries,
   radii,

--- a/website/src/components/comment-section.css.ts
+++ b/website/src/components/comment-section.css.ts
@@ -1,0 +1,83 @@
+import { style } from "@vanilla-extract/css"
+import { withSSRContext } from "aws-amplify"
+import { borderWidth, margin } from "polished"
+import {
+  colors,
+  fonts,
+  hspace,
+  mediaQueries,
+  radii,
+  tagColors,
+  thickness,
+  vspace,
+} from "src/style/constants"
+import { marginX, marginY, paddingX, paddingY } from "src/style/utils"
+
+const wordShared = style([
+  paddingY(vspace.quarter),
+  paddingX(hspace.halfEdge),
+  {
+    borderWidth: thickness.thick,
+    borderStyle: "solid",
+    "@media": {
+      [mediaQueries.print]: {
+        ...margin(0, "3.5rem", vspace[1.5], hspace.small),
+      },
+      [mediaQueries.medium]: margin(0, "2.5rem", vspace.one, hspace.small),
+    },
+  },
+])
+
+export const commentWrapper = style([
+  wordShared,
+  marginY(vspace.half),
+  {
+    borderColor: colors.borders,
+    borderRadius: radii.large,
+    lineHeight: vspace.one,
+    pageBreakInside: "avoid",
+    breakInside: "avoid",
+    "@media": {
+      [mediaQueries.medium]: {},
+    },
+  },
+])
+
+export const headerStyle = style([
+  marginX(hspace.medium),
+  {
+    fontSize: "0.7rem",
+  },
+])
+
+export const tagPadding = style([paddingY(vspace.medium)])
+
+export const tagColorStory = style([
+  paddingX(hspace.medium),
+  {
+    display: "inline-block",
+    borderRadius: radii.round,
+    backgroundColor: tagColors.story,
+    fontSize: "0.7rem",
+  },
+])
+
+export const tagColorSuggestion = style([
+  paddingX(hspace.medium),
+  {
+    display: "inline-block",
+    borderRadius: radii.round,
+    backgroundColor: tagColors.suggestion,
+    fontSize: "0.7rem",
+  },
+])
+
+export const tagColorQuestion = style([
+  paddingX(hspace.medium),
+  {
+    display: "inline-block",
+    borderRadius: radii.round,
+    backgroundColor: tagColors.question,
+    fontSize: "0.7rem",
+  },
+])

--- a/website/src/components/comment-section.tsx
+++ b/website/src/components/comment-section.tsx
@@ -1,5 +1,4 @@
-import React, { ReactNode, SetStateAction } from "react"
-import { useState } from "react"
+import React from "react"
 import * as Dailp from "src/graphql/dailp"
 import { TranslatedParagraph } from "src/segment"
 import * as css from "./comment-section.css"
@@ -25,11 +24,11 @@ export const WordCommentSection = (p: { word: Dailp.FormFieldsFragment }) => {
     variables: { wordId: p.word.id },
   })
 
-  const wordComments = data?.wordById
+  const wordComments = data?.wordById.comments
 
   return (
     <div>
-      {wordComments?.comments.map((comment) => (
+      {wordComments?.map((comment) => (
         <div>
           <CommentHeader comment={comment} />
           <CommentBody comment={comment} />
@@ -46,11 +45,11 @@ export const ParagraphCommentSection = (p: {
     variables: { paragraphId: p.paragraph.id },
   })
 
-  const paragraphComments = data?.paragraphById
+  const paragraphComments = data?.paragraphById.comments
 
   return (
     <div>
-      {paragraphComments?.comments.map((comment) => (
+      {paragraphComments?.map((comment) => (
         <div>
           <div>
             <CommentHeader comment={comment} />

--- a/website/src/components/comment-section.tsx
+++ b/website/src/components/comment-section.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, SetStateAction } from "react"
 import { useState } from "react"
 import * as Dailp from "src/graphql/dailp"
 import { TranslatedParagraph } from "src/segment"
+import * as css from "./comment-section.css"
 
 export const CommentSection = (p: {
   parent: Dailp.FormFieldsFragment | TranslatedParagraph
@@ -51,7 +52,9 @@ export const ParagraphCommentSection = (p: {
     <div>
       {paragraphComments?.comments.map((comment) => (
         <div>
-          <CommentHeader comment={comment} />
+          <div>
+            <CommentHeader comment={comment} />
+          </div>
           <CommentBody comment={comment} />
         </div>
       ))}
@@ -60,12 +63,38 @@ export const ParagraphCommentSection = (p: {
 }
 
 export const CommentBody = (p: { comment: Dailp.Comment }) => {
-  return <div>{p.comment.textContent}</div>
+  const commentTypeNames: Record<Dailp.CommentType, string> = {
+    // ... TS will then make sure you have an entry for everything on the "CommentTag" type that you import from the codegen
+    [Dailp.CommentType.Story]: "Story",
+    [Dailp.CommentType.Suggestion]: "Suggestion",
+    [Dailp.CommentType.Question]: "Question",
+  }
+
+  return (
+    <div className={css.commentWrapper}>
+      {p.comment.textContent}
+      <div className={css.tagPadding}>
+        <div
+          className={
+            p.comment.commentType === Dailp.CommentType.Story
+              ? css.tagColorStory
+              : p.comment.commentType === Dailp.CommentType.Suggestion
+              ? css.tagColorSuggestion
+              : css.tagColorQuestion
+          }
+        >
+          {p.comment.commentType
+            ? commentTypeNames[p.comment.commentType as Dailp.CommentType]
+            : ""}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export const CommentHeader = (p: { comment: Dailp.Comment }) => {
   return (
-    <div>
+    <div className={css.headerStyle}>
       {p.comment.postedBy.displayName} contributed on{" "}
       {p.comment.postedAt.date.formattedDate}
     </div>

--- a/website/src/components/comment-section.tsx
+++ b/website/src/components/comment-section.tsx
@@ -9,11 +9,7 @@ export const CommentSection = (p: {
   return (
     <div>
       {p.parent.__typename === "DocumentParagraph" ? (
-        <ParagraphCommentSection
-          // Actually call the specific query and map here
-          // to each individual comment
-          paragraph={p.parent}
-        />
+        <ParagraphCommentSection paragraph={p.parent} />
       ) : p.parent.__typename === "AnnotatedForm" ? (
         <WordCommentSection word={p.parent} />
       ) : (
@@ -24,17 +20,54 @@ export const CommentSection = (p: {
 }
 
 export const WordCommentSection = (p: { word: Dailp.FormFieldsFragment }) => {
-  // Use GraphQL query, iterate through returned comments,
-  // rendering a CommentHeader and CommentBody for each
-  return <div></div>
+  const [{ data }] = Dailp.useWordCommentsQuery({
+    variables: { wordId: p.word.id },
+  })
+
+  const wordComments = data?.wordById
+
+  return (
+    <div>
+      {wordComments?.comments.map((comment) => (
+        <div>
+          <CommentHeader comment={comment} />
+          <CommentBody comment={comment} />
+        </div>
+      ))}
+    </div>
+  )
 }
 
 export const ParagraphCommentSection = (p: {
   paragraph: TranslatedParagraph
 }) => {
-  return <div></div>
+  const [{ data }] = Dailp.useParagraphCommentsQuery({
+    variables: { paragraphId: p.paragraph.id },
+  })
+
+  const paragraphComments = data?.paragraphById
+
+  return (
+    <div>
+      {paragraphComments?.comments.map((comment) => (
+        <div>
+          <CommentHeader comment={comment} />
+          <CommentBody comment={comment} />
+        </div>
+      ))}
+    </div>
+  )
 }
 
-export const CommentBody = (p: {}) => {}
+export const CommentBody = (p: { comment: Dailp.Comment }) => {
+  return <div>{p.comment.textContent}</div>
+}
 
-export const CommentHeader = (p: {}) => {}
+export const CommentHeader = (p: { comment: Dailp.Comment }) => {
+  return (
+    <div>
+      {p.comment.postedBy.displayName} contributed on{" "}
+      {p.comment.postedAt.date.formattedDate}
+    </div>
+  )
+}

--- a/website/src/components/comment-section.tsx
+++ b/website/src/components/comment-section.tsx
@@ -1,0 +1,40 @@
+import React, { ReactNode, SetStateAction } from "react"
+import { useState } from "react"
+import * as Dailp from "src/graphql/dailp"
+import { TranslatedParagraph } from "src/segment"
+
+export const CommentSection = (p: {
+  parent: Dailp.FormFieldsFragment | TranslatedParagraph
+}) => {
+  return (
+    <div>
+      {p.parent.__typename === "DocumentParagraph" ? (
+        <ParagraphCommentSection
+          // Actually call the specific query and map here
+          // to each individual comment
+          paragraph={p.parent}
+        />
+      ) : p.parent.__typename === "AnnotatedForm" ? (
+        <WordCommentSection word={p.parent} />
+      ) : (
+        ""
+      )}
+    </div>
+  )
+}
+
+export const WordCommentSection = (p: { word: Dailp.FormFieldsFragment }) => {
+  // Use GraphQL query, iterate through returned comments,
+  // rendering a CommentHeader and CommentBody for each
+  return <div></div>
+}
+
+export const ParagraphCommentSection = (p: {
+  paragraph: TranslatedParagraph
+}) => {
+  return <div></div>
+}
+
+export const CommentBody = (p: {}) => {}
+
+export const CommentHeader = (p: {}) => {}

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -1155,6 +1155,9 @@ export type DocumentContentsQuery = { readonly __typename?: "Query" } & {
                           })
                       | { readonly __typename: "LineBreak" }
                     >
+                    readonly comments: ReadonlyArray<
+                      { readonly __typename?: "Comment" } & Pick<Comment, "id">
+                    >
                   }
               >
             }
@@ -2261,6 +2264,9 @@ export const DocumentContentsDocument = gql`
           id
           translation
           index
+          comments {
+            id
+          }
         }
       }
       forms @include(if: $isReference) {

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -1754,6 +1754,64 @@ export type BookmarkedDocumentsQuery = { readonly __typename?: "Query" } & {
   >
 }
 
+export type WordCommentsQueryVariables = Exact<{
+  wordId: Scalars["UUID"]
+}>
+
+export type WordCommentsQuery = { readonly __typename?: "Query" } & {
+  readonly wordById: { readonly __typename?: "AnnotatedForm" } & {
+    readonly comments: ReadonlyArray<
+      { readonly __typename?: "Comment" } & Pick<
+        Comment,
+        "textContent" | "commentType"
+      > & {
+          readonly postedAt: { readonly __typename?: "DateTime" } & Pick<
+            DateTime,
+            "timestamp"
+          > & {
+              readonly date: { readonly __typename?: "Date" } & Pick<
+                Date,
+                "year" | "month" | "day"
+              >
+            }
+          readonly postedBy: { readonly __typename?: "User" } & Pick<
+            User,
+            "displayName"
+          >
+        }
+    >
+  }
+}
+
+export type ParagraphCommentsQueryVariables = Exact<{
+  paragraphId: Scalars["UUID"]
+}>
+
+export type ParagraphCommentsQuery = { readonly __typename?: "Query" } & {
+  readonly paragraphById: { readonly __typename?: "DocumentParagraph" } & {
+    readonly comments: ReadonlyArray<
+      { readonly __typename?: "Comment" } & Pick<
+        Comment,
+        "textContent" | "commentType"
+      > & {
+          readonly postedAt: { readonly __typename?: "DateTime" } & Pick<
+            DateTime,
+            "timestamp"
+          > & {
+              readonly date: { readonly __typename?: "Date" } & Pick<
+                Date,
+                "year" | "month" | "day"
+              >
+            }
+          readonly postedBy: { readonly __typename?: "User" } & Pick<
+            User,
+            "displayName"
+          >
+        }
+    >
+  }
+}
+
 export type UpdateWordMutationVariables = Exact<{
   word: AnnotatedFormUpdate
   morphemeSystem: CherokeeOrthography
@@ -2599,6 +2657,65 @@ export function useBookmarkedDocumentsQuery(
     BookmarkedDocumentsQuery,
     BookmarkedDocumentsQueryVariables
   >({ query: BookmarkedDocumentsDocument, ...options })
+}
+export const WordCommentsDocument = gql`
+  query WordComments($wordId: UUID!) {
+    wordById(id: $wordId) {
+      comments {
+        postedAt {
+          timestamp
+          date {
+            year
+            month
+            day
+          }
+        }
+        postedBy {
+          displayName
+        }
+        textContent
+        commentType
+      }
+    }
+  }
+`
+
+export function useWordCommentsQuery(
+  options: Omit<Urql.UseQueryArgs<WordCommentsQueryVariables>, "query">
+) {
+  return Urql.useQuery<WordCommentsQuery, WordCommentsQueryVariables>({
+    query: WordCommentsDocument,
+    ...options,
+  })
+}
+export const ParagraphCommentsDocument = gql`
+  query ParagraphComments($paragraphId: UUID!) {
+    paragraphById(id: $paragraphId) {
+      comments {
+        postedAt {
+          timestamp
+          date {
+            year
+            month
+            day
+          }
+        }
+        postedBy {
+          displayName
+        }
+        textContent
+        commentType
+      }
+    }
+  }
+`
+
+export function useParagraphCommentsQuery(
+  options: Omit<Urql.UseQueryArgs<ParagraphCommentsQueryVariables>, "query">
+) {
+  return Urql.useQuery<ParagraphCommentsQuery, ParagraphCommentsQueryVariables>(
+    { query: ParagraphCommentsDocument, ...options }
+  )
 }
 export const UpdateWordDocument = gql`
   mutation UpdateWord(

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -1146,6 +1146,12 @@ export type DocumentContentsQuery = { readonly __typename?: "Query" } & {
                             readonly position: {
                               readonly __typename?: "PositionInDocument"
                             } & Pick<PositionInDocument, "documentId">
+                            readonly comments: ReadonlyArray<
+                              { readonly __typename?: "Comment" } & Pick<
+                                Comment,
+                                "id"
+                              >
+                            >
                           })
                       | { readonly __typename: "LineBreak" }
                     >
@@ -1221,6 +1227,9 @@ export type DocumentContentsQuery = { readonly __typename?: "Query" } & {
             readonly position: {
               readonly __typename?: "PositionInDocument"
             } & Pick<PositionInDocument, "documentId">
+            readonly comments: ReadonlyArray<
+              { readonly __typename?: "Comment" } & Pick<Comment, "id">
+            >
           }
       >
     }
@@ -1312,6 +1321,9 @@ export type FormFieldsFragment = {
     readonly position: { readonly __typename?: "PositionInDocument" } & Pick<
       PositionInDocument,
       "documentId"
+    >
+    readonly comments: ReadonlyArray<
+      { readonly __typename?: "Comment" } & Pick<Comment, "id">
     >
   }
 
@@ -1635,6 +1647,9 @@ export type DocSliceQuery = { readonly __typename?: "Query" } & {
               readonly position: {
                 readonly __typename?: "PositionInDocument"
               } & Pick<PositionInDocument, "documentId">
+              readonly comments: ReadonlyArray<
+                { readonly __typename?: "Comment" } & Pick<Comment, "id">
+              >
             }
         >
       }
@@ -1763,7 +1778,7 @@ export type WordCommentsQuery = { readonly __typename?: "Query" } & {
     readonly comments: ReadonlyArray<
       { readonly __typename?: "Comment" } & Pick<
         Comment,
-        "textContent" | "commentType"
+        "id" | "textContent" | "commentType"
       > & {
           readonly postedAt: { readonly __typename?: "DateTime" } & Pick<
             DateTime,
@@ -1771,12 +1786,12 @@ export type WordCommentsQuery = { readonly __typename?: "Query" } & {
           > & {
               readonly date: { readonly __typename?: "Date" } & Pick<
                 Date,
-                "year" | "month" | "day"
+                "year" | "month" | "day" | "formattedDate"
               >
             }
           readonly postedBy: { readonly __typename?: "User" } & Pick<
             User,
-            "displayName"
+            "id" | "displayName"
           >
         }
     >
@@ -1792,7 +1807,7 @@ export type ParagraphCommentsQuery = { readonly __typename?: "Query" } & {
     readonly comments: ReadonlyArray<
       { readonly __typename?: "Comment" } & Pick<
         Comment,
-        "textContent" | "commentType"
+        "id" | "textContent" | "commentType"
       > & {
           readonly postedAt: { readonly __typename?: "DateTime" } & Pick<
             DateTime,
@@ -1800,12 +1815,12 @@ export type ParagraphCommentsQuery = { readonly __typename?: "Query" } & {
           > & {
               readonly date: { readonly __typename?: "Date" } & Pick<
                 Date,
-                "year" | "month" | "day"
+                "year" | "month" | "day" | "formattedDate"
               >
             }
           readonly postedBy: { readonly __typename?: "User" } & Pick<
             User,
-            "displayName"
+            "id" | "displayName"
           >
         }
     >
@@ -1884,6 +1899,9 @@ export type UpdateWordMutation = { readonly __typename?: "Mutation" } & {
       readonly position: { readonly __typename?: "PositionInDocument" } & Pick<
         PositionInDocument,
         "documentId"
+      >
+      readonly comments: ReadonlyArray<
+        { readonly __typename?: "Comment" } & Pick<Comment, "id">
       >
     }
 }
@@ -2142,6 +2160,9 @@ export const FormFieldsFragmentDoc = gql`
     }
     position {
       documentId
+    }
+    comments {
+      id
     }
   }
 `
@@ -2662,15 +2683,18 @@ export const WordCommentsDocument = gql`
   query WordComments($wordId: UUID!) {
     wordById(id: $wordId) {
       comments {
+        id
         postedAt {
           timestamp
           date {
             year
             month
             day
+            formattedDate
           }
         }
         postedBy {
+          id
           displayName
         }
         textContent
@@ -2692,15 +2716,18 @@ export const ParagraphCommentsDocument = gql`
   query ParagraphComments($paragraphId: UUID!) {
     paragraphById(id: $paragraphId) {
       comments {
+        id
         postedAt {
           timestamp
           date {
             year
             month
             day
+            formattedDate
           }
         }
         postedBy {
+          id
           displayName
         }
         textContent

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -125,6 +125,9 @@ fragment FormFields on AnnotatedForm {
   position {
     documentId
   }
+  comments {
+    id
+  }
 }
 
 query Collection($slug: String!) {
@@ -381,15 +384,18 @@ query BookmarkedDocuments {
 query WordComments($wordId: UUID!) {
   wordById(id: $wordId) {
     comments {
+      id
       postedAt {
         timestamp
         date {
           year
           month
           day
+          formattedDate
         }
       }
       postedBy {
+        id
         displayName
       }
       textContent
@@ -401,15 +407,18 @@ query WordComments($wordId: UUID!) {
 query ParagraphComments($paragraphId: UUID!) {
   paragraphById(id: $paragraphId) {
     comments {
+      id
       postedAt {
         timestamp
         date {
           year
           month
           day
+          formattedDate
         }
       }
       postedBy {
+        id
         displayName
       }
       textContent

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -63,6 +63,9 @@ query DocumentContents(
         id
         translation
         index
+        comments {
+          id
+        }
       }
     }
     forms @include(if: $isReference) {

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -378,6 +378,46 @@ query BookmarkedDocuments {
   }
 }
 
+query WordComments($wordId: UUID!) {
+  wordById(id: $wordId) {
+    comments {
+      postedAt {
+        timestamp
+        date {
+          year
+          month
+          day
+        }
+      }
+      postedBy {
+        displayName
+      }
+      textContent
+      commentType
+    }
+  }
+}
+
+query ParagraphComments($paragraphId: UUID!) {
+  paragraphById(id: $paragraphId) {
+    comments {
+      postedAt {
+        timestamp
+        date {
+          year
+          month
+          day
+        }
+      }
+      postedBy {
+        displayName
+      }
+      textContent
+      commentType
+    }
+  }
+}
+
 mutation UpdateWord(
   $word: AnnotatedFormUpdate!
   $morphemeSystem: CherokeeOrthography!

--- a/website/src/panel-layout.tsx
+++ b/website/src/panel-layout.tsx
@@ -4,7 +4,12 @@ import { useState } from "react"
 import { AiFillSound } from "react-icons/ai/index"
 import { GrDown, GrUp } from "react-icons/gr/index"
 import { IoEllipsisHorizontalCircle } from "react-icons/io5/index"
-import { MdClose, MdNotes, MdRecordVoiceOver } from "react-icons/md/index"
+import {
+  MdClose,
+  MdNotes,
+  MdOutlineComment,
+  MdRecordVoiceOver,
+} from "react-icons/md/index"
 import { OnChangeValue } from "react-select"
 import { Disclosure, DisclosureContent, useDisclosureState } from "reakit"
 import { unstable_Form as Form, unstable_FormInput as FormInput } from "reakit"
@@ -276,6 +281,8 @@ export const PanelContent = (p: {
     />
   )
 
+  const discussionContent = <CommentSection parent={p.word} />
+
   return (
     <>
       {(p.word.editedAudio.length || p.panel === PanelType.EditWordPanel) && (
@@ -321,7 +328,18 @@ export const PanelContent = (p: {
         />
       )}
 
-      {p.word.comments.length > 0 && <CommentSection parent={p.word} />}
+      {p.word.comments && p.word.comments.length > 0 && (
+        <CollapsiblePanel
+          title={"Discussion"}
+          content={discussionContent}
+          icon={
+            <MdOutlineComment
+              size={24}
+              className={css.wordPanelButton.colpleft}
+            />
+          }
+        />
+      )}
     </>
   )
 }

--- a/website/src/panel-layout.tsx
+++ b/website/src/panel-layout.tsx
@@ -12,6 +12,7 @@ import * as Dailp from "src/graphql/dailp"
 import { useCredentials } from "./auth"
 import CommentPanel from "./comment-panel"
 import { AudioPlayer, Button, IconButton } from "./components"
+import { CommentSection } from "./components/comment-section"
 import { CustomCreatable } from "./components/creatable"
 import { EditWordAudio } from "./components/edit-word-audio"
 import { SubtleButton } from "./components/subtle-button"
@@ -319,6 +320,8 @@ export const PanelContent = (p: {
           icon={<MdNotes size={24} className={css.wordPanelButton.colpleft} />}
         />
       )}
+
+      {p.word.comments.length > 0 && <CommentSection parent={p.word} />}
     </>
   )
 }

--- a/website/src/panel-layout.tsx
+++ b/website/src/panel-layout.tsx
@@ -328,18 +328,16 @@ export const PanelContent = (p: {
         />
       )}
 
-      {p.word.comments && p.word.comments.length > 0 && (
-        <CollapsiblePanel
-          title={"Discussion"}
-          content={discussionContent}
-          icon={
-            <MdOutlineComment
-              size={24}
-              className={css.wordPanelButton.colpleft}
-            />
-          }
-        />
-      )}
+      <CollapsiblePanel
+        title={"Discussion"}
+        content={discussionContent}
+        icon={
+          <MdOutlineComment
+            size={24}
+            className={css.wordPanelButton.colpleft}
+          />
+        }
+      />
     </>
   )
 }

--- a/website/src/paragraph-panel.tsx
+++ b/website/src/paragraph-panel.tsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { MdClose, MdNotes } from "react-icons/md/index"
+import { MdClose, MdNotes, MdOutlineComment } from "react-icons/md/index"
 import { IconButton } from "./components"
+import { CommentSection } from "./components/comment-section"
 import { CollapsiblePanel, PanelSegment } from "./panel-layout"
 import * as css from "./panel-layout.css"
 import { TranslatedParagraph } from "./segment"
@@ -14,6 +15,8 @@ const ParagraphPanel = (p: {
       `${paragraph} ${word.__typename === "AnnotatedForm" && word.source}`,
     ""
   )
+
+  const discussionContent = <CommentSection parent={p.segment} />
 
   return (
     <>
@@ -46,6 +49,19 @@ const ParagraphPanel = (p: {
         content={<div>Example notes</div>}
         icon={<MdNotes size={24} className={css.wordPanelButton.colpleft} />}
       />
+
+      {p.segment.comments && p.segment.comments.length > 0 && (
+        <CollapsiblePanel
+          title={"Discussion"}
+          content={discussionContent}
+          icon={
+            <MdOutlineComment
+              size={24}
+              className={css.wordPanelButton.colpleft}
+            />
+          }
+        />
+      )}
     </>
   )
 }

--- a/website/src/paragraph-panel.tsx
+++ b/website/src/paragraph-panel.tsx
@@ -50,18 +50,16 @@ const ParagraphPanel = (p: {
         icon={<MdNotes size={24} className={css.wordPanelButton.colpleft} />}
       />
 
-      {p.segment.comments && p.segment.comments.length > 0 && (
-        <CollapsiblePanel
-          title={"Discussion"}
-          content={discussionContent}
-          icon={
-            <MdOutlineComment
-              size={24}
-              className={css.wordPanelButton.colpleft}
-            />
-          }
-        />
-      )}
+      <CollapsiblePanel
+        title={"Discussion"}
+        content={discussionContent}
+        icon={
+          <MdOutlineComment
+            size={24}
+            className={css.wordPanelButton.colpleft}
+          />
+        }
+      />
     </>
   )
 }

--- a/website/src/style/constants.ts
+++ b/website/src/style/constants.ts
@@ -14,11 +14,18 @@ export const typography = new Typography({
 
 export const rhythm = typography.rhythm
 
+export const tagColors = {
+  story: "#C3E0EE",
+  suggestion: "#F0D6C1",
+  question: "#C3EEDE",
+}
+
 export const radii = {
   none: 0,
   small: "1px",
   medium: "2px",
   large: "4px",
+  round: "15px",
 }
 
 export const thickness = {
@@ -30,6 +37,7 @@ export const thickness = {
 export const space = {
   [0]: 0,
   none: 0,
+  xsmall: "2px",
   small: "4px",
   medium: "8px",
   large: "16px",


### PR DESCRIPTION
[Jira ticket
](https://dailp.atlassian.net/browse/DP-276)

Now we can view comments both in the word pane and the paragraph pane!

One note-- in order to render comments immediately after they are submitted, I am currently also showing the collapsible Discussion panel even when it is empty. Otherwise, the pane has to be closed and re-opened in order for comments to show. Maybe there's a better way around this?

<img width="205" alt="image" src="https://github.com/NEU-DSG/dailp-encoding/assets/62397296/e07b3178-00ca-467e-9fc7-96b2ecb6bdb8">
