### PR TITLE
Revert "[DP-337] Selecting a paragraph while editing sometimes selects a word instead"

### DIFF
--- a/website/src/panel-layout.tsx
+++ b/website/src/panel-layout.tsx
@@ -1,6 +1,5 @@
 import { groupBy } from "lodash"
-import React, { ReactNode, useEffect } from "react"
-import { useState } from "react"
+import React, { ReactNode } from "react"
 import { GrDown, GrUp } from "react-icons/gr/index"
 import { MdClose } from "react-icons/md/index"
 import { Disclosure, DisclosureContent, useDisclosureState } from "reakit"
@@ -52,24 +51,12 @@ export const PanelLayout = (p: {
   segment: PanelSegment | null
   setContent: (content: PanelSegment | null) => void
 }) => {
-  const { form, isEditing, setIsEditing } = useForm()
-  const { paragraphForm, isEditingParagraph, setIsEditingParagraph } =
-    useParagraphForm()
-
-  const [prevSegment, setPrevSegment] = useState<PanelSegment | null>(p.segment)
-
-  useEffect(() => {
-    // If the segment has changed, reset the editing states
-    if (p.segment && p.segment !== prevSegment) {
-      setIsEditing(false) // Reset word editing state
-      setIsEditingParagraph(false) // Reset paragraph editing state (if applicable)
-      setPrevSegment(p.segment) // Update the previous segment to the new one
-    }
-  }, [p.segment, prevSegment, setIsEditing, setIsEditingParagraph])
-
   if (!p.segment) {
     return null
   }
+
+  const { form, isEditing } = useForm()
+  const { paragraphForm, isEditingParagraph } = useParagraphForm()
 
   const token = useCredentials()
   const userGroups = useCognitoUserGroups()


### PR DESCRIPTION
Reverts NEU-DSG/dailp-encoding#426 to check a production error when selecting paragraphs.

Error: 
Attempting to open a paragraph detail pane causes a fatal react error. 
Error details at https://react.dev/errors/31?invariant=31&args%5B%5D=object%2520with%2520keys%2520%257B__typename%252C%2520id%252C%2520index%252C%2520source%252C%2520romanizedSource%252C%2520phonemic%252C%2520segments%252C%2520englishGloss%252C%2520commentary%252C%2520ingestedAudioTrack%252C%2520editedAudio%252C%2520userContributedAudio%252C%2520position%252C%2520comments%257D