### PR TITLE
Fixed contributor_attribution foreign key constraint issue

### DIFF
--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -2465,7 +2465,7 @@ impl Database {
         {
             let contributors = meta.contributors.iter().flatten();
             let names: Vec<String> = contributors.clone().map(|c| c.name.clone()).collect();
-            let doc_id: Vec<Uuid> = vec![meta.id.0];
+            let doc_id: Vec<Uuid> = vec![document_uuid];
             let roles: Vec<String> = contributors
                 .clone()
                 .map(|c| {


### PR DESCRIPTION
I believe that this issue has been resolved from my code changes. I was unable to recreate the error; however, its effects were seen in the failure of new entries in the contributor_attribution insert upon document creation.

Based on the error messages, it appeared that the issue was that the contributor_attribution document_id was being created with a random key, not the associated document_id that was just created when a document is created. This insert is what was failing and required the change of inserting into a collection from a new uuid to the document id.