### PR TITLE
655 subject headings edit abilities

### DIFF
--- a/graphql/.sqlx/query-0059a524d1966fe179b81afdf27abe1206e98d5dbd342f95fefe7449e663a89d.json
+++ b/graphql/.sqlx/query-0059a524d1966fe179b81afdf27abe1206e98d5dbd342f95fefe7449e663a89d.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id\nfrom document\nwhere short_name = $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0059a524d1966fe179b81afdf27abe1206e98d5dbd342f95fefe7449e663a89d"
+}

--- a/graphql/.sqlx/query-06b8461f89e4dc227c28b2fa754688c67ec2cdb8dfc3f82d34002bf24b886d3d.json
+++ b/graphql/.sqlx/query-06b8461f89e4dc227c28b2fa754688c67ec2cdb8dfc3f82d34002bf24b886d3d.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "delete from collection_chapter\nwhere collection_slug = $1;\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "06b8461f89e4dc227c28b2fa754688c67ec2cdb8dfc3f82d34002bf24b886d3d"
+}

--- a/graphql/.sqlx/query-06df1964f758ac1d6a38824db0b238c080e871211565e3f762ef3db8c48595d9.json
+++ b/graphql/.sqlx/query-06df1964f758ac1d6a38824db0b238c080e871211565e3f762ef3db8c48595d9.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  dk.document_id,\n  k.id,\n  k.name,\n  k.status as \"status: ApprovalStatus\"\nfrom document_keyword dk\njoin keyword k on k.id = dk.keyword_id\nwhere dk.document_id = any($1);",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "06df1964f758ac1d6a38824db0b238c080e871211565e3f762ef3db8c48595d9"
+}

--- a/graphql/.sqlx/query-075d6a8230eb7246513b111a111fc1433e967f16551d25b430ef211817f0666c.json
+++ b/graphql/.sqlx/query-075d6a8230eb7246513b111a111fc1433e967f16551d25b430ef211817f0666c.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  dsc.document_id,\n  sc.id,\n  sc.name,\n  sc.status as \"status: ApprovalStatus\"\nfrom document_spatial_coverage dsc\njoin spatial_coverage sc on sc.id = dsc.spatial_coverage_id\nwhere dsc.document_id = any($1);",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "075d6a8230eb7246513b111a111fc1433e967f16551d25b430ef211817f0666c"
+}

--- a/graphql/.sqlx/query-07c44e7e2037267dcdd8fcb9cb1e922a8c35460116cb1611064116ccbb149ad4.json
+++ b/graphql/.sqlx/query-07c44e7e2037267dcdd8fcb9cb1e922a8c35460116cb1611064116ccbb149ad4.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into collection_chapter (\n  title,\n  document_id,\n  wordpress_id,\n  index_in_parent,\n  chapter_path,\n  section)\nvalues (\n  $1,\n  $2,\n  $3,\n  $4,\n  $5,\n  $6\n)\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid",
+        "Int8",
+        "Int8",
+        {
+          "Custom": {
+            "name": "ltree",
+            "kind": "Simple"
+          }
+        },
+        {
+          "Custom": {
+            "name": "collection_section",
+            "kind": {
+              "Enum": [
+                "Intro",
+                "Body",
+                "Credit"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "07c44e7e2037267dcdd8fcb9cb1e922a8c35460116cb1611064116ccbb149ad4"
+}

--- a/graphql/.sqlx/query-0c697fa7d3e8459a4577e54b76a3b17bf1c872d3aa5cecb7a585d1b664261350.json
+++ b/graphql/.sqlx/query-0c697fa7d3e8459a4577e54b76a3b17bf1c872d3aa5cecb7a585d1b664261350.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into morpheme_gloss (document_id, gloss, example_shape, tag_id)\n  values ($1, $2, $3, $4)\non conflict (coalesce(document_id, uuid_nil()), gloss)\n  do update set example_shape = excluded.example_shape,\n     tag_id = excluded.tag_id\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0c697fa7d3e8459a4577e54b76a3b17bf1c872d3aa5cecb7a585d1b664261350"
+}

--- a/graphql/.sqlx/query-0eb7a20b6f240395c632e18ebe2aa7867c5e80c9516797fa44bedde694a512c4.json
+++ b/graphql/.sqlx/query-0eb7a20b6f240395c632e18ebe2aa7867c5e80c9516797fa44bedde694a512c4.json
@@ -1,0 +1,45 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n  f.id,\n  f.name,\n  f.status as \"status: ApprovalStatus\"\nFROM doc_format f\nJOIN document d ON d.format_id = f.id\nWHERE d.id = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0eb7a20b6f240395c632e18ebe2aa7867c5e80c9516797fa44bedde694a512c4"
+}

--- a/graphql/.sqlx/query-111528602fe0b3526ee8b1f1738c90d4715021bd6e194e0839df3bc6480525b6.json
+++ b/graphql/.sqlx/query-111528602fe0b3526ee8b1f1738c90d4715021bd6e194e0839df3bc6480525b6.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert the new set of spatial coverage IDs\ninsert into document_spatial_coverage (document_id, spatial_coverage_id)\nselect $1, unnest($2::uuid[]);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "111528602fe0b3526ee8b1f1738c90d4715021bd6e194e0839df3bc6480525b6"
+}

--- a/graphql/.sqlx/query-135c9817f7c50fa78c7d5bb4f2bfe950a0e7fa24fcb67169974fd885620ed78c.json
+++ b/graphql/.sqlx/query-135c9817f7c50fa78c7d5bb4f2bfe950a0e7fa24fcb67169974fd885620ed78c.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into menu (name, slug, items) values ($1, $2, $3);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "135c9817f7c50fa78c7d5bb4f2bfe950a0e7fa24fcb67169974fd885620ed78c"
+}

--- a/graphql/.sqlx/query-1dcb94a92cf69699d7e0db1f8b1cbd36a2aa2558823274c9399bd65bd39ab3a4.json
+++ b/graphql/.sqlx/query-1dcb94a92cf69699d7e0db1f8b1cbd36a2aa2558823274c9399bd65bd39ab3a4.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id from subject_heading where name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1dcb94a92cf69699d7e0db1f8b1cbd36a2aa2558823274c9399bd65bd39ab3a4"
+}

--- a/graphql/.sqlx/query-1dcec22261dae61c4404af7c630eb24e3cd2acc5b4717bcc9706f14c6dde7efc.json
+++ b/graphql/.sqlx/query-1dcec22261dae61c4404af7c630eb24e3cd2acc5b4717bcc9706f14c6dde7efc.json
@@ -1,0 +1,83 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  document.id as document_id,\n  document.is_reference,\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.recorded_at,\n  word.commentary,\n  word.index_in_document,\n  word.page_number\nfrom word\n  inner join document on document.id = word.document_id\n  left join word_segment on word_segment.word_id = word.id\n  inner join morpheme_gloss on morpheme_gloss.id = word_segment.gloss_id\nwhere morpheme_gloss.gloss = $1\n  and (word.document_id = $2 or $2 is null)\ngroup by document.id, word.id\norder by document.id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "is_reference",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 2,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "source_text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "simple_phonetics",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "phonemic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "english_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "recorded_at",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 8,
+        "name": "commentary",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "index_in_document",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 10,
+        "name": "page_number",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "1dcec22261dae61c4404af7c630eb24e3cd2acc5b4717bcc9706f14c6dde7efc"
+}

--- a/graphql/.sqlx/query-202e3b5ddb772a5b637ac29d49feb97ad13e871b48f6de117d98dd7a58514e2e.json
+++ b/graphql/.sqlx/query-202e3b5ddb772a5b637ac29d49feb97ad13e871b48f6de117d98dd7a58514e2e.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select page_id, title, content, path from page;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "page_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "path",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "202e3b5ddb772a5b637ac29d49feb97ad13e871b48f6de117d98dd7a58514e2e"
+}

--- a/graphql/.sqlx/query-25d44690f3c33f3fe3a206607956ab24ca52b0ad6693a8b66620452011eb4fc8.json
+++ b/graphql/.sqlx/query-25d44690f3c33f3fe3a206607956ab24ca52b0ad6693a8b66620452011eb4fc8.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert the new set of subject heading IDs\ninsert into document_subject_heading (document_id, subject_heading_id)\nselect $1, unnest($2::uuid[]);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "25d44690f3c33f3fe3a206607956ab24ca52b0ad6693a8b66620452011eb4fc8"
+}

--- a/graphql/.sqlx/query-2602151b0b02e7def582ae9adf17a0153514378a068b267334fe90e69e97b363.json
+++ b/graphql/.sqlx/query-2602151b0b02e7def582ae9adf17a0153514378a068b267334fe90e69e97b363.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Binds: document_id, slice_id, include_in_edited_collection, editor_id\n\nwith document_update as (\n  -- update ingested audio, if the slice_id was ingested audio\n  update document\n  set include_audio_in_edited_collection=$3,\n      audio_edited_by=$4\n  where document.id = $1\n    -- if the slice_id given doesn't match, we won't update\n    and document.audio_slice_id = $2 \n  returning document.id as document_id\n),\ndocument_user_media_update as (\n-- update user contributed audio, if the slice id is user contributed audio tied to the document\n  update document_user_media\n  set include_in_edited_collection=$3,\n      edited_by=$4\n  where document_id = $1\n    and media_slice_id = $2\n    returning document_id\n)\n\nselect distinct t.document_id\nfrom (\n  select document_id from document_update\n  union\n  select document_id from document_user_media_update\n) as t",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Bool",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "2602151b0b02e7def582ae9adf17a0153514378a068b267334fe90e69e97b363"
+}

--- a/graphql/.sqlx/query-26fb16ba5cc531729a4e24aa202c2c4aba2ea7895d20b129dbe7c330e08270c8.json
+++ b/graphql/.sqlx/query-26fb16ba5cc531729a4e24aa202c2c4aba2ea7895d20b129dbe7c330e08270c8.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into edited_collection(title, slug, description, thumbnail_url)\nvalues ($1, $2, $3, $4)\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "26fb16ba5cc531729a4e24aa202c2c4aba2ea7895d20b129dbe7c330e08270c8"
+}

--- a/graphql/.sqlx/query-274bff0dadd3e0556134490164981244659bbf07396f984a88e1f2840847fc3a.json
+++ b/graphql/.sqlx/query-274bff0dadd3e0556134490164981244659bbf07396f984a88e1f2840847fc3a.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT \n  id, \n  display_name, \n  created_at, \n  avatar_url, \n  bio, \n  organization, \n  location, \n  role::text as role\nFROM dailp_user\nWHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 3,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "bio",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "organization",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "location",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "role",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      null
+    ]
+  },
+  "hash": "274bff0dadd3e0556134490164981244659bbf07396f984a88e1f2840847fc3a"
+}

--- a/graphql/.sqlx/query-280ea98e88e4981b6d52a462dd82d4147f200fb051f395c8deb5aed197f5cc22.json
+++ b/graphql/.sqlx/query-280ea98e88e4981b6d52a462dd82d4147f200fb051f395c8deb5aed197f5cc22.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert a new language into the database\ninsert into language (id, name, status)\nvalues ($1::uuid, $2, $3)\nreturning id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "280ea98e88e4981b6d52a462dd82d4147f200fb051f395c8deb5aed197f5cc22"
+}

--- a/graphql/.sqlx/query-2874ae8f9cec1ce09c268adc74b096a15ca1d90cbb324289c679df9e451cb2ee.json
+++ b/graphql/.sqlx/query-2874ae8f9cec1ce09c268adc74b096a15ca1d90cbb324289c679df9e451cb2ee.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Delete all document pages, which will cascade to delete all associated\n-- paragraphs and words.\ndelete from document_page\nwhere document_id = $1\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2874ae8f9cec1ce09c268adc74b096a15ca1d90cbb324289c679df9e451cb2ee"
+}

--- a/graphql/.sqlx/query-2bd1bc1888b889a4dc59d1824c9e1787492602e2850aa2a4b487d4376eaa2a36.json
+++ b/graphql/.sqlx/query-2bd1bc1888b889a4dc59d1824c9e1787492602e2850aa2a4b487d4376eaa2a36.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "update dailp_user set\n    display_name =\n        case\n            when $2::text[] != '{}' and $2[1] is not null then $2[1]\n            else display_name\n        end,\n    avatar_url =\n        case\n            when $3::text[] != '{}' and $3[1] is not null then $3[1]\n            else avatar_url\n        end,\n    bio =\n        case\n            when $4::text[] != '{}' and $4[1] is not null then $4[1]\n            else bio\n        end,\n    organization =\n        case\n            when $5::text[] != '{}' and $5[1] is not null then $5[1]\n            else organization\n        end,\n    location =\n        case\n            when $6::text[] != '{}' and $6[1] is not null then $6[1]\n            else location\n        end,\n    role =\n        case\n            when $7::text[] != '{}' and $7[1] is not null then $7[1]::user_role\n            else role\n        end\nwhere id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2bd1bc1888b889a4dc59d1824c9e1787492602e2850aa2a4b487d4376eaa2a36"
+}

--- a/graphql/.sqlx/query-2cd850e19f25a475e87dc145dd1905fbf0af2b65f819b9caaa0ff71cac411b95.json
+++ b/graphql/.sqlx/query-2cd850e19f25a475e87dc145dd1905fbf0af2b65f819b9caaa0ff71cac411b95.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Delete all existing associations for this document\ndelete from document_language\nwhere document_id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2cd850e19f25a475e87dc145dd1905fbf0af2b65f819b9caaa0ff71cac411b95"
+}

--- a/graphql/.sqlx/query-2dbab3e84c02adad2c49a975de61a4ae53c4924d59f697720a7f7e5beb451617.json
+++ b/graphql/.sqlx/query-2dbab3e84c02adad2c49a975de61a4ae53c4924d59f697720a7f7e5beb451617.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- delete a comment given its ID\ndelete from comment where id = $1 returning id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2dbab3e84c02adad2c49a975de61a4ae53c4924d59f697720a7f7e5beb451617"
+}

--- a/graphql/.sqlx/query-2de4ffee6fd22585e8c39260e3bc30698f215cd349daf3e7a1172097101beb52.json
+++ b/graphql/.sqlx/query-2de4ffee6fd22585e8c39260e3bc30698f215cd349daf3e7a1172097101beb52.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Delete all existing associations for this document\ndelete from document_subject_heading\nwhere document_id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2de4ffee6fd22585e8c39260e3bc30698f215cd349daf3e7a1172097101beb52"
+}

--- a/graphql/.sqlx/query-3022824a364c2d9ca5062b985a08744f74e641818f5ee128e24fb2a89a344ce2.json
+++ b/graphql/.sqlx/query-3022824a364c2d9ca5062b985a08744f74e641818f5ee128e24fb2a89a344ce2.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "update paragraph set\n    english_translation =\n        case\n            when $2::text[] != '{}' and $2[1] is not null then $2[1]\n            else english_translation\n        end\nwhere id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3022824a364c2d9ca5062b985a08744f74e641818f5ee128e24fb2a89a344ce2"
+}

--- a/graphql/.sqlx/query-32052923a631af8b0a51564e9d08578fc30b5d0e58b1593e8651f53343c91156.json
+++ b/graphql/.sqlx/query-32052923a631af8b0a51564e9d08578fc30b5d0e58b1593e8651f53343c91156.json
@@ -1,0 +1,77 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  word_segment.morpheme,\n  word.id as word_id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number\nfrom morpheme_gloss\n  inner join document on document.id = morpheme_gloss.document_id\n  left join word_segment on word_segment.gloss_id = morpheme_gloss.id\n  left join word on word.id = word_segment.word_id\nwhere morpheme_gloss.gloss = $1\n  and document.short_name = $2\norder by word_segment.morpheme\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "morpheme",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "word_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "source_text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "simple_phonetics",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "phonemic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "english_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "commentary",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "index_in_document",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 9,
+        "name": "page_number",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "32052923a631af8b0a51564e9d08578fc30b5d0e58b1593e8651f53343c91156"
+}

--- a/graphql/.sqlx/query-333974583762f15eac58b81ebac55539897164e1229a12f061de23fa5a4f43ea.json
+++ b/graphql/.sqlx/query-333974583762f15eac58b81ebac55539897164e1229a12f061de23fa5a4f43ea.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Delete a creator from a document\ndelete from document_creator\nwhere document_id = $1::uuid;\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "333974583762f15eac58b81ebac55539897164e1229a12f061de23fa5a4f43ea"
+}

--- a/graphql/.sqlx/query-34755721c3c12ea731be9251242e9536b0c380137d1ef70a2d0ced7755eefd7f.json
+++ b/graphql/.sqlx/query-34755721c3c12ea731be9251242e9536b0c380137d1ef70a2d0ced7755eefd7f.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  media_slice.id as \"id\",\n  media_slice.time_range as \"range?\",\n  media_resource.url as \"resource_url\",\n  word_user_media.include_in_edited_collection as \"include_in_edited_collection\",\n  media_resource.recorded_at as \"recorded_at?\",\n  contributor.id as \"recorded_by?\",\n  contributor.display_name as \"recorded_by_name?\",\n  editor.id as \"edited_by?\",\n  editor.display_name as \"edited_by_name?\"\nfrom word_user_media\n  left join media_slice on media_slice.id = word_user_media.media_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user contributor on contributor.id = media_resource.recorded_by\n  left join dailp_user editor on editor.id = word_user_media.edited_by\nwhere\n  word_id = $1\norder by media_resource.recorded_at desc\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "range?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 2,
+        "name": "resource_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "include_in_edited_collection",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 5,
+        "name": "recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "edited_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "edited_by_name?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "34755721c3c12ea731be9251242e9536b0c380137d1ef70a2d0ced7755eefd7f"
+}

--- a/graphql/.sqlx/query-35acc71b364ed7efb64b5082a4a23c1424955963bbad243dba6269984a8f69c7.json
+++ b/graphql/.sqlx/query-35acc71b364ed7efb64b5082a4a23c1424955963bbad243dba6269984a8f69c7.json
@@ -1,0 +1,63 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  word_segment.index_in_word,\n  word_segment.word_id,\n  word_segment.morpheme,\n  word_segment.gloss_id,\n  morpheme_gloss.gloss,\n  word_segment.role as \"role: WordSegmentRole\"\nfrom word_segment\n  inner join morpheme_gloss on morpheme_gloss.id = word_segment.gloss_id\nwhere word_segment.word_id = any($1)\norder by word_segment.index_in_word\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "index_in_word",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "word_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "morpheme",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "gloss_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "role: WordSegmentRole",
+        "type_info": {
+          "Custom": {
+            "name": "word_segment_role",
+            "kind": {
+              "Enum": [
+                "Morpheme",
+                "Clitic",
+                "Modifier"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "35acc71b364ed7efb64b5082a4a23c1424955963bbad243dba6269984a8f69c7"
+}

--- a/graphql/.sqlx/query-363ece97aadc2e4337605619ae9c6a05618ec651a61aecddaa07ebc66698479c.json
+++ b/graphql/.sqlx/query-363ece97aadc2e4337605619ae9c6a05618ec651a61aecddaa07ebc66698479c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into dailp_user (id, display_name, created_at)\nvalues (\n    -- hint for uuid type instead of autouuid (column type), which can't be used\n    -- as a parameter\n    $1::uuid,\n    '',\n    now()\n)\non conflict do nothing;\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "363ece97aadc2e4337605619ae9c6a05618ec651a61aecddaa07ebc66698479c"
+}

--- a/graphql/.sqlx/query-388c671a0e5cf32298db07a5286a1ecb0efe59c9ddbdff1c7c49f79454a21801.json
+++ b/graphql/.sqlx/query-388c671a0e5cf32298db07a5286a1ecb0efe59c9ddbdff1c7c49f79454a21801.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select abstract_morpheme_tag.id as \"id!\"\nfrom unnest($1::text[]) as morpheme_gloss\n  inner join\n    abstract_morpheme_tag on abstract_morpheme_tag.internal_gloss = morpheme_gloss\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "388c671a0e5cf32298db07a5286a1ecb0efe59c9ddbdff1c7c49f79454a21801"
+}

--- a/graphql/.sqlx/query-3b0b4d896036ab2e88c29c9e98b0ec85ffc6d084774a4b499c70afac580c826b.json
+++ b/graphql/.sqlx/query-3b0b4d896036ab2e88c29c9e98b0ec85ffc6d084774a4b499c70afac580c826b.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert a new subject heading into the database\ninsert into subject_heading (id, name, status)\nvalues ($1::uuid, $2, $3)\nreturning id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3b0b4d896036ab2e88c29c9e98b0ec85ffc6d084774a4b499c70afac580c826b"
+}

--- a/graphql/.sqlx/query-3cf2408c84d9004128643f0e8e96747328340bf155ff46e3c21642a25518e81e.json
+++ b/graphql/.sqlx/query-3cf2408c84d9004128643f0e8e96747328340bf155ff46e3c21642a25518e81e.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT d.id\nFROM document as d\nJOIN user_bookmarked_document as ubd on ubd.document_id = d.id\nWHERE ubd.user_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3cf2408c84d9004128643f0e8e96747328340bf155ff46e3c21642a25518e81e"
+}

