### PR TITLE
Word segments saved across all words

### DIFF
--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -876,6 +876,23 @@ impl Database {
         .execute(&mut *tx)
         .await?;
 
+        for (gloss, ling_type) in internal_glosses.iter().zip(role.iter()) {
+            let abstract_id =
+                query_file_scalar!("queries/upsert_morpheme_tag.sql", gloss as _, role as _)
+                    .fetch_one(&mut *tx)
+                    .await?;
+
+            query_file!(
+                "queries/upsert_morpheme_gloss.sql",
+                document_id,
+                gloss as _,
+                None::<String>,
+                abstract_id
+            )
+            .fetch_one(&mut *tx)
+            .await?;
+        }
+
         tx.commit().await?;
 
         Ok(word.id)

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -431,11 +431,17 @@ const EditWordPartGloss = (props: {
           title: title,
           system: preferences.cherokeeRepresentation,
         })
-        // Refresh the query to get the new tag
-        await executeQuery({ requestPolicy: "network-only" })
       } else {
         //just do frontend update
+        await insertCustomMorphemeTag({
+          tag: newValue.value,
+          title: newValue.value,
+          system: preferences.cherokeeRepresentation,
+        })
       }
+
+      // Refresh the query to get the new tag
+      await executeQuery({ requestPolicy: "network-only" })
 
       let matchingTag =
         newValue.value === newValue.label


### PR DESCRIPTION
Now when a word is saved with word segments, it will upsert a new morpheme tag entry by inserting in abstract_morpheme_tag and abstract_morpheme_glossary. These are then displayed in the dropdown when a new tag is being added in the edit word menu. This allows for contributors and editors to quickly add already existing word segments to prevent constant retyping.