### PR TITLE
remove `redirectURL`

### DIFF
--- a/website/src/pages/edited-collections/edited-collection.page.tsx
+++ b/website/src/pages/edited-collections/edited-collection.page.tsx
@@ -33,7 +33,7 @@ const EditedCollectionPage = () => {
       <main className={util.paddedCenterColumn}>
         <article className={dialog.visible ? css.leftMargin : util.fullWidth}>
           <header>
-            <h1>Cherokees Writing the Keetoowah Way</h1>
+            <h1>{collection.title}</h1>
           </header>
 
           <h3>

--- a/website/src/pages/edited-collections/edited-collection.page.tsx
+++ b/website/src/pages/edited-collections/edited-collection.page.tsx
@@ -2,8 +2,8 @@ import React, { useEffect } from "react"
 import { Helmet } from "react-helmet"
 import { navigate } from "vite-plugin-ssr/client/router"
 import { Link, WordpressPage } from "src/components"
-import { useRouteParams } from "src/renderer/PageShell"
 import * as Dailp from "src/graphql/dailp"
+import { useRouteParams } from "src/renderer/PageShell"
 import { chapterRoute } from "src/routes"
 import * as util from "src/style/utils.css"
 import CWKWLayout from "../cwkw/cwkw-layout"
@@ -19,7 +19,9 @@ const EditedCollectionPage = () => {
   const firstChapter = chapters ? chapters[0] : null
 
   const [{ data: dailp }] = Dailp.useEditedCollectionsQuery()
-  let collection = dailp?.allEditedCollections.find(({slug})=>slug===collectionSlug)
+  let collection = dailp?.allEditedCollections.find(
+    ({ slug }) => slug === collectionSlug
+  )
 
   if (!collection) {
     return null

--- a/website/src/pages/edited-collections/edited-collection.page.tsx
+++ b/website/src/pages/edited-collections/edited-collection.page.tsx
@@ -9,26 +9,6 @@ import CWKWLayout from "../cwkw/cwkw-layout"
 import * as css from "../cwkw/cwkw-layout.css"
 import { useChapters, useDialog } from "./edited-collection-context"
 
-function redirectUrl(collectionSlug: string) {
-  if (collectionSlug != "cwkw") {
-    // Put here in case someone has one of these old collections bookmarked, but can remove if necessary
-    switch (collectionSlug) {
-      case "dollie-duncan-letters":
-        navigate("/collections/cwkw/dollie_duncan")
-        break
-      case "echota-funeral-notices":
-        navigate("/collections/cwkw/funeral_notices")
-        break
-      case "government documents":
-        navigate("/collections/cwkw/governance_documents")
-        break
-      default:
-        // TODO Don't go to a 404 page!!!!! first rule of 404s... jesus.
-        navigate("/404")
-    }
-  }
-}
-
 // Renders an edited collection page based on the route parameters.
 const EditedCollectionPage = () => {
   const { collectionSlug } = useRouteParams()
@@ -36,10 +16,6 @@ const EditedCollectionPage = () => {
 
   const chapters = useChapters()
   const firstChapter = chapters ? chapters[0] : null
-
-  useEffect(() => {
-    redirectUrl(collectionSlug!)
-  }, [collectionSlug])
 
   if (collectionSlug != "cwkw") {
     return null

--- a/website/src/pages/edited-collections/edited-collection.page.tsx
+++ b/website/src/pages/edited-collections/edited-collection.page.tsx
@@ -3,6 +3,7 @@ import { Helmet } from "react-helmet"
 import { navigate } from "vite-plugin-ssr/client/router"
 import { Link, WordpressPage } from "src/components"
 import { useRouteParams } from "src/renderer/PageShell"
+import * as Dailp from "src/graphql/dailp"
 import { chapterRoute } from "src/routes"
 import * as util from "src/style/utils.css"
 import CWKWLayout from "../cwkw/cwkw-layout"
@@ -17,7 +18,10 @@ const EditedCollectionPage = () => {
   const chapters = useChapters()
   const firstChapter = chapters ? chapters[0] : null
 
-  if (collectionSlug != "cwkw") {
+  const [{ data: dailp }] = Dailp.useEditedCollectionsQuery()
+  let collection = dailp?.allEditedCollections.find(({slug})=>slug===collectionSlug)
+
+  if (!collection) {
     return null
   }
 


### PR DESCRIPTION
Prevent auto-directing to a 404 page when accessing non-CWKW collections by removing `redirectURL`