--- a/graphql/.sqlx/query-3ec2b1049a9f046a3525cdc92d993a3537a26e80647c7004582a30f4fc8613e0.json
+++ b/graphql/.sqlx/query-3ec2b1049a9f046a3525cdc92d993a3537a26e80647c7004582a30f4fc8613e0.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  dcr.document_id,\n  cr.id,\n  cr.name\nfrom document_creator dcr\njoin creator cr on cr.id = dcr.creator_id\nwhere dcr.document_id = any($1);",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3ec2b1049a9f046a3525cdc92d993a3537a26e80647c7004582a30f4fc8613e0"
+}

--- a/graphql/.sqlx/query-4045ffba55ad0ae1f2d3a312992deb720e304c59e46de256a2307f00dd6d7143.json
+++ b/graphql/.sqlx/query-4045ffba55ad0ae1f2d3a312992deb720e304c59e46de256a2307f00dd6d7143.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id\nfrom doc_format\nwhere name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "4045ffba55ad0ae1f2d3a312992deb720e304c59e46de256a2307f00dd6d7143"
+}

--- a/graphql/.sqlx/query-409cb1c7a1d9400f22fd5bce041c9a897e2e51f24f9c660ae0e46e91a027628d.json
+++ b/graphql/.sqlx/query-409cb1c7a1d9400f22fd5bce041c9a897e2e51f24f9c660ae0e46e91a027628d.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id from creator where name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "409cb1c7a1d9400f22fd5bce041c9a897e2e51f24f9c660ae0e46e91a027628d"
+}

--- a/graphql/.sqlx/query-43e42033828a07a488a1fbe4be6a5c7cea9d5c8d471d51a9fd39f939abd060f6.json
+++ b/graphql/.sqlx/query-43e42033828a07a488a1fbe4be6a5c7cea9d5c8d471d51a9fd39f939abd060f6.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  id,\n  index_in_document,\n  document_id,\n  iiif_source_id,\n  iiif_oid\nfrom document_page\nwhere document_id = any($1)\norder by index_in_document asc\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "index_in_document",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "iiif_source_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "iiif_oid",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "43e42033828a07a488a1fbe4be6a5c7cea9d5c8d471d51a9fd39f939abd060f6"
+}

--- a/graphql/.sqlx/query-46b1d304c94ba9adf55b2fa265b635d07af98af0796587af4bcfef8ab95ecffc.json
+++ b/graphql/.sqlx/query-46b1d304c94ba9adf55b2fa265b635d07af98af0796587af4bcfef8ab95ecffc.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT ubd.bookmarked_on\nFROM user_bookmarked_document AS ubd\nWHERE ubd.document_id = $1 AND ubd.user_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bookmarked_on",
+        "type_info": "Date"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "46b1d304c94ba9adf55b2fa265b635d07af98af0796587af4bcfef8ab95ecffc"
+}

--- a/graphql/.sqlx/query-47626f51affde3132dc7723df14672dfd5f606b93f3a7783bfad78bb528879a4.json
+++ b/graphql/.sqlx/query-47626f51affde3132dc7723df14672dfd5f606b93f3a7783bfad78bb528879a4.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into document_page (document_id, index_in_document, iiif_source_id, iiif_oid)\nvalues ($1, $2, $3, $4)\non conflict (document_id, index_in_document) do update set\nindex_in_document = excluded.index_in_document,\niiif_source_id = excluded.iiif_source_id,\niiif_oid = excluded.iiif_oid\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "47626f51affde3132dc7723df14672dfd5f606b93f3a7783bfad78bb528879a4"
+}

--- a/graphql/.sqlx/query-485b68540ad5d84e5e98c8ec34d4bbc9ddf5a4d129dca5aa9a87b5217c26e9a0.json
+++ b/graphql/.sqlx/query-485b68540ad5d84e5e98c8ec34d4bbc9ddf5a4d129dca5aa9a87b5217c26e9a0.json
@@ -1,0 +1,88 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  morpheme_gloss.id as gloss_id,\n  morpheme_gloss.example_shape,\n  abbreviation_system.short_name as system_name,\n  morpheme_gloss.gloss as abstract_gloss,\n  morpheme_tag.gloss as concrete_gloss,\n  morpheme_tag.title,\n  morpheme_tag.description,\n  morpheme_tag.role_override as \"role_override: WordSegmentRole\",\n  abstract_morpheme_tag.linguistic_type,\n  array(\n    select abstract_morpheme_tag.internal_gloss\n    from unnest(morpheme_tag.abstract_ids) as abstract_id\n      inner join abstract_morpheme_tag on abstract_morpheme_tag.id = abstract_id) as internal_tags\nfrom morpheme_gloss\n  inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id\n  left join abbreviation_system on abbreviation_system.short_name = any($2)\n  inner join morpheme_tag on morpheme_tag.abstract_ids[1] = abstract_morpheme_tag.id\nwhere morpheme_gloss.gloss = any($1)\n  and morpheme_tag.system_id = abbreviation_system.id\norder by array_length(morpheme_tag.abstract_ids, 1) desc\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "gloss_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "example_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "system_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "abstract_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "concrete_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "role_override: WordSegmentRole",
+        "type_info": {
+          "Custom": {
+            "name": "word_segment_role",
+            "kind": {
+              "Enum": [
+                "Morpheme",
+                "Clitic",
+                "Modifier"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "linguistic_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "internal_tags",
+        "type_info": "TextArray"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      null
+    ]
+  },
+  "hash": "485b68540ad5d84e5e98c8ec34d4bbc9ddf5a4d129dca5aa9a87b5217c26e9a0"
+}

--- a/graphql/.sqlx/query-49f26a45b73a43fe847fdeba747d4b857705f380fa7a5f314c9d5ae1103d81a9.json
+++ b/graphql/.sqlx/query-49f26a45b73a43fe847fdeba747d4b857705f380fa7a5f314c9d5ae1103d81a9.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  morpheme_gloss.id as gloss_id,\n  morpheme_gloss.example_shape,\n  abbreviation_system.short_name as system_name,\n  morpheme_tag.gloss,\n  morpheme_tag.title,\n  morpheme_tag.description,\n  morpheme_tag.role_override as \"role_override: WordSegmentRole\",\n  abstract_morpheme_tag.linguistic_type\nfrom morpheme_gloss\n  inner join abstract_morpheme_tag on abstract_morpheme_tag.id = morpheme_gloss.tag_id\n  left join abbreviation_system on abbreviation_system.short_name = any($2)\n  inner join morpheme_tag on morpheme_tag.abstract_ids[1] = abstract_morpheme_tag.id\nwhere morpheme_gloss.id = any($1)\n  and morpheme_tag.system_id = abbreviation_system.id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "gloss_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "example_shape",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "system_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "role_override: WordSegmentRole",
+        "type_info": {
+          "Custom": {
+            "name": "word_segment_role",
+            "kind": {
+              "Enum": [
+                "Morpheme",
+                "Clitic",
+                "Modifier"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "linguistic_type",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "49f26a45b73a43fe847fdeba747d4b857705f380fa7a5f314c9d5ae1103d81a9"
+}

--- a/graphql/.sqlx/query-4a730b276afaa42329bc3112b9ba071e1f59ac9664decc6c2c49d6c72be8e08b.json
+++ b/graphql/.sqlx/query-4a730b276afaa42329bc3112b9ba071e1f59ac9664decc6c2c49d6c72be8e08b.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Delete all existing associations for this document\ndelete from document_keyword\nwhere document_id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4a730b276afaa42329bc3112b9ba071e1f59ac9664decc6c2c49d6c72be8e08b"
+}

--- a/graphql/.sqlx/query-53da2fb268a480a278acccc99495181a2237caf1760dd96f290337a0e72ebe67.json
+++ b/graphql/.sqlx/query-53da2fb268a480a278acccc99495181a2237caf1760dd96f290337a0e72ebe67.json
@@ -1,0 +1,69 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "with t as (\n  select distinct on (morpheme_tag.gloss)\n    abbreviation_system.short_name as system_name,\n    morpheme_tag.abstract_ids,\n    morpheme_tag.gloss,\n    morpheme_tag.title,\n    morpheme_tag.description,\n    morpheme_tag.role_override as \"role_override: WordSegmentRole\",\n    abstract_morpheme_tag.linguistic_type\n  from abbreviation_system\n    inner join\n      morpheme_tag on abbreviation_system.id = morpheme_tag.system_id\n    inner join\n      abstract_morpheme_tag on\n        abstract_morpheme_tag.id = any(morpheme_tag.abstract_ids)\n  where abbreviation_system.short_name = $1\n  or abbreviation_system.short_name like 'CUS'\n)\n\nselect *\nfrom t\norder by linguistic_type asc, gloss asc;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "system_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "abstract_ids",
+        "type_info": "UuidArray"
+      },
+      {
+        "ordinal": 2,
+        "name": "gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "role_override: WordSegmentRole",
+        "type_info": {
+          "Custom": {
+            "name": "word_segment_role",
+            "kind": {
+              "Enum": [
+                "Morpheme",
+                "Clitic",
+                "Modifier"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "linguistic_type",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "53da2fb268a480a278acccc99495181a2237caf1760dd96f290337a0e72ebe67"
+}

--- a/graphql/.sqlx/query-5549c7f2ae3991f56bf51c9aa562c2a4672277cd741b6ca303b5a24ccc508065.json
+++ b/graphql/.sqlx/query-5549c7f2ae3991f56bf51c9aa562c2a4672277cd741b6ca303b5a24ccc508065.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id, title, slug, chapter_path\nfrom collection_chapter\nwhere chapter_path @> $1 and chapter_path != $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "chapter_path",
+        "type_info": {
+          "Custom": {
+            "name": "ltree",
+            "kind": "Simple"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "ltree",
+            "kind": "Simple"
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5549c7f2ae3991f56bf51c9aa562c2a4672277cd741b6ca303b5a24ccc508065"
+}

--- a/graphql/.sqlx/query-557d3873ee9d7a09888ebd831dc0256725e9f726c189b4e24d36d8a3201f007a.json
+++ b/graphql/.sqlx/query-557d3873ee9d7a09888ebd831dc0256725e9f726c189b4e24d36d8a3201f007a.json
@@ -1,0 +1,126 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number,\n  media_resource.recorded_at as \"audio_recorded_at?\",\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  media_slice.id as \"audio_slice_id?\",\n  contributor.id as \"audio_recorded_by?\",\n  contributor.display_name as \"audio_recorded_by_name?\",\n  word.include_audio_in_edited_collection,\n  editor.id as \"audio_edited_by?\",\n  editor.display_name as \"audio_edited_by_name?\"\nfrom word\n  left join media_slice on media_slice.id = word.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user contributor on contributor.id = media_resource.recorded_by\n  left join dailp_user editor on editor.id = media_resource.recorded_by\nwhere\n  document_id = $1 and (\n    word.index_in_document >= $2 or $2 is null\n  ) and (word.index_in_document < $3 or $3 is null)\norder by index_in_document\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "source_text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "simple_phonetics",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "phonemic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "english_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "commentary",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "index_in_document",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 8,
+        "name": "page_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "audio_recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 10,
+        "name": "audio_url?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "audio_slice?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 12,
+        "name": "audio_slice_id?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "audio_recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "audio_recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "include_audio_in_edited_collection",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "audio_edited_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 17,
+        "name": "audio_edited_by_name?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "557d3873ee9d7a09888ebd831dc0256725e9f726c189b4e24d36d8a3201f007a"
+}

--- a/graphql/.sqlx/query-5658907658d581f2644f3eb0bc921269e317e3b5386efa73fb76c6e611ae34ce.json
+++ b/graphql/.sqlx/query-5658907658d581f2644f3eb0bc921269e317e3b5386efa73fb76c6e611ae34ce.json
@@ -1,0 +1,45 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select \n    sh.id, \n    sh.name, \n    sh.status as \"status: ApprovalStatus\"\nfrom subject_heading sh\njoin document_subject_heading dsh on sh.id = dsh.subject_heading_id\nwhere dsh.document_id = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5658907658d581f2644f3eb0bc921269e317e3b5386efa73fb76c6e611ae34ce"
+}

--- a/graphql/.sqlx/query-5794962daf1326932373ee33c1b06702d50ec31a741a43871d05ce37120a5f0d.json
+++ b/graphql/.sqlx/query-5794962daf1326932373ee33c1b06702d50ec31a741a43871d05ce37120a5f0d.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  slug,\n  title,\n  id\nfrom document_group\nwhere slug = $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5794962daf1326932373ee33c1b06702d50ec31a741a43871d05ce37120a5f0d"
+}

--- a/graphql/.sqlx/query-587e868e1c86816469a9169bf07be80df5add11ef357029f74629e112d88b88e.json
+++ b/graphql/.sqlx/query-587e868e1c86816469a9169bf07be80df5add11ef357029f74629e112d88b88e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert a document-local morpheme gloss if and only if there's no matching\n-- global gloss.\ninsert into morpheme_gloss (document_id, gloss)\nselect document_id, gloss from unnest($1::uuid[], $2::text[]) as input_data(document_id, gloss)\nwhere not exists (select from morpheme_gloss where morpheme_gloss.document_id is null and morpheme_gloss.gloss = input_data.gloss)\non conflict (coalesce(document_id, uuid_nil()), gloss) do nothing\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "587e868e1c86816469a9169bf07be80df5add11ef357029f74629e112d88b88e"
+}

--- a/graphql/.sqlx/query-5a0b15cba34f7675b31afa6c09d970533df17db3dd3df43b67df271101fbd2e7.json
+++ b/graphql/.sqlx/query-5a0b15cba34f7675b31afa6c09d970533df17db3dd3df43b67df271101fbd2e7.json
@@ -1,0 +1,124 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number,\n  media_resource.recorded_at as \"audio_recorded_at?\",\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  media_slice.id as \"audio_slice_id?\",\n  contributor.id as \"audio_recorded_by?\",\n  contributor.display_name as \"audio_recorded_by_name?\",\n  word.include_audio_in_edited_collection as \"include_audio_in_edited_collection\",\n  editor.id as \"audio_edited_by?\",\n  editor.display_name as \"audio_edited_by_name?\"\nfrom word\n  left join media_slice on media_slice.id = word.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user contributor on contributor.id = media_resource.recorded_by\n  left join dailp_user editor on editor.id = word.audio_edited_by\nwhere source_text like any($1)\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "source_text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "simple_phonetics",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "phonemic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "english_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "commentary",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "index_in_document",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 8,
+        "name": "page_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "audio_recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 10,
+        "name": "audio_url?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "audio_slice?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 12,
+        "name": "audio_slice_id?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "audio_recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "audio_recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "include_audio_in_edited_collection",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "audio_edited_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 17,
+        "name": "audio_edited_by_name?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "5a0b15cba34f7675b31afa6c09d970533df17db3dd3df43b67df271101fbd2e7"
+}

--- a/graphql/.sqlx/query-5b02e933a678ac98033d73b4a7e306c50fd3b52fefe5557e5a6b3058276edb49.json
+++ b/graphql/.sqlx/query-5b02e933a678ac98033d73b4a7e306c50fd3b52fefe5557e5a6b3058276edb49.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id from language where name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5b02e933a678ac98033d73b4a7e306c50fd3b52fefe5557e5a6b3058276edb49"
+}

--- a/graphql/.sqlx/query-5e289d51c54b8f14432482d05e86ec9b6ffddd5b83acee04fcd76bdab6dd27a5.json
+++ b/graphql/.sqlx/query-5e289d51c54b8f14432482d05e86ec9b6ffddd5b83acee04fcd76bdab6dd27a5.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into abstract_morpheme_tag (internal_gloss, linguistic_type)\nvalues ($1, $2)\non conflict (internal_gloss) do update set\nlinguistic_type = excluded.linguistic_type\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5e289d51c54b8f14432482d05e86ec9b6ffddd5b83acee04fcd76bdab6dd27a5"
+}

--- a/graphql/.sqlx/query-5ed736651d677fd216c010f1dec8b0617a3d682d6a438b977185d94423e05300.json
+++ b/graphql/.sqlx/query-5ed736651d677fd216c010f1dec8b0617a3d682d6a438b977185d94423e05300.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  attr.document_id,\n  attr.contribution_role,\n  contributor.id,\n  contributor.full_name\nfrom contributor_attribution as attr\n  inner join contributor on contributor.id = attr.contributor_id\nwhere attr.document_id = any($1)\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "contribution_role",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "full_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5ed736651d677fd216c010f1dec8b0617a3d682d6a438b977185d94423e05300"
+}

--- a/graphql/.sqlx/query-5f5b9be067b8a06464c69a59a8d4f678d95235de17a97131509b0bbccdd4a3b2.json
+++ b/graphql/.sqlx/query-5f5b9be067b8a06464c69a59a8d4f678d95235de17a97131509b0bbccdd4a3b2.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into abstract_morpheme_tag (internal_gloss, linguistic_type)\nvalues ($1, $2)\non conflict (internal_gloss) do update set\nlinguistic_type = excluded.linguistic_type\nreturning id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5f5b9be067b8a06464c69a59a8d4f678d95235de17a97131509b0bbccdd4a3b2"
+}

--- a/graphql/.sqlx/query-620b4f982ca02edd00c541f95fd0562c473ffdc88e20a40bc89cbcc8fb043978.json
+++ b/graphql/.sqlx/query-620b4f982ca02edd00c541f95fd0562c473ffdc88e20a40bc89cbcc8fb043978.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id, name, slug, items from menu where slug = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "items",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "620b4f982ca02edd00c541f95fd0562c473ffdc88e20a40bc89cbcc8fb043978"
+}

