### PR TITLE
Add environment marker bar

### DIFF
--- a/website/src/env-marker-bar.css.ts
+++ b/website/src/env-marker-bar.css.ts
@@ -1,0 +1,45 @@
+import { style, styleVariants } from "@vanilla-extract/css"
+import { reduce } from "lodash"
+import { backgroundImages } from "polished"
+import { fonts, thickness } from "./style/constants"
+
+const palette = {
+  red: "#f22727",
+  orange: "#f28927",
+  yellow: "#f2e427",
+}
+
+const stripe = (color: string) => {
+  return `linear-gradient(to top right, ${color} 25%, #000000 25%, #000000 50%, ${color} 50%, ${color} 75%, #000000 75%, #000000 100%)`
+}
+
+const markerBarBase = style({
+  position: "sticky",
+  bottom: "0px",
+  width: "100%",
+  height: "min-content",
+  backgroundSize: "113.14px 113.14px",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+})
+
+const markerLabelBase = style({
+  width: "max-content",
+  height: "max-content",
+  textAlign: "center",
+  padding: thickness.thick,
+  margin: thickness.thick,
+  fontFamily: fonts.header,
+  fontWeight: "bold",
+})
+
+export const markerBar = styleVariants(palette, (color) => [
+  markerBarBase,
+  { backgroundImage: stripe(color) },
+])
+
+export const markerLabel = styleVariants(palette, (color) => [
+  markerLabelBase,
+  { background: color },
+])

--- a/website/src/env-marker-bar.tsx
+++ b/website/src/env-marker-bar.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { Environment, deploymentEnvironment } from "./env"
+import { markerBar, markerLabel } from "./env-marker-bar.css"
+
+enum EnvLabel {
+  Local = "Local",
+  Development = "Development",
+  UAT = "Testing",
+}
+
+enum markerColors {
+  Red = "red",
+  Yellow = "yellow",
+  Orange = "orange",
+}
+
+const markerParams = () => {
+  switch (deploymentEnvironment) {
+    case Environment.Local:
+      return { color: markerColors.Red, text: EnvLabel.Local }
+    case Environment.Development:
+      return { color: markerColors.Orange, text: EnvLabel.Development }
+    case Environment.UAT:
+      return { color: markerColors.Yellow, text: EnvLabel.UAT }
+    default:
+      return {}
+  }
+}
+
+/// Visually indicates whether the user is on the uat or development site
+export const EnvMarkerBar = () => {
+  let { color, text } = markerParams()
+
+  return (
+    <>
+      {color && text && (
+        <div className={markerBar[color]}>
+          <p className={markerLabel[color]}>{text} Copy</p>
+        </div>
+      )}
+    </>
+  )
+}

--- a/website/src/layout.tsx
+++ b/website/src/layout.tsx
@@ -9,6 +9,7 @@ import "src/style/global.css"
 import { themeClass } from "src/theme.css"
 import { LayoutClient } from "./client/layout"
 import { Environment, deploymentEnvironment } from "./env"
+import { EnvMarkerBar } from "./env-marker-bar"
 import Footer from "./footer"
 import * as css from "./layout.css"
 import { MobileNav, NavMenu } from "./menu"
@@ -54,6 +55,7 @@ const Layout: React.FC = ({ children }) => {
         </header>
         {children}
         <Footer />
+        <EnvMarkerBar />
       </LayoutClient>
     </PreferencesProvider>
   )


### PR DESCRIPTION
Adds a visual indicator for showing which site environment a user is accessing. Bar should not be present on production.