### PR TITLE
Save collection thumbnails with https schema

### DIFF
--- a/website/src/pages/edited-collections/new.page.tsx
+++ b/website/src/pages/edited-collections/new.page.tsx
@@ -46,7 +46,7 @@ const NewEditedCollectionPage = () => {
         input: {
           title: formData.title,
           description: formData.description,
-          thumbnailUrl: uploadResult.resourceUrl,
+          thumbnailUrl: `https://${uploadResult.resourceUrl}`,
         },
       })
 


### PR DESCRIPTION
Save collection thumbnails to the database prefixed with `https://` so renderer pulls image correctly