--- a/graphql/.sqlx/query-6353f976ce1b230cc524cbc6d2811b034ef8d5d8b4edad4fbef36143ff8293f2.json
+++ b/graphql/.sqlx/query-6353f976ce1b230cc524cbc6d2811b034ef8d5d8b4edad4fbef36143ff8293f2.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into page (slug, path, title, content)\nvalues ($1, $2, $3, $4)\non conflict (path) do update set\ntitle = excluded.title,\ncontent = excluded.content",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6353f976ce1b230cc524cbc6d2811b034ef8d5d8b4edad4fbef36143ff8293f2"
+}

--- a/graphql/.sqlx/query-645cd4a34cc6d5509f6785a67821ccfa58bfecaf2ae70103f2e617232467a0b9.json
+++ b/graphql/.sqlx/query-645cd4a34cc6d5509f6785a67821ccfa58bfecaf2ae70103f2e617232467a0b9.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id\nfrom genre\nwhere name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "645cd4a34cc6d5509f6785a67821ccfa58bfecaf2ae70103f2e617232467a0b9"
+}

--- a/graphql/.sqlx/query-666ca11632c6ce33f6fa36f05bdf9289282d4dca4348ce9ba63643973b32ed60.json
+++ b/graphql/.sqlx/query-666ca11632c6ce33f6fa36f05bdf9289282d4dca4348ce9ba63643973b32ed60.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select \n    e.id,\n    e.title,\n    e.wordpress_menu_id,\n    e.description,\n    e.slug,\n    e.thumbnail_url\nfrom edited_collection as e;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "wordpress_menu_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "thumbnail_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "666ca11632c6ce33f6fa36f05bdf9289282d4dca4348ce9ba63643973b32ed60"
+}

--- a/graphql/.sqlx/query-674a9d3f98f6701f08b1dc9295a8f76201dbc70d4a1e7c2eeb1fd22364658fab.json
+++ b/graphql/.sqlx/query-674a9d3f98f6701f08b1dc9295a8f76201dbc70d4a1e7c2eeb1fd22364658fab.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Binds: user_id, resource_url, start, end, document_id\n\nwith upserted_audio_resource as (\n  insert into media_resource (url, recorded_at, recorded_by)\n  select $2::text, now(), $1\n  -- we do this no-op update to ensure an id is returned\n  on conflict (url) do update set url=excluded.url\n  returning id\n),\n\ninserted_audio_slice as (\n  insert into media_slice (resource_id, time_range)\n  select upserted_audio_resource.id, int8range($3, $4)\n  from upserted_audio_resource\n  returning id\n)\n\ninsert into document_user_media (document_id, media_slice_id)\n  select $5, inserted_audio_slice.id\n  from inserted_audio_slice\n  join document on document.id = $5\n    on conflict (media_slice_id, document_id) do nothing -- document already associated\n  returning media_slice_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "media_slice_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Int8",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "674a9d3f98f6701f08b1dc9295a8f76201dbc70d4a1e7c2eeb1fd22364658fab"
+}

--- a/graphql/.sqlx/query-6858e67c5a27aa4f38366244a46c9a4a50546c164a2b91599301aad1bc8f3cd0.json
+++ b/graphql/.sqlx/query-6858e67c5a27aa4f38366244a46c9a4a50546c164a2b91599301aad1bc8f3cd0.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into contributor_attribution (contributor_id, document_id, contribution_role)\nselect\n  contributor.id,\n  input_data.doc_id,\n  input_data.contribution_role\nfrom\n  unnest(\n    $1::text[], $2::uuid[], $3::text[]\n  ) as input_data(full_name, doc_id, contribution_role)\n  inner join contributor on contributor.full_name = input_data.full_name\n-- If this document already has this contributor, move on.\non conflict do nothing\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        "UuidArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6858e67c5a27aa4f38366244a46c9a4a50546c164a2b91599301aad1bc8f3cd0"
+}

--- a/graphql/.sqlx/query-6bd9e2f1fac53364f56f92396da5c9037a968d1a27389d1859f2bee7d9076c2e.json
+++ b/graphql/.sqlx/query-6bd9e2f1fac53364f56f92396da5c9037a968d1a27389d1859f2bee7d9076c2e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert the new set of keyword IDs\ninsert into document_keyword (document_id, keyword_id)\nselect $1, unnest($2::uuid[]);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6bd9e2f1fac53364f56f92396da5c9037a968d1a27389d1859f2bee7d9076c2e"
+}

--- a/graphql/.sqlx/query-6d5a72c97ad0bb2831e0b605a340630b28f70402023f5abec5ff2043f343f0b1.json
+++ b/graphql/.sqlx/query-6d5a72c97ad0bb2831e0b605a340630b28f70402023f5abec5ff2043f343f0b1.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "delete from media_resource\nwhere id in (\n  select media_slice.resource_id\n  from media_slice\n    inner join document on document.audio_slice_id = media_slice.id\n  where document.short_name = $1\n)\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6d5a72c97ad0bb2831e0b605a340630b28f70402023f5abec5ff2043f343f0b1"
+}

--- a/graphql/.sqlx/query-6e7b6214dada232abd76ea916dc0c14aef0f5f4dfc51aa0046511e72d7cfde8b.json
+++ b/graphql/.sqlx/query-6e7b6214dada232abd76ea916dc0c14aef0f5f4dfc51aa0046511e72d7cfde8b.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Delete all existing associations for this document\ndelete from contributor_attribution\nwhere document_id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6e7b6214dada232abd76ea916dc0c14aef0f5f4dfc51aa0046511e72d7cfde8b"
+}

--- a/graphql/.sqlx/query-6f8b00224cf0cfe8f9c273ce515feea869d24052c99c85ab9e4699742764ceac.json
+++ b/graphql/.sqlx/query-6f8b00224cf0cfe8f9c273ce515feea869d24052c99c85ab9e4699742764ceac.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n    id,\n    slug,\n    title,\n    wordpress_menu_id\nFROM\n    edited_collection\nWHERE\n    id = $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "wordpress_menu_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "6f8b00224cf0cfe8f9c273ce515feea869d24052c99c85ab9e4699742764ceac"
+}

--- a/graphql/.sqlx/query-71674fa0e3cc15ae4ab9509aed80adcf20010b5d7bcf7e68a88d95e685abb323.json
+++ b/graphql/.sqlx/query-71674fa0e3cc15ae4ab9509aed80adcf20010b5d7bcf7e68a88d95e685abb323.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into word (document_id, source_text, simple_phonetics, phonemic, english_gloss, recorded_at, commentary,\n  page_number, index_in_document)\nselect * from unnest($1::uuid[], $2::text[], $3::text[], $4::text[], $5::text[], $6::date[], $7::text[], $8::text[], $9::bigint[])\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "DateArray",
+        "TextArray",
+        "TextArray",
+        "Int8Array"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "71674fa0e3cc15ae4ab9509aed80adcf20010b5d7bcf7e68a88d95e685abb323"
+}

--- a/graphql/.sqlx/query-72f4cf42410b8baab2c488d13e60fe6f4164cba88386430d3cc10e74c293f49e.json
+++ b/graphql/.sqlx/query-72f4cf42410b8baab2c488d13e60fe6f4164cba88386430d3cc10e74c293f49e.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id, title, description, wordpress_menu_id, slug, thumbnail_url\nfrom edited_collection\nwhere slug = any($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "wordpress_menu_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "thumbnail_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "72f4cf42410b8baab2c488d13e60fe6f4164cba88386430d3cc10e74c293f49e"
+}

--- a/graphql/.sqlx/query-73409561936ce0fa2234c9b37c12419fd61bed4d25a4a87599bbf646b80c7d9f.json
+++ b/graphql/.sqlx/query-73409561936ce0fa2234c9b37c12419fd61bed4d25a4a87599bbf646b80c7d9f.json
@@ -1,0 +1,37 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into word_segment (gloss_id, word_id, index_in_word, morpheme, role)\n-- Fill in glosses that weren't inserted with their global match.\nselect\n  coalesce(inserted_gloss.id, global_gloss.id),\n  word_id,\n  index,\n  morpheme,\n  role\nfrom\n  unnest(\n    $1::uuid[], $2::text[], $3::uuid[], $4::bigint[], $5::text[], $6::word_segment_role[]\n  ) as input_data(document_id, gloss, word_id, index, morpheme, role)\n  left join\n    morpheme_gloss as inserted_gloss on\n      inserted_gloss.document_id = input_data.document_id and inserted_gloss.gloss = input_data.gloss\n  left join\n    morpheme_gloss as global_gloss on\n      global_gloss.document_id is null and global_gloss.gloss = input_data.gloss\non conflict (word_id, index_in_word)\ndo update set\nmorpheme = excluded.morpheme,\ngloss_id = excluded.gloss_id,\nrole = excluded.role\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "TextArray",
+        "UuidArray",
+        "Int8Array",
+        "TextArray",
+        {
+          "Custom": {
+            "name": "_word_segment_role",
+            "kind": {
+              "Array": {
+                "Custom": {
+                  "name": "word_segment_role",
+                  "kind": {
+                    "Enum": [
+                      "Morpheme",
+                      "Clitic",
+                      "Modifier"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "73409561936ce0fa2234c9b37c12419fd61bed4d25a4a87599bbf646b80c7d9f"
+}

--- a/graphql/.sqlx/query-736bb1b4c8d050434299383e2f3278824c9bf68ba926e888642e65fdb19b3d2c.json
+++ b/graphql/.sqlx/query-736bb1b4c8d050434299383e2f3278824c9bf68ba926e888642e65fdb19b3d2c.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into morpheme_gloss (document_id, gloss, example_shape)\nselect $1, * from unnest($2::text[], $3::text[])\non conflict (coalesce(document_id, uuid_nil()), gloss)\n  do update set\n    example_shape = excluded.example_shape\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "736bb1b4c8d050434299383e2f3278824c9bf68ba926e888642e65fdb19b3d2c"
+}

--- a/graphql/.sqlx/query-73d95554008fd50133c8cd8c5e71bc7efb994e750d27023fbd0a014430ee717a.json
+++ b/graphql/.sqlx/query-73d95554008fd50133c8cd8c5e71bc7efb994e750d27023fbd0a014430ee717a.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Add a new keyword to the database\ninsert into keyword (id, name, status)\nvalues ($1::uuid, $2, $3)\nreturning id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "73d95554008fd50133c8cd8c5e71bc7efb994e750d27023fbd0a014430ee717a"
+}

--- a/graphql/.sqlx/query-749fb63d5984a981541e4e48f58a537362159925056c7c2ef2da6ef55ce95c53.json
+++ b/graphql/.sqlx/query-749fb63d5984a981541e4e48f58a537362159925056c7c2ef2da6ef55ce95c53.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Binds: word_id, slice_id, include_in_edited_collection, editor_id\n\nwith word_update as (\n  -- update ingested audio, if the slice_id was ingested audio\n  update word\n  set include_audio_in_edited_collection=$3,\n      audio_edited_by=$4\n  where word.id = $1\n    -- if the slice_id given doesn't match, we won't update\n    and word.audio_slice_id = $2 \n  returning word.id as word_id\n),\nword_user_media_update as (\n-- update user contributed audio, if the slice id is user contributed audio tied to the word\n  update word_user_media\n  set include_in_edited_collection=$3,\n      edited_by=$4\n  where word_id = $1\n    and media_slice_id = $2\n    returning word_id\n)\n\nselect distinct t.word_id\nfrom (\n  select word_id from word_update\n  union\n  select word_id from word_user_media_update\n) as t",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "word_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Bool",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "749fb63d5984a981541e4e48f58a537362159925056c7c2ef2da6ef55ce95c53"
+}

--- a/graphql/.sqlx/query-774aa2feee9734f0cb7270b3e330731422aecbd72551cdd4a7f24b5fb1dc7c66.json
+++ b/graphql/.sqlx/query-774aa2feee9734f0cb7270b3e330731422aecbd72551cdd4a7f24b5fb1dc7c66.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into contributor (full_name)\nvalues ($1)\non conflict (full_name) do update set\nfull_name = excluded.full_name\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "774aa2feee9734f0cb7270b3e330731422aecbd72551cdd4a7f24b5fb1dc7c66"
+}

--- a/graphql/.sqlx/query-7860f1d60b1f09d62987a89d413a7243cb23005b6f19bb539b88311dbfbd223d.json
+++ b/graphql/.sqlx/query-7860f1d60b1f09d62987a89d413a7243cb23005b6f19bb539b88311dbfbd223d.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  document_group.slug,\n  document_group.title\nfrom document\n  inner join document_group on document_group.id = document.group_id\nwhere document.id = $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "7860f1d60b1f09d62987a89d413a7243cb23005b6f19bb539b88311dbfbd223d"
+}

--- a/graphql/.sqlx/query-7a6c5fc86cb220cb8e0dcbfbbb994b6288490c39e31cef7bc46a9ccc7e321438.json
+++ b/graphql/.sqlx/query-7a6c5fc86cb220cb8e0dcbfbbb994b6288490c39e31cef7bc46a9ccc7e321438.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into character_transcription (\n  page_id, index_in_page, possible_transcriptions\n)\nselect\n  $1,\n  index,\n  array[transcription]\nfrom unnest($2::bigint[], $3::text[]) as t(index, transcription)\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8Array",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7a6c5fc86cb220cb8e0dcbfbbb994b6288490c39e31cef7bc46a9ccc7e321438"
+}

--- a/graphql/.sqlx/query-7ab61f15f209163e5f67c2570dfe577637c7123cb8b56effcebe8fd7635afb09.json
+++ b/graphql/.sqlx/query-7ab61f15f209163e5f67c2570dfe577637c7123cb8b56effcebe8fd7635afb09.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "update word set\n    source_text =\n        case\n            when $2::text[] != '{}' and $2[1] is not null then $2[1]\n            else source_text\n        end,\n    simple_phonetics =\n        case\n            when $3::text[] != '{}' and $3[1] is not null then $3[1] \n            else simple_phonetics\n        end,\n    commentary =\n        case\n            when $4::text[] != '{}' and $4[1] is not null then $4[1]\n            else commentary\n        end,\n    english_gloss =\n        case\n            when $5::text[] != '{}' and $5[1] is not null then $5[1]\n            else english_gloss\n        end\n\nwhere id = $1\nreturning word.document_id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "7ab61f15f209163e5f67c2570dfe577637c7123cb8b56effcebe8fd7635afb09"
+}

--- a/graphql/.sqlx/query-7cd63426900d1ed9bfaf14ed2b3fe36abc140ba5dd300b8d17c4b82f287a3537.json
+++ b/graphql/.sqlx/query-7cd63426900d1ed9bfaf14ed2b3fe36abc140ba5dd300b8d17c4b82f287a3537.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, \n  display_name, \n  created_at, \n  avatar_url, \n  bio, \n  organization, \n  location, \n  role::text as role\nFROM dailp_user\nORDER BY display_name",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 3,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "bio",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "organization",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "location",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "role",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      null
+    ]
+  },
+  "hash": "7cd63426900d1ed9bfaf14ed2b3fe36abc140ba5dd300b8d17c4b82f287a3537"
+}

--- a/graphql/.sqlx/query-7dd3742e8e678aa19890a52f0843ed635cf126dd6f9b50b57918184dab2485c1.json
+++ b/graphql/.sqlx/query-7dd3742e8e678aa19890a52f0843ed635cf126dd6f9b50b57918184dab2485c1.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert audio resource if there is one for this word.\nwith inserted_audio_resource as (\n  insert into media_resource (url)\n  select $12::text\n  where $12 is not null\n  on conflict (url) do nothing\n),\n\ninserted_audio_slice as (\n  insert into media_slice (resource_id, time_range)\n  select media_resource.id, int8range($13, $14)\n  from media_resource\n  where media_resource.url = $12\n  returning id\n)\n\ninsert into word (\n  source_text, simple_phonetics, phonemic, english_gloss, recorded_at, commentary,\n  document_id, page_number, index_in_document, page_id, character_range, audio_slice_id)\nselect $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, inserted_audio_slice.id\nfrom (values (1)) as t\n  left join inserted_audio_slice on true\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Date",
+        "Text",
+        "Uuid",
+        "Text",
+        "Int8",
+        "Uuid",
+        "Int8Range",
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "7dd3742e8e678aa19890a52f0843ed635cf126dd6f9b50b57918184dab2485c1"
+}

--- a/graphql/.sqlx/query-801894d827b0385398a9e5fd631d66002634a8958eda5565544433318d0af6a4.json
+++ b/graphql/.sqlx/query-801894d827b0385398a9e5fd631d66002634a8958eda5565544433318d0af6a4.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into abbreviation_system (short_name, title)\nvalues ($1, $2)\non conflict (short_name) do update set\ntitle = excluded.title\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "801894d827b0385398a9e5fd631d66002634a8958eda5565544433318d0af6a4"
+}

--- a/graphql/.sqlx/query-829f9c2b35731454ad938f666f546edd281de1873a2899710b5a6b9d694a2012.json
+++ b/graphql/.sqlx/query-829f9c2b35731454ad938f666f546edd281de1873a2899710b5a6b9d694a2012.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into collection_chapter (\n  title,\n  document_id,\n  wordpress_id,\n  index_in_parent,\n  chapter_path,\n  section)\nvalues (\n  $1,\n  ( select id\n    from document\n    where short_name = $2),\n  $3,\n  $4,\n  $5,\n  $6\n)\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int8",
+        "Int8",
+        {
+          "Custom": {
+            "name": "ltree",
+            "kind": "Simple"
+          }
+        },
+        {
+          "Custom": {
+            "name": "collection_section",
+            "kind": {
+              "Enum": [
+                "Intro",
+                "Body",
+                "Credit"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "829f9c2b35731454ad938f666f546edd281de1873a2899710b5a6b9d694a2012"
+}

--- a/graphql/.sqlx/query-83485d5e45864f8200987fb4a6401eafbb81237d50de27b1420ad66663e7d7ee.json
+++ b/graphql/.sqlx/query-83485d5e45864f8200987fb4a6401eafbb81237d50de27b1420ad66663e7d7ee.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM user_bookmarked_document\nWHERE document_id = $1 AND user_id = $2;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "83485d5e45864f8200987fb4a6401eafbb81237d50de27b1420ad66663e7d7ee"
+}

--- a/graphql/.sqlx/query-8505f6cc868d7524f5f05f62724cff4f6c5136afdb0c1df2a3edea53be942bb5.json
+++ b/graphql/.sqlx/query-8505f6cc868d7524f5f05f62724cff4f6c5136afdb0c1df2a3edea53be942bb5.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id, full_name\nfrom contributor\nwhere full_name = any($1)\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "full_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "8505f6cc868d7524f5f05f62724cff4f6c5136afdb0c1df2a3edea53be942bb5"
+}

--- a/graphql/.sqlx/query-85a2e9ee66b665b6b4545f3689093b057885d12eabf0e0593f95537e07f895da.json
+++ b/graphql/.sqlx/query-85a2e9ee66b665b6b4545f3689093b057885d12eabf0e0593f95537e07f895da.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into collection_chapter_attribution (\n  chapter_id,\n  contributor_id,\n  contribution_role\n)\nvalues (\n  $1, $2, $3\n)\non conflict (chapter_id, contributor_id) do update set\n  contribution_role = excluded.contribution_role; ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "85a2e9ee66b665b6b4545f3689093b057885d12eabf0e0593f95537e07f895da"
+}

--- a/graphql/.sqlx/query-8c81f58693bd926e7f4013f3fee19f464d44a641447190298e6d1380f0ab508a.json
+++ b/graphql/.sqlx/query-8c81f58693bd926e7f4013f3fee19f464d44a641447190298e6d1380f0ab508a.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into paragraph (page_id, character_range, english_translation)\nvalues ($1, $2, $3)\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8Range",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8c81f58693bd926e7f4013f3fee19f464d44a641447190298e6d1380f0ab508a"
+}

