### PR TITLE
#781-782 Audio uploads format and metadata

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "@breezystack/lamejs": "^1.2.7",
     "@citation-js/core": "^0.7.21",
     "@citation-js/plugin-csl": "^0.7.21",
     "@fontsource/charis-sil": "^4.5.7",

--- a/website/src/components/contribute-audio-section.tsx
+++ b/website/src/components/contribute-audio-section.tsx
@@ -6,7 +6,7 @@ import {
   statusMessage,
   statusMessageError,
 } from "./contribute-audio-section.css"
-import { useAudioUpload } from "./edit-word-audio/utils"
+import { AudioUploadRelations, useAudioUpload } from "./edit-word-audio/utils"
 
 export type ContributeAudioComponent = (p: {
   uploadAudio: (blob: Blob) => Promise<boolean>
@@ -19,10 +19,11 @@ export type ContributeAudioComponent = (p: {
 export function ContributeAudioSection(p: {
   Component: ContributeAudioComponent
   processUploadedAudio: (resourceUrl: string) => Promise<boolean>
+  relations?: AudioUploadRelations
 }): ReactElement {
-  // const [uploadAudio, uploadState, clearUploadError] = useAudioUpload(p.word.id)
   const [uploadAudio, uploadState, clearUploadError] = useAudioUpload(
-    p.processUploadedAudio
+    p.processUploadedAudio,
+    p.relations
   )
 
   return (

--- a/website/src/components/edit-word-audio/contribute-audio-panel.tsx
+++ b/website/src/components/edit-word-audio/contribute-audio-panel.tsx
@@ -21,6 +21,7 @@ export function ContributeAudioPanel(p: {
       content={
         <ContributeAudioSection
           Component={p.Component}
+          relations={{ wordId: p.word.id }}
           processUploadedAudio={async (resourceUrl: string) => {
             const result = await contributeAudio({
               input: { wordId: p.word.id, contributorAudioUrl: resourceUrl },

--- a/website/src/components/edit-word-audio/record.tsx
+++ b/website/src/components/edit-word-audio/record.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, useEffect } from "react"
 import { FaMicrophone, FaRegStopCircle } from "react-icons/fa/index"
 import { RiRecordCircleFill } from "react-icons/ri/index"
+import { encodeBlobToMp3 } from "src/utils/encode-mp3"
 import { AudioPlayer } from ".."
 import * as Dailp from "../../graphql/dailp"
 import {
@@ -45,7 +46,16 @@ export function RecordAudioContent({
   }, [permissionStatus])
 
   async function uploadAudioAndReset(data: Blob) {
-    if (await uploadAudio(data)) {
+    // Transcode the recording (Opus) to MP3, then hand the uploader a named
+    // file so the audio carries its format (extension) and upload date
+    // (lastModified) at the file level.
+    const mp3 = await encodeBlobToMp3(data)
+    const mp3File = new File(
+      [mp3],
+      `recording-${new Date().toISOString().replace(/[:.]/g, "-")}.mp3`,
+      { type: "audio/mpeg", lastModified: Date.now() }
+    )
+    if (await uploadAudio(mp3File)) {
       clearRecording?.()
     }
   }

--- a/website/src/components/edit-word-audio/utils.ts
+++ b/website/src/components/edit-word-audio/utils.ts
@@ -2,12 +2,19 @@ import { CognitoUser } from "amazon-cognito-identity-js"
 import { useMemo, useState } from "react"
 import { useUser } from "src/auth"
 import * as Dailp from "../../graphql/dailp"
-import { S3Uploader } from "../../utils/s3"
+import { ContributorAudioMetadata, S3Uploader } from "../../utils/s3"
 
 type UploadAudioState = "ready" | "uploading" | "error"
 
+// Relational context a panel can attach to its audio uploads.
+export interface AudioUploadRelations {
+  wordId?: string
+  documentId?: string
+}
+
 export function useAudioUpload(
-  processUploadedAudio: (resourceUrl: string) => Promise<boolean>
+  processUploadedAudio: (resourceUrl: string) => Promise<boolean>,
+  relations?: AudioUploadRelations
 ) {
   const [uploadAudioState, setUploadAudioState] =
     useState<UploadAudioState>("ready")
@@ -21,7 +28,10 @@ export function useAudioUpload(
   async function uploadAudio(data: Blob) {
     setUploadAudioState("uploading")
     try {
-      const { resourceUrl } = await uploadContributorAudioToS3(user!, data)
+      const { resourceUrl } = await uploadContributorAudioToS3(user!, data, {
+        ...relations,
+        speakerId: user!.getUsername(),
+      })
       // const resourceUrl = "https://" + prompt("url?")
       const success = await processUploadedAudio(resourceUrl)
       if (!success) {
@@ -50,8 +60,9 @@ export function useAudioUpload(
 
 export async function uploadContributorAudioToS3(
   user: CognitoUser,
-  data: Blob
+  data: Blob,
+  meta?: ContributorAudioMetadata
 ) {
   const uploader = new S3Uploader(user)
-  return uploader.uploadContributorAudio(data)
+  return uploader.uploadContributorAudio(data, meta)
 }

--- a/website/src/components/record-document-audio-panel.tsx
+++ b/website/src/components/record-document-audio-panel.tsx
@@ -22,11 +22,12 @@ export function RecordDocumentAudioPanel(p: {
       content={
         <ContributeAudioSection
           Component={RecordAudioContent}
+          relations={{ documentId: p.document.id }}
           processUploadedAudio={async (resourceUrl: string) => {
             const result = await contributeAudio({
               input: {
                 documentId: p.document.id,
-                contributorAudioUrl: `https://${resourceUrl}`,
+                contributorAudioUrl: resourceUrl,
               },
             })
             return result.error === undefined

--- a/website/src/utils/encode-mp3.ts
+++ b/website/src/utils/encode-mp3.ts
@@ -1,0 +1,59 @@
+import { Mp3Encoder } from "@breezystack/lamejs"
+
+// Samples per frame for MP3 encoding. 1152 is the standard for MPEG-1 Layer III
+const SAMPLES_PER_FRAME = 1152
+// Should be fine for most use cases, but can be adjusted if needed
+const BITRATE_KBPS = 128
+
+export async function encodeBlobToMp3(blob: Blob): Promise<Blob> {
+  // Get raw bytes from the Blob
+  const buf = await blob.arrayBuffer()
+
+  // Decode step and release audio context resources after decoding
+  const audioCtx = new AudioContext()
+  const audio = await audioCtx.decodeAudioData(buf)
+  await audioCtx.close()
+
+  // Metadata for MP3 encoding
+  const channels = audio.numberOfChannels
+  const sampleRate = audio.sampleRate
+
+  const encoder = new Mp3Encoder(channels, sampleRate, BITRATE_KBPS)
+
+  // Convert float audio data to 16-bit PCM as per LAME requirements
+  const left = floatTo16BitPCM(audio.getChannelData(0))
+  // If stereo, get the right channel; otherwise, set it to null
+  const right = channels > 1 ? floatTo16BitPCM(audio.getChannelData(1)) : null
+
+  // Encode audio data in chunks to MP3 format based on the defined samples per frame
+  const mp3Chunks: Uint8Array[] = []
+  for (let i = 0; i < left.length; i += SAMPLES_PER_FRAME) {
+    const leftChunk = left.subarray(i, i + SAMPLES_PER_FRAME)
+    // If stereo, encode both channels
+    // If mono, the left channel is mirrored to the right channel for encoding
+    const encoded = right
+      ? encoder.encodeBuffer(
+          leftChunk,
+          right.subarray(i, i + SAMPLES_PER_FRAME)
+        )
+      : encoder.encodeBuffer(leftChunk)
+    if (encoded.length > 0) mp3Chunks.push(encoded)
+  }
+
+  const flushed = encoder.flush()
+  if (flushed.length > 0) mp3Chunks.push(flushed)
+
+  // Concatenate all MP3 chunks into a single Blob tagged audio/mpeg and return it
+  const blobParts: BlobPart[] = mp3Chunks.map((chunk) => new Uint8Array(chunk))
+  return new Blob(blobParts, { type: "audio/mpeg" })
+}
+
+function floatTo16BitPCM(input: Float32Array): Int16Array {
+  const output = new Int16Array(input.length)
+  for (let i = 0; i < input.length; i++) {
+    // Clamp the float value to the range [-1, 1]
+    const s = Math.max(-1, Math.min(1, input[i]!))
+    output[i] = s < 0 ? s * 0x8000 : s * 0x7fff
+  }
+  return output
+}

--- a/website/src/utils/encode-mp3.ts
+++ b/website/src/utils/encode-mp3.ts
@@ -37,11 +37,15 @@ export async function encodeBlobToMp3(blob: Blob): Promise<Blob> {
           right.subarray(i, i + SAMPLES_PER_FRAME)
         )
       : encoder.encodeBuffer(leftChunk)
-    if (encoded.length > 0) mp3Chunks.push(encoded)
+    if (encoded.length > 0) {
+      mp3Chunks.push(encoded)
+    }
   }
 
   const flushed = encoder.flush()
-  if (flushed.length > 0) mp3Chunks.push(flushed)
+  if (flushed.length > 0) {
+    mp3Chunks.push(flushed)
+  }
 
   // Concatenate all MP3 chunks into a single Blob tagged audio/mpeg and return it
   const blobParts: BlobPart[] = mp3Chunks.map((chunk) => new Uint8Array(chunk))

--- a/website/src/utils/s3.ts
+++ b/website/src/utils/s3.ts
@@ -9,6 +9,14 @@ interface S3UploadConfig {
   keyPrefix: string
   contentType?: string
   extension?: string
+  metadata?: Record<string, string>
+}
+
+// Relational context for a contributor audio upload, stored as S3 metadata.
+export interface ContributorAudioMetadata {
+  wordId?: string
+  documentId?: string
+  speakerId?: string
 }
 
 export class S3Uploader {
@@ -52,6 +60,7 @@ export class S3Uploader {
         Key: key,
         ContentType:
           config.contentType || data.type || "application/octet-stream",
+        Metadata: config.metadata,
       })
     )
 
@@ -63,13 +72,27 @@ export class S3Uploader {
 
   // Convenience methods for common upload types
   async uploadContributorAudio(
-    data: Blob
+    data: Blob,
+    meta?: ContributorAudioMetadata
   ): Promise<{ resourceUrl: string; key: string }> {
     const bucket = `dailp-${process.env["TF_STAGE"] || "dev"}-media-storage`
+
+    // Describe the audio on the S3 object: format + upload date for every clip,
+    // plus whatever relational context (document/word/speaker) was provided.
+    const metadata: Record<string, string> = {
+      format: "mp3",
+      "upload-date": new Date().toISOString(),
+    }
+    if (meta?.documentId) metadata["document-id"] = meta.documentId
+    if (meta?.wordId) metadata["word-id"] = meta.wordId
+    if (meta?.speakerId) metadata["speaker-id"] = meta.speakerId
+
     return this.uploadFile(data, {
       bucket,
       keyPrefix: "user-uploaded-audio",
-      contentType: "audio/wav", // or detect from blob
+      contentType: "audio/mpeg", // or detect from blob
+      extension: "mp3",
+      metadata,
     })
   }
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2708,6 +2708,11 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
+"@breezystack/lamejs@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@breezystack/lamejs/-/lamejs-1.2.7.tgz#c4779f7f0b6b685da675ebbaaff85e52187a51ad"
+  integrity sha512-6wc7ck65ctA75Hq7FYHTtTvGnYs6msgdxiSUICQ+A01nVOWg6rqouZB8IdyteRlfpYYiFovkf67dIeOgWIUzTA==
+
 "@brillout/import@^0.2.1":
   version "0.2.1"
   resolved "https://registry.npmjs.org/@brillout/import/-/import-0.2.1.tgz"


### PR DESCRIPTION
The tasks were to ensure site audio recordings were encoded as mp3 before upload, and add descriptive metadata such as codec/format and relational ids (user, document, word ids, upload date) to the S3 object, and format info to the mp3 file itself.

Changes Summary:
1. Transcoding layer using [lamejs](https://www.npmjs.com/package/@breezystack/lamejs). Decodes the browser's Opus recording to PCM and re-encodes to mp3 (at 128 kbps).
2. Added `metadata` as a parameter for the S3 `PutObjectCommand`, `uploadContributorAudio` writes `format`, `upload-date`, and relational ids. `useAudioUpload` accepts `relations` grabbed from the parent panels (word/document), with the speaker taken from the signed-in user.
3. In `record.tsx` wrap the encoded bytes in a named file with `timestamp` and `.mp3` extension so the file carries its format and upload date at the file level.