### PR TITLE
fix paragraph panel unauthed

### DIFF
--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -1343,7 +1343,7 @@ export type DocFormFieldsFragment = {
   }
 
 export type ParagraphFormFieldsFragment = {
-  readonly __typename?: "DocumentParagraph"
+  readonly __typename: "DocumentParagraph"
 } & Pick<DocumentParagraph, "id" | "index" | "translation"> & {
     readonly source: ReadonlyArray<
       | ({ readonly __typename: "AnnotatedForm" } & Pick<
@@ -1416,7 +1416,7 @@ export type ParagraphFormFieldsFragment = {
               { readonly __typename?: "Comment" } & Pick<Comment, "id">
             >
           })
-      | { readonly __typename?: "LineBreak" }
+      | { readonly __typename: "LineBreak" }
     >
     readonly comments: ReadonlyArray<
       { readonly __typename?: "Comment" } & Pick<Comment, "id">
@@ -2533,10 +2533,12 @@ export const FormFieldsFragmentDoc = gql`
 `
 export const ParagraphFormFieldsFragmentDoc = gql`
   fragment ParagraphFormFields on DocumentParagraph {
+    __typename
     id
     index
     translation
     source {
+      __typename
       ...FormFields
     }
     comments {

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -130,10 +130,12 @@ fragment DocFormFields on AnnotatedDoc {
 }
 
 fragment ParagraphFormFields on DocumentParagraph {
+  __typename
   id
   index
   translation
   source {
+    __typename
     ...FormFields
   }
   comments {

--- a/website/src/panel-layout.tsx
+++ b/website/src/panel-layout.tsx
@@ -210,7 +210,6 @@ export const PanelLayout = (p: {
               <h1
                 className={css.noSpaceBelow}
               >{`Paragraph ${p.segment.index}`}</h1>
-              <h2 className={css.cherHeader}>{p.segment.source}</h2>
             </header>
           </>
         )}

--- a/website/src/panel-layout.tsx
+++ b/website/src/panel-layout.tsx
@@ -67,10 +67,6 @@ export const PanelLayout = (p: {
     }
   }, [p.segment, prevSegment, setIsEditing, setIsEditingParagraph])
 
-  if (!p.segment) {
-    return null
-  }
-
   const token = useCredentials()
   const userGroups = useCognitoUserGroups()
 
@@ -105,6 +101,10 @@ export const PanelLayout = (p: {
       }
     }
   )
+
+  if (!p.segment) {
+    return null
+  }
 
   let panel = null
 

--- a/website/src/paragraph-panel.tsx
+++ b/website/src/paragraph-panel.tsx
@@ -64,9 +64,7 @@ const ParagraphPanel = (p: {
       />
     </Form>
   )
-  const discussionContent = (
-    <CommentSection parent={p.paragraph as TranslatedParagraph} />
-  )
+  const discussionContent = <CommentSection parent={p.paragraph} />
 
   return (
     <>


### PR DESCRIPTION
Right now, on dev, the paragraph panel causes a full crash if you are not authed.

- don't return before all hooks are called
- do not try to render all the words in the paragraph as react elements (**_this was the actual issue_**)
- remove unneeded "as"

While finding this issue, I have uncovered that our react type checking is too loose, and will let you pass any object into the {} braces in a JSX block. This is an issue with React 17 and its type defs. We can override them (ick) or upgrade to react 18/19 (also ick, but only for the short term pain).