--- a/graphql/.sqlx/query-8cb0a451858f4732fb2ad08616b5654aaeca3c60f861105227d43aebedab71e3.json
+++ b/graphql/.sqlx/query-8cb0a451858f4732fb2ad08616b5654aaeca3c60f861105227d43aebedab71e3.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id from spatial_coverage where name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8cb0a451858f4732fb2ad08616b5654aaeca3c60f861105227d43aebedab71e3"
+}

--- a/graphql/.sqlx/query-8d3ceaae6a15910949eceeeff805e3a93231b1d234897dc2f8bd71fc6df3baaa.json
+++ b/graphql/.sqlx/query-8d3ceaae6a15910949eceeeff805e3a93231b1d234897dc2f8bd71fc6df3baaa.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert a collection with a certain slug.\ninsert into document_group (slug, title)\nvalues ($1, $2)\non conflict (slug) do update set\ntitle = excluded.title\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8d3ceaae6a15910949eceeeff805e3a93231b1d234897dc2f8bd71fc6df3baaa"
+}

--- a/graphql/.sqlx/query-8f23f2ea8730fc8f24aee4a5a62d102d386a68749f299d84b341513a5b9048c5.json
+++ b/graphql/.sqlx/query-8f23f2ea8730fc8f24aee4a5a62d102d386a68749f299d84b341513a5b9048c5.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into document (\n  short_name, title, is_reference, written_at, audio_slice_id, group_id, index_in_group\n)\nvalues ($1, $2, $3, $4, $5, $6, $7)\non conflict (short_name) do update set\ntitle = excluded.title,\nis_reference = excluded.is_reference,\nwritten_at = excluded.written_at,\naudio_slice_id = excluded.audio_slice_id,\ngroup_id = excluded.group_id,\nindex_in_group = excluded.index_in_group\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Bool",
+        "Date",
+        "Uuid",
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8f23f2ea8730fc8f24aee4a5a62d102d386a68749f299d84b341513a5b9048c5"
+}

--- a/graphql/.sqlx/query-9404181792966be2d77b3a751ebba731341f0a2fb8bd5f231e6add7a438c525d.json
+++ b/graphql/.sqlx/query-9404181792966be2d77b3a751ebba731341f0a2fb8bd5f231e6add7a438c525d.json
@@ -1,0 +1,124 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number,\n  media_resource.recorded_at as \"audio_recorded_at?\",\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  media_slice.id as \"audio_slice_id?\",\n  contributor.id as \"audio_recorded_by?\",\n  contributor.display_name as \"audio_recorded_by_name?\",\n  word.include_audio_in_edited_collection,\n  editor.id as \"audio_edited_by?\",\n  editor.display_name as \"audio_edited_by_name?\"\nfrom word\n  left join media_slice on media_slice.id = word.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user contributor on contributor.id = media_resource.recorded_by\n  left join dailp_user editor on editor.id = media_resource.recorded_by\nwhere\n  word.id = $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "source_text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "simple_phonetics",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "phonemic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "english_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "commentary",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "index_in_document",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 8,
+        "name": "page_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "audio_recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 10,
+        "name": "audio_url?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "audio_slice?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 12,
+        "name": "audio_slice_id?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "audio_recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "audio_recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "include_audio_in_edited_collection",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "audio_edited_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 17,
+        "name": "audio_edited_by_name?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9404181792966be2d77b3a751ebba731341f0a2fb8bd5f231e6add7a438c525d"
+}

--- a/graphql/.sqlx/query-997a6b67374a45f8069b7d705048c3a5809123915a689afbfe41b469298d66dc.json
+++ b/graphql/.sqlx/query-997a6b67374a45f8069b7d705048c3a5809123915a689afbfe41b469298d66dc.json
@@ -1,0 +1,102 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n    comment.id,\n    posted_at,\n    posted_by,\n    u_posted_by.display_name as \"posted_by_name\",\n    text_content,\n    edited,\n    comment_type as \"comment_type: _\",\n    parent_id,\n    parent_type as \"parent_type: _\"\nfrom comment\njoin dailp_user u_posted_by on u_posted_by.id = posted_by\nwhere parent_id = $1 and parent_type = $2\norder by posted_at asc",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "posted_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 2,
+        "name": "posted_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "posted_by_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "text_content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "edited",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "comment_type: _",
+        "type_info": {
+          "Custom": {
+            "name": "comment_type_enum",
+            "kind": {
+              "Enum": [
+                "Story",
+                "Suggestion",
+                "Question"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "parent_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "parent_type: _",
+        "type_info": {
+          "Custom": {
+            "name": "comment_parent_type",
+            "kind": {
+              "Enum": [
+                "Word",
+                "Paragraph"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        {
+          "Custom": {
+            "name": "comment_parent_type",
+            "kind": {
+              "Enum": [
+                "Word",
+                "Paragraph"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "997a6b67374a45f8069b7d705048c3a5809123915a689afbfe41b469298d66dc"
+}

--- a/graphql/.sqlx/query-99d55eae86048794baccc42af37865490076942b51b668f9f22e178189f87db4.json
+++ b/graphql/.sqlx/query-99d55eae86048794baccc42af37865490076942b51b668f9f22e178189f87db4.json
@@ -1,0 +1,45 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select \n    sc.id, \n    sc.name, \n    sc.status as \"status: ApprovalStatus\"\nfrom spatial_coverage sc\njoin document_spatial_coverage dsc on sc.id = dsc.spatial_coverage_id\nwhere dsc.document_id = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "99d55eae86048794baccc42af37865490076942b51b668f9f22e178189f87db4"
+}

--- a/graphql/.sqlx/query-9a64bbf49ee505cb6d937a227b7831f1370437f8ba18d453b4952da2447be64b.json
+++ b/graphql/.sqlx/query-9a64bbf49ee505cb6d937a227b7831f1370437f8ba18d453b4952da2447be64b.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "update document set\n    title = \n        case\n            when $2::text[] != '{}' and $2[1] is not null then $2[1]\n            else title\n        end,\n    written_at =\n        case\n            when $3::date is not null then $3::date\n            else written_at\n        end,\n    format_id =\n        case\n            when $4::uuid is not null then $4\n            else format_id\n        end,\n    genre_id =\n        case\n            when $5::uuid is not null then $5\n            else genre_id\n        end\nwhere id = $1\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "TextArray",
+        "Date",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9a64bbf49ee505cb6d937a227b7831f1370437f8ba18d453b4952da2447be64b"
+}

--- a/graphql/.sqlx/query-9ca4777c2467a1c905282887ba13a518fcc32730683509386941fbecd5b322f1.json
+++ b/graphql/.sqlx/query-9ca4777c2467a1c905282887ba13a518fcc32730683509386941fbecd5b322f1.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into document (\n  short_name, title, is_reference, written_at, group_id, index_in_group\n)\nvalues ($1, $2, $3, $4, $5, $6)\non conflict (short_name) do update set\n  title = excluded.title,\n  is_reference = excluded.is_reference,\n  written_at = excluded.written_at,\n  group_id = excluded.group_id,\n  index_in_group = excluded.index_in_group\nreturning id;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Bool",
+        "Date",
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9ca4777c2467a1c905282887ba13a518fcc32730683509386941fbecd5b322f1"
+}

--- a/graphql/.sqlx/query-9d270f3e33540bd0dd7217a854269a03f504367d9158530ff3724de866197c0d.json
+++ b/graphql/.sqlx/query-9d270f3e33540bd0dd7217a854269a03f504367d9158530ff3724de866197c0d.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id\nfrom contributor\nwhere full_name = $1 ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9d270f3e33540bd0dd7217a854269a03f504367d9158530ff3724de866197c0d"
+}

--- a/graphql/.sqlx/query-9e02521e2e4f9bb5ee2e1c9dd33e18bb9b0ee8b7d584cf9867b889b92334f082.json
+++ b/graphql/.sqlx/query-9e02521e2e4f9bb5ee2e1c9dd33e18bb9b0ee8b7d584cf9867b889b92334f082.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  d.id,\n  d.short_name,\n  d.title,\n  d.written_at as \"date: Date\",\n  d.index_in_group as order_index\nfrom document_group\n  inner join document as d on document_group.id = d.group_id\nwhere document_group.slug = $1\norder by d.index_in_group asc\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "short_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "date: Date",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 4,
+        "name": "order_index",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "9e02521e2e4f9bb5ee2e1c9dd33e18bb9b0ee8b7d584cf9867b889b92334f082"
+}

--- a/graphql/.sqlx/query-9f25d7904e761e4a2503d49da62c92df0020e1f6f19ede29621f8bc22395553c.json
+++ b/graphql/.sqlx/query-9f25d7904e761e4a2503d49da62c92df0020e1f6f19ede29621f8bc22395553c.json
@@ -1,0 +1,45 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n  g.id,\n  g.name,\n  g.status as \"status: ApprovalStatus\"\nFROM genre g\nJOIN document d ON d.genre_id = g.id\nWHERE d.id = $1;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9f25d7904e761e4a2503d49da62c92df0020e1f6f19ede29621f8bc22395553c"
+}

--- a/graphql/.sqlx/query-9f7eb50f8ed21c61994cca0aece59dd7cf1997b8df85b8d26b57a53b8348e865.json
+++ b/graphql/.sqlx/query-9f7eb50f8ed21c61994cca0aece59dd7cf1997b8df85b8d26b57a53b8348e865.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert new creator or update name if creator with same ID exists\ninsert into creator (id, name)\nvalues ($1::uuid, $2)\nreturning id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9f7eb50f8ed21c61994cca0aece59dd7cf1997b8df85b8d26b57a53b8348e865"
+}

--- a/graphql/.sqlx/query-9f91be464c9e113d326e6ba91b03dc95f1b94adf482990dba756305fb68b0165.json
+++ b/graphql/.sqlx/query-9f91be464c9e113d326e6ba91b03dc95f1b94adf482990dba756305fb68b0165.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into document (\n  short_name, title, is_reference, written_at, audio_slice_id, group_id\n)\nvalues ($1, $2, $3, $4, $5, $6)\non conflict (short_name) do update set\ntitle = excluded.title,\nis_reference = excluded.is_reference,\nwritten_at = excluded.written_at,\naudio_slice_id = excluded.audio_slice_id,\ngroup_id = excluded.group_id\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Bool",
+        "Date",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9f91be464c9e113d326e6ba91b03dc95f1b94adf482990dba756305fb68b0165"
+}

--- a/graphql/.sqlx/query-9fa592632c5e08225d16fdea92e255ee52d1ad39562f9c1f19876668148e36e3.json
+++ b/graphql/.sqlx/query-9fa592632c5e08225d16fdea92e255ee52d1ad39562f9c1f19876668148e36e3.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "update comment set\n    text_content =\n        case\n            when $2::text[] != '{}' and $2[1] is not null then $2[1]\n            else text_content\n        end,\n    comment_type = \n        case\n            when $3::comment_type_enum[] != '{}' and $3[1] is not null then $3[1]\n            else comment_type\n        end,\n    edited = $4\nwhere id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "TextArray",
+        {
+          "Custom": {
+            "name": "_comment_type_enum",
+            "kind": {
+              "Array": {
+                "Custom": {
+                  "name": "comment_type_enum",
+                  "kind": {
+                    "Enum": [
+                      "Story",
+                      "Suggestion",
+                      "Question"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "Bool"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9fa592632c5e08225d16fdea92e255ee52d1ad39562f9c1f19876668148e36e3"
+}

--- a/graphql/.sqlx/query-9fb47c8eb49c684dfbc203446a131bcbe29d26092d7b45002c3580d72c74c327.json
+++ b/graphql/.sqlx/query-9fb47c8eb49c684dfbc203446a131bcbe29d26092d7b45002c3580d72c74c327.json
@@ -1,0 +1,45 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select \n    k.id, \n    k.name, \n    k.status as \"status: ApprovalStatus\"\nfrom keyword k\njoin document_keyword dk on dk.keyword_id = k.id\nwhere dk.document_id = $1;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9fb47c8eb49c684dfbc203446a131bcbe29d26092d7b45002c3580d72c74c327"
+}

--- a/graphql/.sqlx/query-a24146cbf9ffcb7b7c90f722b3c295a2f55ffbe0edb36f06cc2d18df4707b549.json
+++ b/graphql/.sqlx/query-a24146cbf9ffcb7b7c90f722b3c295a2f55ffbe0edb36f06cc2d18df4707b549.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  id,\n  base_url\nfrom iiif_source\nwhere id = $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "base_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "a24146cbf9ffcb7b7c90f722b3c295a2f55ffbe0edb36f06cc2d18df4707b549"
+}

--- a/graphql/.sqlx/query-a3de9c6ddb10a50518b2fa828ea6819795526edd0b89244def851fcc204debc6.json
+++ b/graphql/.sqlx/query-a3de9c6ddb10a50518b2fa828ea6819795526edd0b89244def851fcc204debc6.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Binds: user_id, resource_url, start, end, word_id\n\nwith upserted_audio_resource as (\n  insert into media_resource (url, recorded_at, recorded_by)\n  select $2::text, now(), $1\n  -- we do this no-op update to ensure an id is returned\n  on conflict (url) do update set url=excluded.url\n  returning id\n),\n\ninserted_audio_slice as (\n  insert into media_slice (resource_id, time_range)\n  select upserted_audio_resource.id, int8range($3, $4)\n  from upserted_audio_resource\n  returning id\n)\n\ninsert into word_user_media (word_id, media_slice_id)\n  select $5, inserted_audio_slice.id\n  from inserted_audio_slice\n  join word on word.id = $5\n    on conflict (media_slice_id, word_id) do nothing -- word already associated\n  returning media_slice_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "media_slice_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Int8",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a3de9c6ddb10a50518b2fa828ea6819795526edd0b89244def851fcc204debc6"
+}

--- a/graphql/.sqlx/query-a4d2e1e84878d6a249ca0a9dd9486828a139f5993c75bc350fef3612650e038f.json
+++ b/graphql/.sqlx/query-a4d2e1e84878d6a249ca0a9dd9486828a139f5993c75bc350fef3612650e038f.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  document.id,\n  document.short_name,\n  document.title,\n  document.written_at,\n  document.is_reference,\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'name',\n        contributor.full_name,\n        'role',\n        contributor_attribution.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  )\n  as contributors\nfrom document\n  left join\n    contributor_attribution on contributor_attribution.document_id = document.id\n  left join contributor on contributor.id = contributor_attribution.contributor_id\ngroup by\n  document.id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "short_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "written_at",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 4,
+        "name": "is_reference",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "contributors",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      null
+    ]
+  },
+  "hash": "a4d2e1e84878d6a249ca0a9dd9486828a139f5993c75bc350fef3612650e038f"
+}

--- a/graphql/.sqlx/query-a5799421963397f074375ebf431af110f81ae2ec4038f272c82112c3eda5a742.json
+++ b/graphql/.sqlx/query-a5799421963397f074375ebf431af110f81ae2ec4038f272c82112c3eda5a742.json
@@ -1,0 +1,125 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "with recursive relations as (\n  -- Base case: all relations involving the input morpheme.\n  select\n    rl.left_gloss_id,\n    rl.right_gloss_id\n  from morpheme_gloss_relation as rl\n    inner join\n      morpheme_gloss on\n        rl.left_gloss_id = morpheme_gloss.id or rl.right_gloss_id = morpheme_gloss.id\n  where morpheme_gloss.gloss = $1 and morpheme_gloss.document_id = $2\n\n  -- Recursive case: saturate the graph (no duplicates)\n  union\n  select\n    rlr.left_gloss_id,\n    rlr.right_gloss_id\n  from morpheme_gloss_relation as rlr\n    -- Retrieve all relations that involve any previous sources or destinations\n    inner join\n      relations on\n        rlr.left_gloss_id = relations.right_gloss_id or rlr.right_gloss_id = relations.left_gloss_id or rlr.left_gloss_id = relations.left_gloss_id or rlr.right_gloss_id = relations.right_gloss_id\n)\n\nselect\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number,\n  media_resource.recorded_at as \"audio_recorded_at?\",\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  media_slice.id as \"audio_slice_id?\",\n  contributor.id as \"audio_recorded_by?\",\n  contributor.display_name as \"audio_recorded_by_name?\",\n  word.include_audio_in_edited_collection,\n  editor.id as \"audio_edited_by?\",\n  editor.display_name as \"audio_edited_by_name?\"\nfrom relations\n  inner join\n    morpheme_gloss on\n      morpheme_gloss.id = relations.left_gloss_id or morpheme_gloss.id = relations.right_gloss_id\n  inner join word_segment on word_segment.gloss_id = morpheme_gloss.id\n  inner join word on word.id = word_segment.word_id\n  left join media_slice on media_slice.id = word.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user contributor on contributor.id = media_resource.recorded_by\n  left join dailp_user editor on editor.id = word.audio_edited_by\norder by word.document_id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "source_text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "simple_phonetics",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "phonemic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "english_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "commentary",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "index_in_document",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 8,
+        "name": "page_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "audio_recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 10,
+        "name": "audio_url?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "audio_slice?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 12,
+        "name": "audio_slice_id?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "audio_recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "audio_recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "include_audio_in_edited_collection",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "audio_edited_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 17,
+        "name": "audio_edited_by_name?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a5799421963397f074375ebf431af110f81ae2ec4038f272c82112c3eda5a742"
+}

--- a/graphql/.sqlx/query-a73d2efa8ce1946a030d738070f2075478c1c8ba8bf87ff39d8e75d9e0bfcb2d.json
+++ b/graphql/.sqlx/query-a73d2efa8ce1946a030d738070f2075478c1c8ba8bf87ff39d8e75d9e0bfcb2d.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into morpheme_tag (\n  system_id, abstract_ids, gloss, title, role_override, description\n)\nvalues ($1, $2, $3, $4, $5, $6)\nreturning id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray",
+        "Text",
+        "Text",
+        {
+          "Custom": {
+            "name": "word_segment_role",
+            "kind": {
+              "Enum": [
+                "Morpheme",
+                "Clitic",
+                "Modifier"
+              ]
+            }
+          }
+        },
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a73d2efa8ce1946a030d738070f2075478c1c8ba8bf87ff39d8e75d9e0bfcb2d"
+}

--- a/graphql/.sqlx/query-a8f7e026b923c82ddcdc135f55b78f9be10bd15d79ab6bbe38d67bf765d08ed8.json
+++ b/graphql/.sqlx/query-a8f7e026b923c82ddcdc135f55b78f9be10bd15d79ab6bbe38d67bf765d08ed8.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  dsh.document_id,\n  sh.id,\n  sh.name,\n  sh.status as \"status: ApprovalStatus\"\nfrom document_subject_heading dsh\njoin subject_heading sh on sh.id = dsh.subject_heading_id\nwhere dsh.document_id = any($1);",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a8f7e026b923c82ddcdc135f55b78f9be10bd15d79ab6bbe38d67bf765d08ed8"
+}

--- a/graphql/.sqlx/query-ad6298118abd413f4b812fac74d3b3eca67df20cb41fe98fa69c31e4b0c46b0b.json
+++ b/graphql/.sqlx/query-ad6298118abd413f4b812fac74d3b3eca67df20cb41fe98fa69c31e4b0c46b0b.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into doc_format (id, name, status)\nvalues ($1::uuid, $2, $3)\nreturning id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ad6298118abd413f4b812fac74d3b3eca67df20cb41fe98fa69c31e4b0c46b0b"
+}

