### PR TITLE
Word pane audio bug

### DIFF
--- a/website/src/pages/documents/document-info.tsx
+++ b/website/src/pages/documents/document-info.tsx
@@ -2,7 +2,7 @@ import "@reach/dialog/styles.css"
 import React, { Fragment } from "react"
 import { Helmet } from "react-helmet"
 import { unstable_Form as Form } from "reakit"
-import { useCredentials } from "src/auth"
+import { UserRole, useCredentials, useUserRole } from "src/auth"
 import { Link } from "src/components"
 import { useForm } from "src/edit-doc-data-form-context"
 import EditDocPanel, { EditButton } from "src/edit-doc-data-panel"
@@ -26,6 +26,7 @@ export const DocumentInfo = ({ doc }: { doc: Document }) => {
     variables: { slug: doc.slug! },
   })
   const token = useCredentials()
+  const userRole = useUserRole()
   const { form } = useForm()
   const { isEditing, setIsEditing } = useEditing()
   const [, updateDocument] = Dailp.useUpdateDocumentMetadataMutation()
@@ -319,7 +320,7 @@ export const DocumentInfo = ({ doc }: { doc: Document }) => {
       {/* If the user is logged in, then display an edit button on the word
   panel along with its corresponding formatted header. Otherwise, display
   the normal word panel. */}
-      {token ? (
+      {token && userRole !== UserRole.Reader ? (
         <>
           {!isEditing && <>{metadataDisplay}</>}
           <EditButton />


### PR DESCRIPTION
Fixes to the following issues:

- In the word pane - If text is input, then the audio is recorded, the text won't save. If the audio is recorded and you hit the higher level save button, then the audio doesn’t save. Likely issues is that the Save buttons are fighting

- Also fixed metadata editing button permissions by making it inaccessible to Readers.