### PR TITLE
bump rust to v1.72 - stable simd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         fenix = inputs.fenix.packages.${system};
         toolchainFile = {
           file = ./rust-toolchain.toml;
-          sha256 = "sha256-gdYqng0y9iHYzYPAdkC/ka3DRny3La/S5G8ASj0Ayyc=";
+          sha256 = "sha256-Q9UgzzvxLi4x9aWUJTn+/5EXekC98ODRU1TwhUs9RnY=";
         };
         rust-toolchain = fenix.fromToolchainFile toolchainFile;
         naersk = inputs.naersk.lib.${system}.override {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.72.0"
 profile = "minimal"
 components = ["rust-src", "rustfmt", "clippy"]
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Rust version 1.70 did not have stable simd instructions for arm architecture (M1 Macs), meaning the development environment would not build on M1/M2/Apple Silicon macs. This was stabilized in version 1.72.