### PR TITLE
add cloudfront url to amplify settings

### DIFF
--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -66,6 +66,7 @@ in {
             DAILP_IDENTITY_POOL = "$\{aws_cognito_identity_pool.main.id}";
             TF_STAGE = config.setup.stage;
             VITE_DEPLOYMENT_ENV = config.setup.stage;
+            CF_URL = "\${aws_cloudfront_distribution.media_distribution.domain_name}";
           };
           frontend = {
             artifacts = {


### PR DESCRIPTION
@LN7-cyber & @CharlieMcVicker:
This resolves the issue discussed in today's meeting.

@CharlieMcVicker: **Important** With the current code, amplify will have a url in the format `xxxxxxxxxxxxx.cloudflare.net/` and *not* `https://xxxxxxxxxxxxx.cloudflare.net/`. I can change this for simplicity though.