--- a/graphql/.sqlx/query-adf7c2e1df3df7933db162eab569fca49c7129f52d156dd9b658c2f4736b4888.json
+++ b/graphql/.sqlx/query-adf7c2e1df3df7933db162eab569fca49c7129f52d156dd9b658c2f4736b4888.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert the new set of language IDs\ninsert into document_language (document_id, language_id)\nselect $1, unnest($2::uuid[]);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "adf7c2e1df3df7933db162eab569fca49c7129f52d156dd9b658c2f4736b4888"
+}

--- a/graphql/.sqlx/query-ae6c1dc518463a7cc00dd96de74a7c4b955f1b7b74fa09c843581e6bcdb534d6.json
+++ b/graphql/.sqlx/query-ae6c1dc518463a7cc00dd96de74a7c4b955f1b7b74fa09c843581e6bcdb534d6.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into genre (id, name, status)\nvalues ($1::uuid, $2, $3)\nreturning id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ae6c1dc518463a7cc00dd96de74a7c4b955f1b7b74fa09c843581e6bcdb534d6"
+}

--- a/graphql/.sqlx/query-afca9b69fc11aef29379ab4d753d0b644b6ee3a698f3a6e857bfb6a83a4b38f1.json
+++ b/graphql/.sqlx/query-afca9b69fc11aef29379ab4d753d0b644b6ee3a698f3a6e857bfb6a83a4b38f1.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into iiif_source (title, base_url)\nvalues ($1, $2)\non conflict (base_url) do update\nset title = excluded.title\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "afca9b69fc11aef29379ab4d753d0b644b6ee3a698f3a6e857bfb6a83a4b38f1"
+}

--- a/graphql/.sqlx/query-b2cd756955024a13a5c1e385ef85461a7335fd7fe7bd4c3067f3a872516a77ce.json
+++ b/graphql/.sqlx/query-b2cd756955024a13a5c1e385ef85461a7335fd7fe7bd4c3067f3a872516a77ce.json
@@ -1,0 +1,80 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n    id,\n    title,\n    document_id,\n    wordpress_id,\n    index_in_parent,\n    section as \"section: CollectionSection\",\n    chapter_path,\n    ltree2text(subpath(chapter_path, 0, 1)) AS \"collection_slug!\"\nfrom collection_chapter\nwhere ltree2text(subpath(chapter_path, 0, 1)) = any($1);",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "wordpress_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "index_in_parent",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "section: CollectionSection",
+        "type_info": {
+          "Custom": {
+            "name": "collection_section",
+            "kind": {
+              "Enum": [
+                "Intro",
+                "Body",
+                "Credit"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "chapter_path",
+        "type_info": {
+          "Custom": {
+            "name": "ltree",
+            "kind": "Simple"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "collection_slug!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "b2cd756955024a13a5c1e385ef85461a7335fd7fe7bd4c3067f3a872516a77ce"
+}

--- a/graphql/.sqlx/query-b48c8aaace5a866c6b39949a5b06954e8b9916c363ac4aad0d72bf006accf84b.json
+++ b/graphql/.sqlx/query-b48c8aaace5a866c6b39949a5b06954e8b9916c363ac4aad0d72bf006accf84b.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Selects the internal_gloss if there is one, otherwise \n-- selects the given gloss, a custom gloss entered by the user.\nselect coalesce(internal_gloss, input_gloss) as gloss\nfrom abstract_morpheme_tag\n\n-- Limits the fields of the table to only those with one abstract id,\n-- and which have the same abstract id as the abstract_morpheme_tag table.\n  inner join morpheme_tag\n    on array_length(morpheme_tag.abstract_ids, 1) = 1 \n      and abstract_morpheme_tag.id = morpheme_tag.abstract_ids[1] \n\n-- Limits the fields of the table to only those with the matching short name\n-- as the input and those with the corresponding system id from morpheme_tag.\n  inner join abbreviation_system \n    on abbreviation_system.short_name = $2::text \n      and morpheme_tag.system_id = abbreviation_system.id\n\n-- Joins matching glosses with the morpheme_tag table,\n-- and keeps the input_gloss even if there is no matching gloss (these will\n-- be the custom gloss entered by the user.)\n  right join unnest($1::text[]) as input_gloss\n    on input_gloss = morpheme_tag.gloss",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "gloss",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b48c8aaace5a866c6b39949a5b06954e8b9916c363ac4aad0d72bf006accf84b"
+}

--- a/graphql/.sqlx/query-b7038dc48a868e64a92cb7c32e8758da16d4c15891cdc5b06a25251f75fc8747.json
+++ b/graphql/.sqlx/query-b7038dc48a868e64a92cb7c32e8758da16d4c15891cdc5b06a25251f75fc8747.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id from keyword where name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "b7038dc48a868e64a92cb7c32e8758da16d4c15891cdc5b06a25251f75fc8747"
+}

--- a/graphql/.sqlx/query-bba471ad9b42019470e67093fe974374468b993c472479dfae34b60d505188c0.json
+++ b/graphql/.sqlx/query-bba471ad9b42019470e67093fe974374468b993c472479dfae34b60d505188c0.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into edited_collection (slug, title, wordpress_menu_id)\nvalues ($1, $2, $3)\non conflict (slug) do update\nset title = excluded.title,\nwordpress_menu_id = excluded.wordpress_menu_id\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bba471ad9b42019470e67093fe974374468b993c472479dfae34b60d505188c0"
+}

--- a/graphql/.sqlx/query-bd01d061f04d7e8e1087d2c68e31bb3a08bb3e1da52b4b094608d3ebb45c88ff.json
+++ b/graphql/.sqlx/query-bd01d061f04d7e8e1087d2c68e31bb3a08bb3e1da52b4b094608d3ebb45c88ff.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id, page_id, english_translation\nfrom paragraph\nwhere page_id = any($1)\norder by character_range asc\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "page_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "english_translation",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "bd01d061f04d7e8e1087d2c68e31bb3a08bb3e1da52b4b094608d3ebb45c88ff"
+}

--- a/graphql/.sqlx/query-bde80529393c1595fe31c0bdbaa7e840c68ea7c74896d512c60f6f3b2431fba5.json
+++ b/graphql/.sqlx/query-bde80529393c1595fe31c0bdbaa7e840c68ea7c74896d512c60f6f3b2431fba5.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "delete from word\nwhere document_id = $1\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bde80529393c1595fe31c0bdbaa7e840c68ea7c74896d512c60f6f3b2431fba5"
+}

--- a/graphql/.sqlx/query-bffbcce7cc64754d41ab50c77b7b9b4327542888637fe3a76e686f7fbb361c44.json
+++ b/graphql/.sqlx/query-bffbcce7cc64754d41ab50c77b7b9b4327542888637fe3a76e686f7fbb361c44.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into morpheme_tag (\n  system_id, abstract_ids, gloss, title, role_override, description\n)\nvalues ($1, $2, $3, $4, $5, $6)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray",
+        "Text",
+        "Text",
+        {
+          "Custom": {
+            "name": "word_segment_role",
+            "kind": {
+              "Enum": [
+                "Morpheme",
+                "Clitic",
+                "Modifier"
+              ]
+            }
+          }
+        },
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bffbcce7cc64754d41ab50c77b7b9b4327542888637fe3a76e686f7fbb361c44"
+}

--- a/graphql/.sqlx/query-c0cef7d704075f0154e3f22cdca0667d65e70bb6c2da5ed3a3b32d1ca97364a6.json
+++ b/graphql/.sqlx/query-c0cef7d704075f0154e3f22cdca0667d65e70bb6c2da5ed3a3b32d1ca97364a6.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select c.* \nfrom creator c \njoin document_creator dc \non dc.creator_id = c.id \nwhere dc.document_id = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "c0cef7d704075f0154e3f22cdca0667d65e70bb6c2da5ed3a3b32d1ca97364a6"
+}

--- a/graphql/.sqlx/query-c20fa09d88d5c220c2d9740229c13876f5a7cf8ae114170a5ceaa0e357b61006.json
+++ b/graphql/.sqlx/query-c20fa09d88d5c220c2d9740229c13876f5a7cf8ae114170a5ceaa0e357b61006.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  page_id,\n  title,\n  path,\n  slug,\n  content as body\nfrom page\nwhere path = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "page_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "body",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c20fa09d88d5c220c2d9740229c13876f5a7cf8ae114170a5ceaa0e357b61006"
+}

--- a/graphql/.sqlx/query-c65c9c86a72c8d5bcca4f2e241c72579691a52de8c1ae829cee41e35c87c4785.json
+++ b/graphql/.sqlx/query-c65c9c86a72c8d5bcca4f2e241c72579691a52de8c1ae829cee41e35c87c4785.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM abbreviation_system WHERE short_name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c65c9c86a72c8d5bcca4f2e241c72579691a52de8c1ae829cee41e35c87c4785"
+}

--- a/graphql/.sqlx/query-c956fa4511edb5e5a27aef94a615510d10b541d6a5fb33705489ebd28bb89407.json
+++ b/graphql/.sqlx/query-c956fa4511edb5e5a27aef94a615510d10b541d6a5fb33705489ebd28bb89407.json
@@ -1,0 +1,130 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  paragraph.id as paragraph_id,\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number,\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  word.audio_slice_id,\n  media_resource.recorded_at as \"audio_recorded_at?\",\n  contributor.id as \"audio_recorded_by?\",\n  contributor.display_name as \"audio_recorded_by_name?\",\n  word.include_audio_in_edited_collection,\n  editor.id as \"audio_edited_by?\",\n  editor.display_name as \"audio_edited_by_name?\"\nfrom word\n  inner join paragraph on paragraph.page_id = word.page_id\n  left join media_slice on media_slice.id = word.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user contributor on contributor.id = media_resource.recorded_by\n  left join dailp_user editor on editor.id = media_resource.recorded_by\nwhere paragraph.id = any($1)\n  and word.character_range is not null\n  -- Include words that overlap with the paragraph range\n  and word.character_range && paragraph.character_range\n  -- Exclude words that start before the paragraph, which means that words are\n  -- always included in the paragraph that they start in. This is the same logic\n  -- as line breaks.\n  and word.character_range &> paragraph.character_range\n-- Include all joined primary keys in the GROUP BY clause.\n-- Why? ^^\ngroup by word.id,\n  paragraph.id,\n  media_slice.id,\n  media_resource.id,\n  contributor.id,\n  editor.id\norder by word.character_range\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "paragraph_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "source_text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "simple_phonetics",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "phonemic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "english_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "commentary",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "index_in_document",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 9,
+        "name": "page_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "audio_url?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "audio_slice?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 12,
+        "name": "audio_slice_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "audio_recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 14,
+        "name": "audio_recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "audio_recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "include_audio_in_edited_collection",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "audio_edited_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 18,
+        "name": "audio_edited_by_name?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c956fa4511edb5e5a27aef94a615510d10b541d6a5fb33705489ebd28bb89407"
+}

--- a/graphql/.sqlx/query-c9c0c39118f06319b1617f8ae8020985ed41a9eeafddbd84887555305ca49cb3.json
+++ b/graphql/.sqlx/query-c9c0c39118f06319b1617f8ae8020985ed41a9eeafddbd84887555305ca49cb3.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  d.id,\n  d.short_name,\n  d.title,\n  d.is_reference,\n  d.written_at,\n  d.audio_slice_id,\n  media_resource.url as \"audio_url?\",\n  media_resource.recorded_at as \"recorded_at?\",\n  dailp_user.id as \"recorded_by?\",\n  dailp_user.display_name as \"recorded_by_name?\",\n  media_slice.time_range as \"audio_slice?\",\n  ubd.bookmarked_on as \"bookmarked_on?\",\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'name', contributor.full_name, 'role', attr.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  )\n  as contributors\nfrom document as d\n  left join contributor_attribution as attr on attr.document_id = d.id\n  left join contributor on contributor.id = attr.contributor_id\n  left join media_slice on media_slice.id = d.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user on dailp_user.id = media_resource.recorded_by\n  left join user_bookmarked_document as ubd on ubd.document_id = d.id\nwhere d.short_name = any($1)\ngroup by d.id,\n  media_slice.id,\n  media_resource.id,\n  dailp_user.id,\n  ubd.bookmarked_on\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "short_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "is_reference",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "written_at",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 5,
+        "name": "audio_slice_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "audio_url?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 8,
+        "name": "recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 9,
+        "name": "recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "audio_slice?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 11,
+        "name": "bookmarked_on?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 12,
+        "name": "contributors",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      null
+    ]
+  },
+  "hash": "c9c0c39118f06319b1617f8ae8020985ed41a9eeafddbd84887555305ca49cb3"
+}

--- a/graphql/.sqlx/query-cc71e3a7b4c013adc4d0cb79acd702aa0daa0290013a31e9fee3bd1f5990fa4f.json
+++ b/graphql/.sqlx/query-cc71e3a7b4c013adc4d0cb79acd702aa0daa0290013a31e9fee3bd1f5990fa4f.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into morpheme_gloss_relation (left_gloss_id, right_gloss_id)\nselect\n  left_gloss.id,\n  right_gloss.id\nfrom\n  unnest(\n    $1::text[], $2::text[], $3::text[], $4::text[]\n  ) as input_relation(left_doc_name, left_gloss, right_doc_name, right_gloss)\n  inner join document as left_doc on left_doc.short_name = input_relation.left_doc_name\n  inner join\n    morpheme_gloss as left_gloss on\n      left_gloss.gloss = input_relation.left_gloss and left_gloss.document_id = left_doc.id\n  inner join\n    document as right_doc on right_doc.short_name = input_relation.right_doc_name\n  inner join\n    morpheme_gloss as right_gloss on\n      right_gloss.gloss = input_relation.right_gloss and right_gloss.document_id = right_doc.id\non conflict do nothing\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cc71e3a7b4c013adc4d0cb79acd702aa0daa0290013a31e9fee3bd1f5990fa4f"
+}

--- a/graphql/.sqlx/query-d5b5032b2eb283890a953ce99b3f300e49283ad20a55f728865e76df483b0576.json
+++ b/graphql/.sqlx/query-d5b5032b2eb283890a953ce99b3f300e49283ad20a55f728865e76df483b0576.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id, name, status::text as status from subject_heading order by name asc;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "status",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "d5b5032b2eb283890a953ce99b3f300e49283ad20a55f728865e76df483b0576"
+}

--- a/graphql/.sqlx/query-d6377d5a54a702f7df73f287390c0c45a1309f7e705c93d49842b409a947a1fd.json
+++ b/graphql/.sqlx/query-d6377d5a54a702f7df73f287390c0c45a1309f7e705c93d49842b409a947a1fd.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select count(id)\nfrom word\nwhere document_id = $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "d6377d5a54a702f7df73f287390c0c45a1309f7e705c93d49842b409a947a1fd"
+}

