### PR TITLE
disable migrate connections

### DIFF
--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -45,8 +45,8 @@ async fn main() -> Result<()> {
 
     migrate_data(&db).await?;
 
-    println!("Migrating connections...");
-    connections::migrate_connections(&db).await?;
+    // println!("Migrating connections...");
+    // connections::migrate_connections(&db).await?;
 
     println!("Migrating collections...");
     edited_collection::migrate_edited_collection(&db).await?;


### PR DESCRIPTION
Our lexical connections sheet was lost in NEU's Google Drive reset last fall. This gives us a chance to answer 3 questions:

1. Do people engage with this feature or know how to find it? 
2. Do people want this feature?
3. Do we want to commit to maintaining these connections? If so, how can we incorporate this into DAILP TI?

Currently, we need to disable connections to allow data migration to run. In the near future, we need to repair or remove migrating connections based on our answers to the above questions. 