### PR TITLE
disable migrate data in main infra deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
           export DATABASE_URL=postgres://dailp:$DATABASE_PASSWORD@localhost:5432/dailp
           nix run --impure .#migrate-schema
           export CF_URL=$(nix run --impure .#tf-output cloudfront_distro_url)
-          nix run --impure .#migrate-data
+          # nix run --impure .#migrate-data
       - name: Publish website
         run: |
           curl -X POST -d {} "$(nix run --impure .#tf-output amplify_webhook)" -H "Content-Type:application/json"


### PR DESCRIPTION
*note* this change is meant to be temporary for use on UAT– we need to reconsider when data migration should run and how we want to control runs for a more permanent workflow better fit to DAILP TI.