--- a/graphql/.sqlx/query-d8430d4cd5dfa365f9c2a8730bad16ed36c2e0b19cda9fc972d62606883a08c6.json
+++ b/graphql/.sqlx/query-d8430d4cd5dfa365f9c2a8730bad16ed36c2e0b19cda9fc972d62606883a08c6.json
@@ -1,0 +1,91 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n    comment.id,\n    posted_at,\n    posted_by,\n    u_posted_by.display_name as \"posted_by_name\",\n    text_content,\n    edited,\n    comment_type as \"comment_type: _\",\n    parent_id,\n    parent_type as \"parent_type: _\"\nfrom comment\njoin dailp_user u_posted_by on u_posted_by.id = posted_by\nwhere comment.id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "posted_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 2,
+        "name": "posted_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "posted_by_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "text_content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "edited",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "comment_type: _",
+        "type_info": {
+          "Custom": {
+            "name": "comment_type_enum",
+            "kind": {
+              "Enum": [
+                "Story",
+                "Suggestion",
+                "Question"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "parent_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "parent_type: _",
+        "type_info": {
+          "Custom": {
+            "name": "comment_parent_type",
+            "kind": {
+              "Enum": [
+                "Word",
+                "Paragraph"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "d8430d4cd5dfa365f9c2a8730bad16ed36c2e0b19cda9fc972d62606883a08c6"
+}

--- a/graphql/.sqlx/query-d8bc89c2d802ac2da071308eb27bdd1bc2bbdc31d64e8ccad71d4b861f8be12b.json
+++ b/graphql/.sqlx/query-d8bc89c2d802ac2da071308eb27bdd1bc2bbdc31d64e8ccad71d4b861f8be12b.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  id,\n  title,\n  base_url\nfrom iiif_source\nwhere id = any($1)\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "base_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d8bc89c2d802ac2da071308eb27bdd1bc2bbdc31d64e8ccad71d4b861f8be12b"
+}

--- a/graphql/.sqlx/query-d97c20748ef0337f3a9079b637595f8b0ad6d2227f97d34131836cae0b4a5f81.json
+++ b/graphql/.sqlx/query-d97c20748ef0337f3a9079b637595f8b0ad6d2227f97d34131836cae0b4a5f81.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  document_group.title,\n  document_group.slug,\n  document_group.id\nfrom document_group\n  left join document on document.group_id = document_group.id\nwhere document.is_reference is false\ngroup by document_group.id\norder by document_group.title asc\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d97c20748ef0337f3a9079b637595f8b0ad6d2227f97d34131836cae0b4a5f81"
+}

--- a/graphql/.sqlx/query-da8fe05cd8a441259c19df0ab08edafe27d11640443b4f62bc2b983485f38278.json
+++ b/graphql/.sqlx/query-da8fe05cd8a441259c19df0ab08edafe27d11640443b4f62bc2b983485f38278.json
@@ -1,0 +1,74 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Select all the chapters containing this document's id.\nselect\n    c.id,\n    c.title,\n    c.document_id,\n    c.wordpress_id,\n    c.index_in_parent,\n    c.chapter_path,\n    c.section as \"section: CollectionSection\"\nfrom collection_chapter as c\n    inner join\n        (select id from document where document.short_name = $1) as d on c.document_id = d.id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "wordpress_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "index_in_parent",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "chapter_path",
+        "type_info": {
+          "Custom": {
+            "name": "ltree",
+            "kind": "Simple"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "section: CollectionSection",
+        "type_info": {
+          "Custom": {
+            "name": "collection_section",
+            "kind": {
+              "Enum": [
+                "Intro",
+                "Body",
+                "Credit"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "da8fe05cd8a441259c19df0ab08edafe27d11640443b4f62bc2b983485f38278"
+}

--- a/graphql/.sqlx/query-db1725a9588ea538f0d4baf92524d6ae79ea413a2e2e780dc4bc85bcd11cff99.json
+++ b/graphql/.sqlx/query-db1725a9588ea538f0d4baf92524d6ae79ea413a2e2e780dc4bc85bcd11cff99.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Add a new spatial coverage to the database\ninsert into spatial_coverage (id, name, status)\nvalues ($1::uuid, $2, $3)\nreturning id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "db1725a9588ea538f0d4baf92524d6ae79ea413a2e2e780dc4bc85bcd11cff99"
+}

--- a/graphql/.sqlx/query-dcb53ebcae2c7e6991f926926826ea6cc2d1b4cda91b7c694f0a3468c56cfc15.json
+++ b/graphql/.sqlx/query-dcb53ebcae2c7e6991f926926826ea6cc2d1b4cda91b7c694f0a3468c56cfc15.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Adds a contributor attribution with role\ninsert into contributor_attribution (document_id, contributor_id, contribution_role)\nvalues ($1, $2, $3);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "dcb53ebcae2c7e6991f926926826ea6cc2d1b4cda91b7c694f0a3468c56cfc15"
+}

--- a/graphql/.sqlx/query-dd1ce7d0ae1bacb8aa1619f928cb32567dd8990345cec2d1dc793dc422fdef85.json
+++ b/graphql/.sqlx/query-dd1ce7d0ae1bacb8aa1619f928cb32567dd8990345cec2d1dc793dc422fdef85.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM contributor_attribution\nWHERE document_id = $1 AND contributor_id = $2;\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "dd1ce7d0ae1bacb8aa1619f928cb32567dd8990345cec2d1dc793dc422fdef85"
+}

--- a/graphql/.sqlx/query-df88a58e22c214bb2590294062faf1a28c50395c4746876536a6115fa8c24aad.json
+++ b/graphql/.sqlx/query-df88a58e22c214bb2590294062faf1a28c50395c4746876536a6115fa8c24aad.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "delete from word_segment\nwhere word_id = $1; ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "df88a58e22c214bb2590294062faf1a28c50395c4746876536a6115fa8c24aad"
+}

--- a/graphql/.sqlx/query-dfe0b95db4e522be05eaea5feaa5e7a7428e3858973f3137b6945d25f6029e79.json
+++ b/graphql/.sqlx/query-dfe0b95db4e522be05eaea5feaa5e7a7428e3858973f3137b6945d25f6029e79.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  media_slice.id as \"id\",\n  media_slice.time_range as \"range?\",\n  media_resource.url as \"resource_url\",\n  document_user_media.include_in_edited_collection as \"include_in_edited_collection\",\n  media_resource.recorded_at as \"recorded_at?\",\n  contributor.id as \"recorded_by?\",\n  contributor.display_name as \"recorded_by_name?\",\n  editor.id as \"edited_by?\",\n  editor.display_name as \"edited_by_name?\"\nfrom document_user_media\n  left join media_slice on media_slice.id = document_user_media.media_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user contributor on contributor.id = media_resource.recorded_by\n  left join dailp_user editor on editor.id = document_user_media.edited_by\nwhere\n  document_id = $1\norder by media_resource.recorded_at desc\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "range?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 2,
+        "name": "resource_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "include_in_edited_collection",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 5,
+        "name": "recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "edited_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "edited_by_name?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "dfe0b95db4e522be05eaea5feaa5e7a7428e3858973f3137b6945d25f6029e79"
+}

--- a/graphql/.sqlx/query-e18c55d3be3d173eb0c3aadb4d29069e99e545ce011745d704417ac1ee7e7442.json
+++ b/graphql/.sqlx/query-e18c55d3be3d173eb0c3aadb4d29069e99e545ce011745d704417ac1ee7e7442.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Delete all existing associations for this document\ndelete from document_spatial_coverage\nwhere document_id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e18c55d3be3d173eb0c3aadb4d29069e99e545ce011745d704417ac1ee7e7442"
+}

--- a/graphql/.sqlx/query-e1ebe64b2e98a03f7803c63a2e9011b0a064d7a6819dfdbc1a8c4d4e1160db90.json
+++ b/graphql/.sqlx/query-e1ebe64b2e98a03f7803c63a2e9011b0a064d7a6819dfdbc1a8c4d4e1160db90.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "with resource as (\n  insert into media_resource (url)\n  values ($1)\n  on conflict (url) do update set\n     url = excluded.url\n  returning id\n)\n\ninsert into media_slice (resource_id, time_range)\nselect\n  id,\n  $2\nfrom resource\nreturning id\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8Range"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e1ebe64b2e98a03f7803c63a2e9011b0a064d7a6819dfdbc1a8c4d4e1160db90"
+}

--- a/graphql/.sqlx/query-e36c26a49c102b82a8b1bf3ef32621d1a8345b64c55a42cb813c1de5c3c159ad.json
+++ b/graphql/.sqlx/query-e36c26a49c102b82a8b1bf3ef32621d1a8345b64c55a42cb813c1de5c3c159ad.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO user_bookmarked_document (document_id, user_id)\nVALUES ($1, $2)\nON CONFLICT (document_id, user_id) DO NOTHING;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e36c26a49c102b82a8b1bf3ef32621d1a8345b64c55a42cb813c1de5c3c159ad"
+}

--- a/graphql/.sqlx/query-e482b08ffa95a64085847ed112c22f364d725df7c552a230cd3d17782c48168d.json
+++ b/graphql/.sqlx/query-e482b08ffa95a64085847ed112c22f364d725df7c552a230cd3d17782c48168d.json
@@ -1,0 +1,75 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  c.id,\n  c.title,\n  c.document_id,\n  c.wordpress_id,\n  c.index_in_parent,\n  c.chapter_path,\n  c.section as \"section: CollectionSection\"\nfrom collection_chapter as c\nwhere c.collection_slug = $1 \n  and c.slug = $2;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "wordpress_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "index_in_parent",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "chapter_path",
+        "type_info": {
+          "Custom": {
+            "name": "ltree",
+            "kind": "Simple"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "section: CollectionSection",
+        "type_info": {
+          "Custom": {
+            "name": "collection_section",
+            "kind": {
+              "Enum": [
+                "Intro",
+                "Body",
+                "Credit"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e482b08ffa95a64085847ed112c22f364d725df7c552a230cd3d17782c48168d"
+}

--- a/graphql/.sqlx/query-e48fa3267b00cc26ac5c6ab79fc7218fa6a6bcc25baec277fff3610e3c87d964.json
+++ b/graphql/.sqlx/query-e48fa3267b00cc26ac5c6ab79fc7218fa6a6bcc25baec277fff3610e3c87d964.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO contributor_attribution (document_id, contributor_id, contribution_role)\nVALUES ($1, $2, $3)\nON CONFLICT (document_id, contributor_id)\nDO UPDATE SET contribution_role = $3;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e48fa3267b00cc26ac5c6ab79fc7218fa6a6bcc25baec277fff3610e3c87d964"
+}

--- a/graphql/.sqlx/query-e4cc3f2dab53d60b0be1a40f4353544f9c5b4e6172723315490b73acbb681d49.json
+++ b/graphql/.sqlx/query-e4cc3f2dab53d60b0be1a40f4353544f9c5b4e6172723315490b73acbb681d49.json
@@ -1,0 +1,45 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n    l.id, \n    l.name, \n    l.status as \"status: ApprovalStatus\"\nfrom language l\njoin document_language dl on l.id = dl.language_id\nwhere dl.document_id = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e4cc3f2dab53d60b0be1a40f4353544f9c5b4e6172723315490b73acbb681d49"
+}

--- a/graphql/.sqlx/query-e5c45f7baa4a80a79be259c35cc3e54e7369970054aaad13553568d2d01c3b08.json
+++ b/graphql/.sqlx/query-e5c45f7baa4a80a79be259c35cc3e54e7369970054aaad13553568d2d01c3b08.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- get a paragraph by id\n-- since paragraphs always include an index within their parent document\n-- we have to count this paragraph's position in on the page\nwith all_paragraphs as (\n  select\n    id,\n    english_translation as translation,\n    ROW_NUMBER() OVER (order by character_range asc) as \"index\"\n  from paragraph\n  where page_id = (\n    select p_inner.page_id from paragraph p_inner where id = $1\n  )\n) \n\nselect\n  id,\n  translation,\n  COALESCE(index, 1) as \"index!\" -- unclear why we need to upcast this\nfrom all_paragraphs\nwhere id=$1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "translation",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "index!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "e5c45f7baa4a80a79be259c35cc3e54e7369970054aaad13553568d2d01c3b08"
+}

--- a/graphql/.sqlx/query-e82f0ddd62b81e877d3c3400a91420cc819eb4d807c37bef371533bb75225609.json
+++ b/graphql/.sqlx/query-e82f0ddd62b81e877d3c3400a91420cc819eb4d807c37bef371533bb75225609.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  dl.document_id,\n  l.id,\n  l.name,\n  l.status as \"status: ApprovalStatus\"\nfrom document_language dl\njoin language l on l.id = dl.language_id\nwhere dl.document_id = any($1);",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: ApprovalStatus",
+        "type_info": {
+          "Custom": {
+            "name": "approval_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "approved",
+                "rejected"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e82f0ddd62b81e877d3c3400a91420cc819eb4d807c37bef371533bb75225609"
+}

--- a/graphql/.sqlx/query-ebd7ea3704612943925067787da8278820b2e69cfba662e56752a9da59cb449a.json
+++ b/graphql/.sqlx/query-ebd7ea3704612943925067787da8278820b2e69cfba662e56752a9da59cb449a.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "update  menu\nset name = $2,\n    slug = $3,\n    items = $4\nwhere id = $1\nreturning *;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "items",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ebd7ea3704612943925067787da8278820b2e69cfba662e56752a9da59cb449a"
+}

--- a/graphql/.sqlx/query-f2c4999389ca455e12e0349afcfab508671042d19332a39a3bad8d85b688f65b.json
+++ b/graphql/.sqlx/query-f2c4999389ca455e12e0349afcfab508671042d19332a39a3bad8d85b688f65b.json
@@ -1,0 +1,136 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  d.id,\n  d.short_name,\n  d.title,\n  d.is_reference,\n  d.written_at,\n  d.format_id,\n  d.genre_id,\n  d.audio_slice_id,\n  media_resource.url as \"audio_url?\",\n  media_resource.recorded_at as \"recorded_at?\",\n  dailp_user.id as \"recorded_by?\",\n  dailp_user.display_name as \"recorded_by_name?\",\n  media_slice.time_range as \"audio_slice?\",\n  ubd.bookmarked_on as \"bookmarked_on?\",\n  coalesce(\n    jsonb_agg(\n      jsonb_build_object(\n        'id', contributor.id,\n        'name', contributor.full_name,\n        'role', attr.contribution_role\n      )\n    ) filter (where contributor is not null),\n    '[]'\n  ) as contributors,\n  (\n    select coalesce(\n      jsonb_agg(\n        jsonb_build_object(\n          'id', k.id,\n          'name', k.name,\n          'status', k.status\n        )\n      ),\n      '[]'\n    )\n    from document_keyword dk\n    join keyword k on k.id = dk.keyword_id\n    where dk.document_id = d.id\n  ) as keywords,\n  (\n    select coalesce(\n      jsonb_agg(\n        jsonb_build_object(\n          'id', l.id,\n          'name', l.name,\n          'status', l.status\n        )\n      ),\n      '[]'\n    )\n    from document_language dl\n    join language l on l.id = dl.language_id\n    where dl.document_id = d.id\n  ) as languages,\n  ( -- Subject Headings\n    select coalesce(\n      jsonb_agg(\n        jsonb_build_object(\n          'id', sh.id,\n          'name', sh.name,\n          'status', sh.status\n    )), '[]')\n    from document_subject_heading dsh\n    join subject_heading sh on sh.id = dsh.subject_heading_id\n    where dsh.document_id = d.id\n  ) as subject_headings,\n  ( -- Spatial Coverage\n    select coalesce(\n      jsonb_agg(\n        jsonb_build_object(\n          'id', sc.id,\n          'name', sc.name,\n          'status', sc.status\n        )\n      ),\n      '[]'\n    )\n    from document_spatial_coverage dsc\n    join spatial_coverage sc on sc.id = dsc.spatial_coverage_id\n    where dsc.document_id = d.id\n  ) as spatial_coverage,\n  (\n    select coalesce(\n      jsonb_agg(\n        jsonb_build_object(\n          'id', cr.id,\n          'name', cr.name\n        )\n      ),\n      '[]'\n    )\n    from document_creator dcr\n    join creator cr on cr.id = dcr.creator_id\n    where dcr.document_id = d.id\n  ) as creators\nfrom document as d\n  left join contributor_attribution as attr on attr.document_id = d.id\n  left join contributor on contributor.id = attr.contributor_id\n  left join media_slice on media_slice.id = d.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user on dailp_user.id = media_resource.recorded_by\n  left join user_bookmarked_document as ubd on ubd.document_id = d.id\nwhere d.id = any($1)\ngroup by\n  d.id,\n  media_slice.id,\n  media_resource.id,\n  dailp_user.id,\n  ubd.bookmarked_on;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "short_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "is_reference",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "written_at",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 5,
+        "name": "format_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "genre_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "audio_slice_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "audio_url?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 10,
+        "name": "recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 11,
+        "name": "recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "audio_slice?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 13,
+        "name": "bookmarked_on?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 14,
+        "name": "contributors",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 15,
+        "name": "keywords",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 16,
+        "name": "languages",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 17,
+        "name": "subject_headings",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 18,
+        "name": "spatial_coverage",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 19,
+        "name": "creators",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "f2c4999389ca455e12e0349afcfab508671042d19332a39a3bad8d85b688f65b"
+}

--- a/graphql/.sqlx/query-f646d0a6f29207b1316c9c963db45928a70f116906d48c25ef8474e56eeaa096.json
+++ b/graphql/.sqlx/query-f646d0a6f29207b1316c9c963db45928a70f116906d48c25ef8474e56eeaa096.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into document_creator (document_id, creator_id)\nselect $1, unnest($2::uuid[]);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f646d0a6f29207b1316c9c963db45928a70f116906d48c25ef8474e56eeaa096"
+}

--- a/graphql/.sqlx/query-f86a2f62b58b5b404883e127574947027ff7a38f8ea4058a7dc4e9e68626c164.json
+++ b/graphql/.sqlx/query-f86a2f62b58b5b404883e127574947027ff7a38f8ea4058a7dc4e9e68626c164.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  id,\n  title,\n  base_url\nfrom iiif_source\nwhere title = $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "base_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f86a2f62b58b5b404883e127574947027ff7a38f8ea4058a7dc4e9e68626c164"
+}

--- a/graphql/.sqlx/query-fb97bbe20200bf87afa0466d52c145bfb0647add1644fe14b9248440837cec3b.json
+++ b/graphql/.sqlx/query-fb97bbe20200bf87afa0466d52c145bfb0647add1644fe14b9248440837cec3b.json
@@ -1,0 +1,124 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select\n  word.id,\n  word.source_text,\n  word.simple_phonetics,\n  word.phonemic,\n  word.english_gloss,\n  word.commentary,\n  word.document_id,\n  word.index_in_document,\n  word.page_number,\n  media_resource.recorded_at as \"audio_recorded_at?\",\n  media_resource.url as \"audio_url?\",\n  media_slice.time_range as \"audio_slice?\",\n  media_slice.id as \"audio_slice_id?\",\n  contributor.id as \"audio_recorded_by?\",\n  contributor.display_name as \"audio_recorded_by_name?\",\n  word.include_audio_in_edited_collection,\n  editor.id as \"audio_edited_by?\",\n  editor.display_name as \"audio_edited_by_name?\"\nfrom word\n  left join media_slice on media_slice.id = word.audio_slice_id\n  left join media_resource on media_resource.id = media_slice.resource_id\n  left join dailp_user contributor on contributor.id = media_resource.recorded_by\n  left join dailp_user editor on editor.id = media_resource.recorded_by\nwhere source_text ilike $1\n  or simple_phonetics ilike $1\n  or english_gloss ilike $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "source_text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "simple_phonetics",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "phonemic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "english_gloss",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "commentary",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "document_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "index_in_document",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 8,
+        "name": "page_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "audio_recorded_at?",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 10,
+        "name": "audio_url?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "audio_slice?",
+        "type_info": "Int8Range"
+      },
+      {
+        "ordinal": 12,
+        "name": "audio_slice_id?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "audio_recorded_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "audio_recorded_by_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "include_audio_in_edited_collection",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "audio_edited_by?",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 17,
+        "name": "audio_edited_by_name?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fb97bbe20200bf87afa0466d52c145bfb0647add1644fe14b9248440837cec3b"
+}

--- a/graphql/.sqlx/query-fcf8a8d667e1d501a534d0c9506dbdd0ed570d5045c1f9dfdbce263c7c7ff9a7.json
+++ b/graphql/.sqlx/query-fcf8a8d667e1d501a534d0c9506dbdd0ed570d5045c1f9dfdbce263c7c7ff9a7.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Insert a new comment from a user\ninsert into comment (posted_at, posted_by, text_content, parent_id, parent_type, comment_type)\nvalues (now(), $1, $2, $3, $4, $5)\nreturning id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Uuid",
+        {
+          "Custom": {
+            "name": "comment_parent_type",
+            "kind": {
+              "Enum": [
+                "Word",
+                "Paragraph"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "comment_type_enum",
+            "kind": {
+              "Enum": [
+                "Story",
+                "Suggestion",
+                "Question"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "fcf8a8d667e1d501a534d0c9506dbdd0ed570d5045c1f9dfdbce263c7c7ff9a7"
+}

--- a/graphql/.sqlx/query-ff235d0d2b332f044f87e65ed35034049a2e37894a6b04ad4a473234ce2c30da.json
+++ b/graphql/.sqlx/query-ff235d0d2b332f044f87e65ed35034049a2e37894a6b04ad4a473234ce2c30da.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id\nfrom document_group\nwhere slug = $1 ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ff235d0d2b332f044f87e65ed35034049a2e37894a6b04ad4a473234ce2c30da"
+}

--- a/graphql/.sqlx/query-ff252e407214c43a05d58a9554e6eed3cfed3fb589f02489a63f5b447252b2af.json
+++ b/graphql/.sqlx/query-ff252e407214c43a05d58a9554e6eed3cfed3fb589f02489a63f5b447252b2af.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "-- Get contributor ID from name\nselect id from contributor where full_name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ff252e407214c43a05d58a9554e6eed3cfed3fb589f02489a63f5b447252b2af"
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1315,6 +1315,10 @@ type Mutation {
 	upsertPage(page: NewPageInput!): String!
 	updateMenu(menu: MenuUpdate!): Menu!
 	validateTurnstileToken(token: String!): Boolean!
+	"""
+	Adds a new subject heading to the global list.
+	"""
+	createSubjectHeading(name: String!, status: ApprovalStatus!): SubjectHeading!
 }
 
 """
@@ -1528,6 +1532,10 @@ type Query {
 	listUsers: [User!]!
 	abbreviationIdFromShortName(shortName: String!): UUID!
 	menuBySlug(slug: String!): Menu!
+	"""
+	Fetch all available subject headings.
+	"""
+	allSubjectHeadings: [SubjectHeading!]!
 }
 
 """

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -8,11 +8,12 @@ use dailp::{
     page::{NewPageInput, Page},
     slugify_ltree,
     user::{User, UserUpdate},
-    AnnotatedForm, AnnotatedSeg, AttachAudioToDocumentInput, AttachAudioToWordInput,
-    CollectionChapter, Contributor, ContributorRole, CreateEditedCollectionInput,
-    CurateDocumentAudioInput, CurateWordAudioInput, Date, DeleteContributorAttribution,
-    DocumentMetadata, DocumentMetadataUpdate, DocumentParagraph, PositionInDocument,
-    SourceAttribution, TranslatedPage, TranslatedSection, UpdateContributorAttribution, Uuid,
+    AnnotatedForm, AnnotatedSeg, ApprovalStatus, AttachAudioToDocumentInput,
+    AttachAudioToWordInput, CollectionChapter, Contributor, ContributorRole,
+    CreateEditedCollectionInput, CurateDocumentAudioInput, CurateWordAudioInput, Date,
+    DeleteContributorAttribution, DocumentMetadata, DocumentMetadataUpdate, DocumentParagraph,
+    PositionInDocument, SourceAttribution, SubjectHeading, TranslatedPage, TranslatedSection,
+    UpdateContributorAttribution, Uuid,
 };
 use itertools::{Itertools, Position};
 use log::{debug, info};
@@ -407,6 +408,16 @@ impl Query {
             .loader()
             .get_menu_by_slug(slug)
             .await?)
+    }
+
+    /// Fetch all available subject headings.
+    async fn all_subject_headings(
+        &self,
+        context: &Context<'_>,
+    ) -> FieldResult<Vec<SubjectHeading>> {
+        let db = context.data::<DataLoader<Database>>()?.loader();
+
+        Ok(db.get_all_subject_headings().await?)
     }
 }
 
@@ -1000,6 +1011,26 @@ impl Mutation {
         let body_json = serde_json::from_str::<serde_json::Value>(&body)?;
 
         Ok(body_json["success"].as_bool().unwrap())
+    }
+
+    /// Adds a new subject heading to the global list.
+    async fn create_subject_heading(
+        &self,
+        context: &Context<'_>,
+        name: String,
+        status: ApprovalStatus,
+    ) -> FieldResult<SubjectHeading> {
+        let db = context.data::<DataLoader<Database>>()?.loader();
+
+        let new_heading = SubjectHeading {
+            id: Uuid::new_v4(),
+            name,
+            status,
+        };
+
+        db.insert_subject_heading(&new_heading).await?;
+
+        Ok(new_heading)
     }
 }
 

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -417,7 +417,7 @@ impl Query {
     ) -> FieldResult<Vec<SubjectHeading>> {
         let db = context.data::<DataLoader<Database>>()?.loader();
 
-        Ok(db.get_all_subject_headings().await?)
+        Ok(db.all_subject_headings().await?)
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "dailp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/types/.sqlx/query-d5b5032b2eb283890a953ce99b3f300e49283ad20a55f728865e76df483b0576.json
+++ b/types/.sqlx/query-d5b5032b2eb283890a953ce99b3f300e49283ad20a55f728865e76df483b0576.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select id, name, status::text as status from subject_heading order by name asc;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "status",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "d5b5032b2eb283890a953ce99b3f300e49283ad20a55f728865e76df483b0576"
+}

--- a/types/queries/all_subject_headings.sql
+++ b/types/queries/all_subject_headings.sql
@@ -1,0 +1,1 @@
+select id, name, status::text as status from subject_heading order by name asc;

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -2713,6 +2713,36 @@ impl Database {
         .await?;
         Ok(())
     }
+
+    pub async fn get_all_subject_headings(&self) -> Result<Vec<SubjectHeading>> {
+        let results = sqlx::query_as::<_, SubjectHeading>(
+            r#"
+            SELECT id, name, status 
+            FROM subject_heading 
+            ORDER BY name ASC
+            "#,
+        )
+        .fetch_all(&self.client)
+        .await?;
+
+        Ok(results)
+    }
+
+    pub async fn insert_subject_heading(&self, heading: &SubjectHeading) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO subject_heading (id, name, status)
+            VALUES ($1, $2, $3)
+            "#,
+        )
+        .bind(heading.id)
+        .bind(&heading.name)
+        .bind(heading.status)
+        .execute(&self.client)
+        .await?;
+
+        Ok(())
+    }
 }
 
 #[async_trait]

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -2714,33 +2714,21 @@ impl Database {
         Ok(())
     }
 
