### PR TITLE
migrate sql schema for contributed/edited audio on documents

### DIFF
--- a/doc/database/documents.md
+++ b/doc/database/documents.md
@@ -12,16 +12,18 @@
 
 ## `document`
 
-| column           | type                     | description                                  |
-| ---------------- | ------------------------ | -------------------------------------------- |
-| `id`             | `uuid`                   | Primary key                                  |
-| `short_name`     | `text`                   | URL slug, natural key                        |
-| `title`          | `text`                   | Full title of the document                   |
-| `group_id`       | `uuid -> document_group` | ID of the `document_group` it belongs to     |
-| `index_in_group` | `bigint`                 | Index of this document in its group          |
-| `is_reference`   | `boolean`                | Is this a lexical source, like a dictionary? |
-| `written_at`     | `date?`                  | When this was written or published           |
-| `audio_slice_id` | `uuid? -> media_slice`   | Audio recording of the whole document        |
+| column                               | type                     | description                                                            |
+| ------------------------------------ | ------------------------ | ---------------------------------------------------------------------- |
+| `id`                                 | `uuid`                   | Primary key                                                            |
+| `short_name`                         | `text`                   | URL slug, natural key                                                  |
+| `title`                              | `text`                   | Full title of the document                                             |
+| `group_id`                           | `uuid -> document_group` | ID of the `document_group` it belongs to                               |
+| `index_in_group`                     | `bigint`                 | Index of this document in its group                                    |
+| `is_reference`                       | `boolean`                | Is this a lexical source, like a dictionary?                           |
+| `written_at`                         | `date?`                  | When this was written or published                                     |
+| `audio_slice_id`                     | `uuid? -> media_slice`   | Audio recording of the whole document, as ingested from GoogleSheets.  |
+| `include_audio_in_edited_collection` | `boolean`                | True if ingested audio should be shown to readers. Defaults to `true`. |
+| `audio_edited_by`                    | `uuid? -> User`          | Last Editor to decide if ingested audio should be shown to readers.    |
 
 - Deleting a `document` auto-deletes all `document_page` rows within it.
 
@@ -87,8 +89,19 @@ This bridge table allows a many to many relationship between `document` and `doc
 This join table stores bookmarked documents. It stores them as the document id, user id, and
 the bookmarked date
 
-| column           | type   | description         |
-| ---------------- | ------ | ------------------- |
-| `document_id`    | `uuid` | Document referenced |
-| `user_id`        | `uuid` | User referenced     |
-| `bookmarked_on`  | `date` | Date bookmarked     |
+| column          | type   | description         |
+| --------------- | ------ | ------------------- |
+| `document_id`   | `uuid` | Document referenced |
+| `user_id`       | `uuid` | User referenced     |
+| `bookmarked_on` | `date` | Date bookmarked     |
+
+## `document_user_media`
+
+A join table linking user audio contributions to documents. This is technically implemented as a many-to-many relationship, and is indexed on both keys, with a compound unique constraint. Additions should be written as upserts. Compare to `word_user_media`, described in `words.md`.
+
+| column                         | type                  | description                                                                                                |
+| ------------------------------ | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `document_id`                  | `uuid -> document`    | Document that is assocated with media slice. Ie. which document is read aloud in the recording.            |
+| `media_slice_id`               | `uuid -> media_slice` | Media slice that is assocated with the document.                                                           |
+| `include_in_edited_collection` | `boolean`             | Should audio be revealed to readers? Defaults to `false`.                                                  |
+| `edited_by`                    | `uuid? -> dailp_user` | Last Editor to decide if audio should be included in edited collection, ie. revealed to un-authed Readers. |

--- a/doc/database/words.md
+++ b/doc/database/words.md
@@ -24,7 +24,7 @@
 
 ## `word_user_media`
 
-A join table linking user audio contributions to words in documents. This is a many-to-many relationship, so should be indexed on both keys, with a compound unique constraint. Ie. you cannot link the same audio to the same word multiple times. Additions should be written as upserts.
+A join table linking user audio contributions to words in documents. This is a many-to-many relationship, so should be indexed on both keys, with a compound unique constraint. Ie. you cannot link the same audio to the same word multiple times. Additions should be written as upserts. Compare to `document_user_media`, described in `documents.md`.
 
 | column                         | type                  | description                                                             |
 | ------------------------------ | --------------------- | ----------------------------------------------------------------------- |

--- a/types/migrations/20241113142347_add_document_user_audio.sql
+++ b/types/migrations/20241113142347_add_document_user_audio.sql
@@ -1,0 +1,19 @@
+-- Create tables and columns needed to have user contributed audio for a whole document
+
+-- add columns for "editing" (hiding/showing) audio ingested from recording sessions
+alter table document
+  add column include_audio_in_edited_collection boolean not null DEFAULT true,
+  add column audio_edited_by uuid,
+  add constraint audio_edited_by_fkey
+    foreign key (audio_edited_by)
+    references dailp_user (id)
+    on delete set null;
+
+-- create a join table for user contributed audio slices
+create table document_user_media (
+    document_id uuid not null references document (id) on delete cascade,
+    media_slice_id uuid not null references media_slice (id) on delete cascade,
+    include_in_edited_collection boolean not null DEFAULT false,
+    edited_by uuid references dailp_user (id) on delete set null,
+    primary key (document_id, media_slice_id)
+);


### PR DESCRIPTION
This PR contains the database migrations (and updates to documentation) to support user-contributed audio on documents.

On the whole, my approach was to replicate what we did with user-contributed audio on words, namely:
1. Add columns on the `document` table to handle "editing" (hiding/showing) audio ingested from sheets
2. Create a join table (`document_id`, `media_slice_id`) for user contributed audio on documents
    1. Like how we did for words, I left the index as a compound index on both keys, which doesn't make a ton of sense (why would the same slice ever be tied to two documents?). But I think having an index on `document_id` is good, and that is listed first in the compound index. Alternatively, we could make the `media_slice_id` the primary key on this table, enforcing a many (slices) to one (document) relationship.

These migrations assume we are going to be replicating the editor workflow for curating contributed audio at the document level. I didn't see that in the mocks though, so let's double check before we merge.

In graphql, we will cover up this implementation detail of which audio is ingested and which audio is contributed, like we did for words.