-    pub async fn get_all_subject_headings(&self) -> Result<Vec<SubjectHeading>> {
-        let results = sqlx::query_as::<_, SubjectHeading>(
-            r#"
-            SELECT id, name, status 
-            FROM subject_heading 
-            ORDER BY name ASC
-            "#,
+    pub async fn all_subject_headings(&self) -> Result<Vec<SubjectHeading>> {
+        Ok(
+            query_file_as!(SubjectHeading, "queries/all_subject_headings.sql")
+                .fetch_all(&self.client)
+                .await?,
         )
-        .fetch_all(&self.client)
-        .await?;
-
-        Ok(results)
     }
 
     pub async fn insert_subject_heading(&self, heading: &SubjectHeading) -> Result<()> {
-        sqlx::query(
-            r#"
-            INSERT INTO subject_heading (id, name, status)
-            VALUES ($1, $2, $3)
-            "#,
-        )
-        .bind(heading.id)
-        .bind(&heading.name)
-        .bind(heading.status)
-        .execute(&self.client)
-        .await?;
-
+        sqlx::query(include_str!("../queries/insert_subject_heading.sql"))
+            .bind(heading.id)
+            .bind(&heading.name)
+            .bind(heading.status)
+            .execute(&self.client)
+            .await?;
         Ok(())
     }
 }

--- a/types/src/doc_metadata.rs
+++ b/types/src/doc_metadata.rs
@@ -20,6 +20,15 @@ pub enum ApprovalStatus {
     Rejected,
 }
 
+// Convert from Option of Strings to ApprovalStatus
+impl From<Option<String>> for ApprovalStatus {
+    fn from(s: Option<String>) -> Self {
+        s.as_deref()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(ApprovalStatus::Pending)
+    }
+}
+
 /// Convert from string to ApprovalStatus
 impl FromStr for ApprovalStatus {
     type Err = ();

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -931,6 +931,8 @@ export type Mutation = {
    */
   readonly attachAudioToWord: AnnotatedForm
   readonly createEditedCollection: Scalars["String"]
+  /** Adds a new subject heading to the global list. */
+  readonly createSubjectHeading: SubjectHeading
   /** Decide if a piece of document audio should be included in edited collection */
   readonly curateDocumentAudio: AnnotatedDoc
   /** Decide if a piece of word audio should be included in edited collection */
@@ -982,6 +984,11 @@ export type MutationAttachAudioToWordArgs = {
 
 export type MutationCreateEditedCollectionArgs = {
   input: CreateEditedCollectionInput
+}
+
+export type MutationCreateSubjectHeadingArgs = {
+  name: Scalars["String"]
+  status: ApprovalStatus
 }
 
 export type MutationCurateDocumentAudioArgs = {
@@ -1153,6 +1160,8 @@ export type Query = {
   readonly allEditedCollections: ReadonlyArray<EditedCollection>
   /** List of all content pages */
   readonly allPages: ReadonlyArray<Page>
+  /** Fetch all available subject headings. */
+  readonly allSubjectHeadings: ReadonlyArray<SubjectHeading>
   /** List of all the functional morpheme tags available */
   readonly allTags: ReadonlyArray<MorphemeTag>
   /** Retrieves all documents that are bookmarked by the current user. */
@@ -1940,6 +1949,30 @@ export type DocFormFieldsFragment = {
       { readonly __typename?: "Genre" } & Pick<Genre, "id" | "name">
     >
   }
+
+export type AllSubjectHeadingsQueryVariables = Exact<{ [key: string]: never }>
+
+export type AllSubjectHeadingsQuery = { readonly __typename?: "Query" } & {
+  readonly allSubjectHeadings: ReadonlyArray<
+    { readonly __typename?: "SubjectHeading" } & Pick<
+      SubjectHeading,
+      "id" | "name" | "status"
+    >
+  >
+}
+
+export type CreateSubjectHeadingMutationVariables = Exact<{
+  name: Scalars["String"]
+  status: ApprovalStatus
+}>
+
+export type CreateSubjectHeadingMutation = {
+  readonly __typename?: "Mutation"
+} & {
+  readonly createSubjectHeading: {
+    readonly __typename?: "SubjectHeading"
+  } & Pick<SubjectHeading, "id" | "name" | "status">
+}
 
 export type ParagraphFormFieldsFragment = {
   readonly __typename: "DocumentParagraph"
@@ -3786,6 +3819,40 @@ export function useDocumentContentsQuery(
     query: DocumentContentsDocument,
     ...options,
   })
+}
+export const AllSubjectHeadingsDocument = gql`
+  query AllSubjectHeadings {
+    allSubjectHeadings {
+      id
+      name
+      status
+    }
+  }
+`
+
+export function useAllSubjectHeadingsQuery(
+  options?: Omit<Urql.UseQueryArgs<AllSubjectHeadingsQueryVariables>, "query">
+) {
+  return Urql.useQuery<
+    AllSubjectHeadingsQuery,
+    AllSubjectHeadingsQueryVariables
+  >({ query: AllSubjectHeadingsDocument, ...options })
+}
+export const CreateSubjectHeadingDocument = gql`
+  mutation CreateSubjectHeading($name: String!, $status: ApprovalStatus!) {
+    createSubjectHeading(name: $name, status: $status) {
+      id
+      name
+      status
+    }
+  }
+`
+
+export function useCreateSubjectHeadingMutation() {
+  return Urql.useMutation<
+    CreateSubjectHeadingMutation,
+    CreateSubjectHeadingMutationVariables
+  >(CreateSubjectHeadingDocument)
 }
 export const CollectionDocument = gql`
   query Collection($slug: String!) {

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -162,6 +162,21 @@ fragment DocFormFields on AnnotatedDoc {
   }
 }
 
+query AllSubjectHeadings {
+  allSubjectHeadings {
+    id
+    name
+    status
+  }
+}
+
+mutation CreateSubjectHeading($name: String!, $status: ApprovalStatus!) {
+  createSubjectHeading(name: $name, status: $status) {
+    id
+    name
+    status
+  }
+}
 fragment ParagraphFormFields on DocumentParagraph {
   __typename
   id

--- a/website/src/pages/documents/edit-document-modal.tsx
+++ b/website/src/pages/documents/edit-document-modal.tsx
@@ -9,10 +9,7 @@ import * as Dailp from "src/graphql/dailp"
 import { UserRole, useUserRole } from "../../auth"
 import { useTagSelector } from "../../hooks/use-tag-selector"
 import Cite from "../../utils/citation-config"
-import {
-  buildCitationMetadata,
-  mergeMetadataOptions,
-} from "../../utils/document-metadata"
+import { buildCitationMetadata } from "../../utils/document-metadata"
 import { Dropdown } from "./dropdown"
 import * as styles from "./edit-document-modal.css"
 import { EditingProvider, useEditing } from "./editing-context"
@@ -69,16 +66,6 @@ const approvedKeywords = [
   "Land Rights",
   "Self-Determination",
   "Tribal Governance",
-]
-
-const approvedSubjectHeadings = [
-  "Cherokee Political Structure",
-  "Sacred Relationships to Land",
-  "Indigenous Self-Determination",
-  "Ecological Stewardship",
-  "Colonial Disruption and Resilience",
-  "Ceremony and Sacred Practice",
-  "Indigenous Governance Models",
 ]
 
 const approvedLanguages = [
@@ -178,14 +165,17 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
     documentMetadata.subjectHeadings ?? []
   )
 
-  //
-  //
-  //
-  //
-  //
-  //
+  const [contributors, setContributors] = useState<FormContributor[]>(() =>
+    (documentMetadata.contributors ?? []).map((c) => ({
+      ...c,
+      isNew: false,
+      isVisible: c.details?.isVisible ?? false,
+      details: c.details ? { ...c.details } : null,
+    }))
+  )
 
-  const [subjectQueryResult, refetchSubjects] =
+  // Changes for pulling and creating new subject headings
+  const [{ data: allSubjectsData }, refetchSubjects] =
     Dailp.useAllSubjectHeadingsQuery()
   const [, createSubjectMutation] = Dailp.useCreateSubjectHeadingMutation()
 
@@ -199,60 +189,46 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
   )
   const [newSubjectName, setNewSubjectName] = useState("")
 
-  const availableSubjects = useMemo(() => {
-    const remoteData = (subjectQueryResult.data?.allSubjectHeadings ??
-      []) as unknown as Dailp.SubjectHeadingUpdate[]
-    return mergeMetadataOptions(remoteData, selectedSubjects)
-  }, [subjectQueryResult.data, selectedSubjects])
+  // Grab just strings from the db
+  const approvedSubjectNames = useMemo(() => {
+    return allSubjectsData?.allSubjectHeadings?.map((h) => h.name) ?? []
+  }, [allSubjectsData])
 
-  const handleAddNewGlobalSubject = async () => {
-    if (!newSubjectName.trim()) return
+  // Mutation call to add new subjects
+  const handleCreateSubject = async () => {
+    const nameToAdd = newSubjectName.trim()
+    if (!nameToAdd) return
 
-    console.log("adding new entered")
+    const subjectSelected = selectedSubjects.some(
+      (s) => s.name.toLowerCase() === nameToAdd.toLowerCase()
+    )
+    const subjectInDatabase = allSubjectsData?.allSubjectHeadings?.find(
+      (h) => h.name.toLowerCase() === nameToAdd.toLowerCase()
+    )
 
-    const result = await createSubjectMutation({
-      name: newSubjectName,
-      status: Dailp.ApprovalStatus.Approved,
-    })
+    if (!subjectSelected) {
+      if (subjectInDatabase) {
+        setSelectedSubjects((prev) => [
+          ...prev,
+          { id: subjectInDatabase.id, name: subjectInDatabase.name },
+        ])
+      } else {
+        const tempId = uuidv4()
+        setSelectedSubjects((prev) => [
+          ...prev,
+          { id: tempId, name: nameToAdd },
+        ])
 
-    if (result.error) {
-      console.error("Mutation failed:", result.error.message)
-      return
+        await createSubjectMutation({
+          name: nameToAdd,
+          status: Dailp.ApprovalStatus.Approved,
+        })
+
+        refetchSubjects({ requestPolicy: "network-only" })
+      }
     }
-
-    console.log("got result")
-
-    if (result.data?.createSubjectHeading) {
-      const newHeading = result.data.createSubjectHeading
-
-      setSelectedSubjects((prev) => [
-        ...prev,
-        { id: newHeading.id, name: newHeading.name },
-      ])
-
-      // Refresh the available dropdown list
-      refetchSubjects({ requestPolicy: "network-only" })
-
-      // NOW the keyword goes away
-      setNewSubjectName("")
-    }
+    setNewSubjectName("")
   }
-
-  //
-  //
-  //
-  //
-  //
-  //
-
-  const [contributors, setContributors] = useState<FormContributor[]>(() =>
-    (documentMetadata.contributors ?? []).map((c) => ({
-      ...c,
-      isNew: false,
-      isVisible: c.details?.isVisible ?? false,
-      details: c.details ? { ...c.details } : null,
-    }))
-  )
 
   // const [description, setDescription] = useState(documentMetadata.description ?? "")
   const [genre, setGenre] = useState(documentMetadata.genre?.name ?? "")
@@ -345,7 +321,7 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
     newTags: newHeadings,
     addTag: addHeading,
     removeTag: removeHeading,
-  } = useTagSelector(subjectHeadingStrings, approvedSubjectHeadings)
+  } = useTagSelector(subjectHeadingStrings)
 
   const {
     tags: selectedLanguages,
@@ -591,15 +567,10 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
     })
 
     // Subject Headings to be submitted
-    const subjectHeadingsToSubmit = selectedSubjectHeadings.map((name) => {
-      // Find existing subject headings by name to get id, otherwise generate new UUID
-      const existing = subjectHeadings.find((sh) => sh.name === name)
-      return {
-        id: existing?.id ?? uuidv4(),
-        name,
-        //status: existing?.status ?? Dailp.ApprovalStatus.Approved,
-      }
-    })
+    const subjectHeadingsToSubmit = selectedSubjects.map((s) => ({
+      id: s.id,
+      name: s.name,
+    }))
 
     // Languages to be submitted
     const languagesToSubmit = selectedLanguages.map((name) => {
@@ -869,61 +840,78 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
           <TagSelector
             label="Subject Headings"
             selectedTags={selectedSubjects.map((s) => s.name)}
-            approvedTags={availableSubjects.map((s) => s.name)}
-            onAdd={(name) => {
-              const match = availableSubjects.find((s) => s.name === name)
-              if (match) setSelectedSubjects((prev) => [...prev, match])
+            approvedTags={approvedSubjectNames}
+            onAdd={(tagName) => {
+              const existing = allSubjectsData?.allSubjectHeadings?.find(
+                (h) => h.name === tagName
+              )
+              if (existing) {
+                setSelectedSubjects((prev) => [
+                  ...prev,
+                  { id: existing.id, name: existing.name },
+                ])
+              }
             }}
             onRemove={(index) => {
               setSelectedSubjects((prev) => prev.filter((_, i) => i !== index))
             }}
-            addButtonLabel="Select Subject Heading"
-          />
-
-          {/* Separate Creation Box */}
-          {isEditing && (
-            <div
-              className={styles.fieldGroup}
-              style={{
-                marginTop: "20px",
-                borderTop: "1px solid #eee",
-                paddingTop: "10px",
-              }}
-            >
-              <label
-                className={styles.label}
-                style={{ fontSize: "14px", color: "#555" }}
-              >
-                Add New Global Heading
-              </label>
-              <div style={{ display: "flex", gap: "10px", marginTop: "5px" }}>
-                <input
-                  type="text"
-                  placeholder="Type new subject here..."
-                  value={newSubjectName}
-                  onChange={(e) => setNewSubjectName(e.target.value)}
+            addButtonLabel="Add Existing Subjects"
+            customForm={
+              approvedSubjectNames.length === 0 && (
+                <div
+                  style={{ color: "#666", fontStyle: "italic", padding: "8px" }}
+                >
+                  No subject headings found in database.
+                </div>
+              )
+            }
+            additionalForm={
+              isEditing && (
+                <div
                   style={{
-                    flex: 1,
-                    padding: "10px",
-                    borderRadius: "8px",
-                    border: "1px solid #ddd",
-                  }}
-                />
-                <button
-                  type="button"
-                  onClick={handleAddNewGlobalSubject}
-                  className={styles.addButton}
-                  style={{
-                    padding: "0 20px",
-                    minWidth: "fit-content",
-                    height: "42px",
+                    display: "flex",
+                    gap: "8px",
+                    alignItems: "center",
+                    width: "100%",
+                    marginTop: "4px",
                   }}
                 >
-                  Create
-                </button>
-              </div>
-            </div>
-          )}
+                  <input
+                    className={styles.input}
+                    type="text"
+                    placeholder="Create or add new heading..."
+                    value={newSubjectName}
+                    onChange={(e) => setNewSubjectName(e.target.value)}
+                    style={{
+                      flex: 1,
+                      height: "42px",
+                      marginBottom: 0,
+                      boxSizing: "border-box",
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault()
+                        handleCreateSubject()
+                      }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleCreateSubject}
+                    className={styles.addTagButton}
+                    style={{
+                      height: "42px",
+                      marginTop: 0,
+                      whiteSpace: "nowrap",
+                      padding: "0 20px",
+                    }}
+                  >
+                    Add New Subject
+                  </button>
+                </div>
+              )
+            }
+          />
 
           <TagSelector
             label="Languages"

--- a/website/src/pages/documents/edit-document-modal.tsx
+++ b/website/src/pages/documents/edit-document-modal.tsx
@@ -8,8 +8,11 @@ import { form } from "src/edit-word-feature.css"
 import * as Dailp from "src/graphql/dailp"
 import { UserRole, useUserRole } from "../../auth"
 import { useTagSelector } from "../../hooks/use-tag-selector"
-import { buildCitationMetadata } from "../../utils/build-citation-metadata"
 import Cite from "../../utils/citation-config"
+import {
+  buildCitationMetadata,
+  mergeMetadataOptions,
+} from "../../utils/document-metadata"
 import { Dropdown } from "./dropdown"
 import * as styles from "./edit-document-modal.css"
 import { EditingProvider, useEditing } from "./editing-context"
@@ -175,6 +178,73 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
     documentMetadata.subjectHeadings ?? []
   )
 
+  //
+  //
+  //
+  //
+  //
+  //
+
+  const [subjectQueryResult, refetchSubjects] =
+    Dailp.useAllSubjectHeadingsQuery()
+  const [, createSubjectMutation] = Dailp.useCreateSubjectHeadingMutation()
+
+  const [selectedSubjects, setSelectedSubjects] = useState<
+    Dailp.SubjectHeadingUpdate[]
+  >(
+    documentMetadata.subjectHeadings?.map((s) => ({
+      id: s.id,
+      name: s.name,
+    })) ?? []
+  )
+  const [newSubjectName, setNewSubjectName] = useState("")
+
+  const availableSubjects = useMemo(() => {
+    const remoteData = (subjectQueryResult.data?.allSubjectHeadings ??
+      []) as unknown as Dailp.SubjectHeadingUpdate[]
+    return mergeMetadataOptions(remoteData, selectedSubjects)
+  }, [subjectQueryResult.data, selectedSubjects])
+
+  const handleAddNewGlobalSubject = async () => {
+    if (!newSubjectName.trim()) return
+
+    console.log("adding new entered")
+
+    const result = await createSubjectMutation({
+      name: newSubjectName,
+      status: Dailp.ApprovalStatus.Approved,
+    })
+
+    if (result.error) {
+      console.error("Mutation failed:", result.error.message)
+      return
+    }
+
+    console.log("got result")
+
+    if (result.data?.createSubjectHeading) {
+      const newHeading = result.data.createSubjectHeading
+
+      setSelectedSubjects((prev) => [
+        ...prev,
+        { id: newHeading.id, name: newHeading.name },
+      ])
+
+      // Refresh the available dropdown list
+      refetchSubjects({ requestPolicy: "network-only" })
+
+      // NOW the keyword goes away
+      setNewSubjectName("")
+    }
+  }
+
+  //
+  //
+  //
+  //
+  //
+  //
+
   const [contributors, setContributors] = useState<FormContributor[]>(() =>
     (documentMetadata.contributors ?? []).map((c) => ({
       ...c,
@@ -229,6 +299,7 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
         format: "text",
         template: citeFormat || "apa",
         lang: "en-US",
+        type: "document",
       })
       console.log("Using citeFormat:", citeFormat)
       console.log("Generated citation:", docCitation)
@@ -428,7 +499,7 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
   }
 
   const creatorStrings = useMemo(
-    () => (documentMetadata.creators ?? []).map((cr) => cr.name),
+    () => (creator ?? []).map((cr) => cr.name),
     [documentMetadata.creators]
   )
 
@@ -797,13 +868,62 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
 
           <TagSelector
             label="Subject Headings"
-            selectedTags={selectedSubjectHeadings}
-            approvedTags={approvedSubjectHeadings}
-            newTags={newHeadings}
-            onAdd={isEditing ? addHeading : undefined}
-            onRemove={isEditing ? removeHeading : undefined}
-            addButtonLabel="Add Subject Heading"
+            selectedTags={selectedSubjects.map((s) => s.name)}
+            approvedTags={availableSubjects.map((s) => s.name)}
+            onAdd={(name) => {
+              const match = availableSubjects.find((s) => s.name === name)
+              if (match) setSelectedSubjects((prev) => [...prev, match])
+            }}
+            onRemove={(index) => {
+              setSelectedSubjects((prev) => prev.filter((_, i) => i !== index))
+            }}
+            addButtonLabel="Select Subject Heading"
           />
+
+          {/* Separate Creation Box */}
+          {isEditing && (
+            <div
+              className={styles.fieldGroup}
+              style={{
+                marginTop: "20px",
+                borderTop: "1px solid #eee",
+                paddingTop: "10px",
+              }}
+            >
+              <label
+                className={styles.label}
+                style={{ fontSize: "14px", color: "#555" }}
+              >
+                Add New Global Heading
+              </label>
+              <div style={{ display: "flex", gap: "10px", marginTop: "5px" }}>
+                <input
+                  type="text"
+                  placeholder="Type new subject here..."
+                  value={newSubjectName}
+                  onChange={(e) => setNewSubjectName(e.target.value)}
+                  style={{
+                    flex: 1,
+                    padding: "10px",
+                    borderRadius: "8px",
+                    border: "1px solid #ddd",
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={handleAddNewGlobalSubject}
+                  className={styles.addButton}
+                  style={{
+                    padding: "0 20px",
+                    minWidth: "fit-content",
+                    height: "42px",
+                  }}
+                >
+                  Create
+                </button>
+              </div>
+            </div>
+          )}
 
           <TagSelector
             label="Languages"

--- a/website/src/pages/documents/edit-document-modal.tsx
+++ b/website/src/pages/documents/edit-document-modal.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from "react"
 import DatePicker from "react-date-picker"
 import TextareaAutosize from "react-textarea-autosize"
 import { v4 as uuidv4 } from "uuid"
-import { form } from "src/edit-word-feature.css"
 import * as Dailp from "src/graphql/dailp"
 import { UserRole, useUserRole } from "../../auth"
 import { useTagSelector } from "../../hooks/use-tag-selector"
@@ -12,7 +11,7 @@ import Cite from "../../utils/citation-config"
 import { buildCitationMetadata } from "../../utils/document-metadata"
 import { Dropdown } from "./dropdown"
 import * as styles from "./edit-document-modal.css"
-import { EditingProvider, useEditing } from "./editing-context"
+import { useEditing } from "./editing-context"
 import { TagSelector } from "./tag-selector"
 
 export type EditDocumentModalProps = {
@@ -187,7 +186,12 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
       name: s.name,
     })) ?? []
   )
+
+  // For the subject heading input field
   const [newSubjectName, setNewSubjectName] = useState("")
+
+  // For tag selector, used for newly added subject headings that are blue
+  const [newSubjectNames, setNewSubjectNames] = useState<Set<string>>(new Set())
 
   // Grab just strings from the db
   const approvedSubjectNames = useMemo(() => {
@@ -228,6 +232,7 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
       }
     }
     setNewSubjectName("")
+    setNewSubjectNames((prev) => new Set(prev).add(nameToAdd))
   }
 
   // const [description, setDescription] = useState(documentMetadata.description ?? "")
@@ -841,6 +846,7 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
             label="Subject Headings"
             selectedTags={selectedSubjects.map((s) => s.name)}
             approvedTags={approvedSubjectNames}
+            newTags={newSubjectNames}
             onAdd={(tagName) => {
               const existing = allSubjectsData?.allSubjectHeadings?.find(
                 (h) => h.name === tagName
@@ -851,6 +857,7 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
                   { id: existing.id, name: existing.name },
                 ])
               }
+              setNewSubjectNames((prev) => new Set(prev).add(tagName))
             }}
             onRemove={(index) => {
               setSelectedSubjects((prev) => prev.filter((_, i) => i !== index))
@@ -859,7 +866,11 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
             customForm={
               approvedSubjectNames.length === 0 && (
                 <div
-                  style={{ color: "#666", fontStyle: "italic", padding: "8px" }}
+                  style={{
+                    color: "#666",
+                    fontStyle: "italic",
+                    padding: "0.5rem",
+                  }}
                 >
                   No subject headings found in database.
                 </div>
@@ -870,10 +881,10 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
                 <div
                   style={{
                     display: "flex",
-                    gap: "8px",
+                    gap: "0.5rem",
                     alignItems: "center",
                     width: "100%",
-                    marginTop: "4px",
+                    marginTop: "0.25rem",
                   }}
                 >
                   <input
@@ -884,7 +895,7 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
                     onChange={(e) => setNewSubjectName(e.target.value)}
                     style={{
                       flex: 1,
-                      height: "42px",
+                      height: "2.625rem",
                       marginBottom: 0,
                       boxSizing: "border-box",
                     }}
@@ -900,10 +911,10 @@ export const EditDocumentModal: React.FC<EditDocumentModalProps> = ({
                     onClick={handleCreateSubject}
                     className={styles.addTagButton}
                     style={{
-                      height: "42px",
+                      height: "2.625rem",
                       marginTop: 0,
                       whiteSpace: "nowrap",
-                      padding: "0 20px",
+                      padding: "0 1.25rem",
                     }}
                   >
                     Add New Subject

--- a/website/src/pages/documents/tag-selector.tsx
+++ b/website/src/pages/documents/tag-selector.tsx
@@ -10,6 +10,7 @@ interface TagSelectorProps {
   onRemove?: (index: number) => void
   addButtonLabel: string
   customForm?: React.ReactNode
+  additionalForm?: React.ReactNode
 }
 
 export const TagSelector: React.FC<TagSelectorProps> = ({
@@ -21,6 +22,7 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
   onRemove,
   addButtonLabel,
   customForm,
+  additionalForm,
 }) => {
   const [showDropdown, setShowDropdown] = useState(false)
 
@@ -50,6 +52,7 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
       </div>
 
       <div className={styles.tagDropdownContainer}>
+        {additionalForm}
         <button
           type="button"
           onClick={() => setShowDropdown(!showDropdown)}

--- a/website/src/utils/document-metadata.ts
+++ b/website/src/utils/document-metadata.ts
@@ -45,3 +45,18 @@ export function buildCitationMetadata(doc: RawDocMetadata): CSL.CitationData {
 
   return citation
 }
+
+/**
+ * Merges global metadata options with current document selections.
+ * Ensuring unique IDs and alphabetical sorting.
+ */
+export function mergeMetadataOptions<T extends { id: string; name: string }>(
+  globalList: T[],
+  currentSelections: T[]
+): T[] {
+  const map = new Map<string, T>()
+  ;[...globalList, ...currentSelections].forEach((item) => {
+    if (item.id) map.set(item.id, item)
+  })
+  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/website/src/utils/document-metadata.ts
+++ b/website/src/utils/document-metadata.ts
@@ -45,18 +45,3 @@ export function buildCitationMetadata(doc: RawDocMetadata): CSL.CitationData {
 
   return citation
 }
-
-/**
- * Merges global metadata options with current document selections.
- * Ensuring unique IDs and alphabetical sorting.
- */
-export function mergeMetadataOptions<T extends { id: string; name: string }>(
-  globalList: T[],
-  currentSelections: T[]
-): T[] {
-  const map = new Map<string, T>()
-  ;[...globalList, ...currentSelections].forEach((item) => {
-    if (item.id) map.set(item.id, item)
-  })
-  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name))
-}

--- a/website/vite.config.ts.timestamp-1775521888040-56a26cb35ad96.mjs
+++ b/website/vite.config.ts.timestamp-1775521888040-56a26cb35ad96.mjs
@@ -1,0 +1,49 @@
+// vite.config.ts
+import { vanillaExtractPlugin } from "file:///home/sonand/dailp/website/node_modules/@vanilla-extract/vite-plugin/dist/vanilla-extract-vite-plugin.cjs.js";
+import react from "file:///home/sonand/dailp/website/node_modules/@vitejs/plugin-react/dist/index.mjs";
+import os from "node:os";
+import postcssPresetEnv from "file:///home/sonand/dailp/website/node_modules/postcss-preset-env/dist/index.mjs";
+import { defineConfig } from "file:///home/sonand/dailp/website/node_modules/vite/dist/node/index.js";
+import checker from "file:///home/sonand/dailp/website/node_modules/vite-plugin-checker/dist/esm/main.js";
+import ssr from "file:///home/sonand/dailp/website/node_modules/vite-plugin-ssr/dist/cjs/node/plugin/index.js";
+var __vite_injected_original_dirname = "/home/sonand/dailp/website";
+var vite_config_default = defineConfig({
+  plugins: [
+    react(),
+    vanillaExtractPlugin(),
+    // Only check types in development mode.
+    process.env.NODE_ENV === "development" ? checker({ typescript: true }) : void 0,
+    ssr({
+      // prerender: false,
+      // Prerendering seems to be required for Amplify to render a page
+      prerender: {
+        parallel: Math.min(4, os.cpus().length)
+      }
+    })
+  ],
+  ssr: {
+    noExternal: ["lodash", "react-markdown"]
+  },
+  css: {
+    postcss: {
+      plugins: [
+        postcssPresetEnv({
+          features: {
+            "focus-visible-pseudo-class": false
+          }
+        })
+      ]
+    }
+  },
+  publicDir: "static",
+  resolve: {
+    alias: {
+      "./runtimeConfig": "./runtimeConfig.browser",
+      src: `${__vite_injected_original_dirname}/src`
+    }
+  }
+});
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvaG9tZS9zb25hbmQvZGFpbHAvd2Vic2l0ZVwiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9maWxlbmFtZSA9IFwiL2hvbWUvc29uYW5kL2RhaWxwL3dlYnNpdGUvdml0ZS5jb25maWcudHNcIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfaW1wb3J0X21ldGFfdXJsID0gXCJmaWxlOi8vL2hvbWUvc29uYW5kL2RhaWxwL3dlYnNpdGUvdml0ZS5jb25maWcudHNcIjtpbXBvcnQgeyB2YW5pbGxhRXh0cmFjdFBsdWdpbiB9IGZyb20gXCJAdmFuaWxsYS1leHRyYWN0L3ZpdGUtcGx1Z2luXCJcbmltcG9ydCByZWFjdCBmcm9tIFwiQHZpdGVqcy9wbHVnaW4tcmVhY3RcIlxuaW1wb3J0IG9zIGZyb20gXCJub2RlOm9zXCJcbmltcG9ydCBwb3N0Y3NzUHJlc2V0RW52IGZyb20gXCJwb3N0Y3NzLXByZXNldC1lbnZcIlxuaW1wb3J0IHsgZGVmaW5lQ29uZmlnIH0gZnJvbSBcInZpdGVcIlxuaW1wb3J0IGNoZWNrZXIgZnJvbSBcInZpdGUtcGx1Z2luLWNoZWNrZXJcIlxuaW1wb3J0IHNzciBmcm9tIFwidml0ZS1wbHVnaW4tc3NyL3BsdWdpblwiXG5cbmV4cG9ydCBkZWZhdWx0IGRlZmluZUNvbmZpZyh7XG4gIHBsdWdpbnM6IFtcbiAgICByZWFjdCgpLFxuICAgIHZhbmlsbGFFeHRyYWN0UGx1Z2luKCksXG4gICAgLy8gT25seSBjaGVjayB0eXBlcyBpbiBkZXZlbG9wbWVudCBtb2RlLlxuICAgIHByb2Nlc3MuZW52Lk5PREVfRU5WID09PSBcImRldmVsb3BtZW50XCJcbiAgICAgID8gY2hlY2tlcih7IHR5cGVzY3JpcHQ6IHRydWUgfSlcbiAgICAgIDogdW5kZWZpbmVkLFxuICAgIHNzcih7XG4gICAgICAvLyBwcmVyZW5kZXI6IGZhbHNlLFxuICAgICAgLy8gUHJlcmVuZGVyaW5nIHNlZW1zIHRvIGJlIHJlcXVpcmVkIGZvciBBbXBsaWZ5IHRvIHJlbmRlciBhIHBhZ2VcbiAgICAgIHByZXJlbmRlcjoge1xuICAgICAgICBwYXJhbGxlbDogTWF0aC5taW4oNCwgb3MuY3B1cygpLmxlbmd0aCksXG4gICAgICB9LFxuICAgIH0pLFxuICBdLFxuICBzc3I6IHtcbiAgICBub0V4dGVybmFsOiBbXCJsb2Rhc2hcIiwgXCJyZWFjdC1tYXJrZG93blwiXSxcbiAgfSxcbiAgY3NzOiB7XG4gICAgcG9zdGNzczoge1xuICAgICAgcGx1Z2luczogW1xuICAgICAgICBwb3N0Y3NzUHJlc2V0RW52KHtcbiAgICAgICAgICBmZWF0dXJlczoge1xuICAgICAgICAgICAgXCJmb2N1cy12aXNpYmxlLXBzZXVkby1jbGFzc1wiOiBmYWxzZSxcbiAgICAgICAgICB9LFxuICAgICAgICB9KSxcbiAgICAgIF0sXG4gICAgfSxcbiAgfSxcbiAgcHVibGljRGlyOiBcInN0YXRpY1wiLFxuICByZXNvbHZlOiB7XG4gICAgYWxpYXM6IHtcbiAgICAgIFwiLi9ydW50aW1lQ29uZmlnXCI6IFwiLi9ydW50aW1lQ29uZmlnLmJyb3dzZXJcIixcbiAgICAgIHNyYzogYCR7X19kaXJuYW1lfS9zcmNgLFxuICAgIH0sXG4gIH0sXG59KVxuIl0sCiAgIm1hcHBpbmdzIjogIjtBQUFnUSxTQUFTLDRCQUE0QjtBQUNyUyxPQUFPLFdBQVc7QUFDbEIsT0FBTyxRQUFRO0FBQ2YsT0FBTyxzQkFBc0I7QUFDN0IsU0FBUyxvQkFBb0I7QUFDN0IsT0FBTyxhQUFhO0FBQ3BCLE9BQU8sU0FBUztBQU5oQixJQUFNLG1DQUFtQztBQVF6QyxJQUFPLHNCQUFRLGFBQWE7QUFBQSxFQUMxQixTQUFTO0FBQUEsSUFDUCxNQUFNO0FBQUEsSUFDTixxQkFBcUI7QUFBQTtBQUFBLElBRXJCLFFBQVEsSUFBSSxhQUFhLGdCQUNyQixRQUFRLEVBQUUsWUFBWSxLQUFLLENBQUMsSUFDNUI7QUFBQSxJQUNKLElBQUk7QUFBQTtBQUFBO0FBQUEsTUFHRixXQUFXO0FBQUEsUUFDVCxVQUFVLEtBQUssSUFBSSxHQUFHLEdBQUcsS0FBSyxFQUFFLE1BQU07QUFBQSxNQUN4QztBQUFBLElBQ0YsQ0FBQztBQUFBLEVBQ0g7QUFBQSxFQUNBLEtBQUs7QUFBQSxJQUNILFlBQVksQ0FBQyxVQUFVLGdCQUFnQjtBQUFBLEVBQ3pDO0FBQUEsRUFDQSxLQUFLO0FBQUEsSUFDSCxTQUFTO0FBQUEsTUFDUCxTQUFTO0FBQUEsUUFDUCxpQkFBaUI7QUFBQSxVQUNmLFVBQVU7QUFBQSxZQUNSLDhCQUE4QjtBQUFBLFVBQ2hDO0FBQUEsUUFDRixDQUFDO0FBQUEsTUFDSDtBQUFBLElBQ0Y7QUFBQSxFQUNGO0FBQUEsRUFDQSxXQUFXO0FBQUEsRUFDWCxTQUFTO0FBQUEsSUFDUCxPQUFPO0FBQUEsTUFDTCxtQkFBbUI7QUFBQSxNQUNuQixLQUFLLEdBQUcsZ0NBQVM7QUFBQSxJQUNuQjtBQUFBLEVBQ0Y7QUFDRixDQUFDOyIsCiAgIm5hbWVzIjogW10KfQo=


### PR DESCRIPTION
Added functionality for editors to add new subject headings and add from existing ones.

Updates:
- Fixed bug of new subject headings being added were not blue to indicate they are new
- Regarding comments about headings not appearing in dropdown when created: they are not appearing since they are automatically added as a subject heading tag (a selected tag doesn't appear in the dropdown to prevent duplicates)
- Regarding added tags in one document not appearing in another unrelated document: was unable to replicate this and works as intended