### PR TITLE
Word Audio Recording Clarity Enhancements

### DIFF
--- a/website/src/components/edit-word-audio/contributor.tsx
+++ b/website/src/components/edit-word-audio/contributor.tsx
@@ -1,83 +1,79 @@
-import { Fragment } from "react"
+import { Fragment, ReactNode } from "react"
 import { useUserId } from "src/auth"
 import { WordAudio } from "src/word-panel"
 import { AudioPlayer } from "../"
 import * as Dailp from "../../graphql/dailp"
 
+type ContributedAudioTrack =
+  Dailp.FormFieldsFragment["userContributedAudio"][number]
+
+function renderTrack(audio: ContributedAudioTrack) {
+  return (
+    <AudioPlayer
+      key={audio.sliceId}
+      audioUrl={audio.resourceUrl}
+      contributor={audio.recordedBy?.displayName}
+      recordedAt={
+        audio.recordedAt ? new Date(audio.recordedAt.formattedDate) : undefined
+      }
+      slices={
+        audio.startTime && audio.endTime
+          ? { start: audio.startTime, end: audio.endTime }
+          : undefined
+      }
+      showProgress
+    />
+  )
+}
+
 function AvailableAudioSection(p: { word: Dailp.FormFieldsFragment }) {
   const userId = useUserId()
 
-  const curatedAudioContent = p.word.editedAudio.length > 0 && (
-    <>
-      <strong>Curated audio (shown to all readers)</strong>
-      <WordAudio word={p.word} />
-    </>
+  // Remove own contributions to render separately
+  const wordWithoutOwnContributions: Dailp.FormFieldsFragment = {
+    ...p.word,
+    editedAudio: p.word.editedAudio.filter(
+      (audio) => audio.recordedBy?.id !== userId
+    ),
+  }
+  const hasOtherPublishedAudio =
+    wordWithoutOwnContributions.editedAudio.length > 0
+
+  const ownPublishedContributions = p.word.userContributedAudio.filter(
+    (audio) =>
+      audio.recordedBy?.id === userId && audio.includeInEditedCollection
   )
 
-  const [audioByUser, audioByOthers] = p.word.userContributedAudio.reduce<
-    [
-      Dailp.FormFieldsFragment["userContributedAudio"],
-      Dailp.FormFieldsFragment["userContributedAudio"]
-    ]
-  >(
-    ([self, other], audio) =>
-      audio.recordedBy?.id === userId
-        ? [[...self, audio], other]
-        : [self, [...other, audio]],
-    [[], []]
-  )
+  const sections: { label: string; content: ReactNode }[] = []
 
-  const userAudioContent = audioByUser.length > 0 && (
-    <>
-      <strong>Audio you've contributed</strong>
-      {audioByUser.map((audio) => (
-        <AudioPlayer
-          audioUrl={audio.resourceUrl}
-          slices={
-            audio.startTime && audio.endTime
-              ? {
-                  start: audio.startTime,
-                  end: audio.endTime,
-                }
-              : undefined
-          }
-          showProgress
-        />
-      ))}
-    </>
-  )
+  if (hasOtherPublishedAudio) {
+    sections.push({
+      label: "Published Audio",
+      content: <WordAudio word={wordWithoutOwnContributions} />,
+    })
+  }
 
-  const otherUserAudioContent = audioByOthers.length > 0 && (
-    <>
-      <strong>Audio from other speakers</strong>
-      {audioByOthers.map((audio) => (
-        <AudioPlayer
-          audioUrl={audio.resourceUrl}
-          slices={
-            audio.startTime && audio.endTime
-              ? {
-                  start: audio.startTime,
-                  end: audio.endTime,
-                }
-              : undefined
-          }
-          showProgress
-        />
-      ))}
-    </>
-  )
+  if (ownPublishedContributions.length > 0) {
+    sections.push({
+      label: "Your Published Contributions",
+      content: ownPublishedContributions.map(renderTrack),
+    })
+  }
 
-  const content = [curatedAudioContent, userAudioContent, otherUserAudioContent]
-    .filter((content) => content !== false)
-    .map((content, idx) => (
-      <Fragment key={idx}>
-        {idx > 0 && <hr />}
-        {content}
-      </Fragment>
-    ))
+  if (sections.length === 0) {
+    return <>No audio available for this word.</>
+  }
 
   return (
-    <>{content.length > 0 ? content : "No audio available for this word."}</>
+    <>
+      {sections.map((section, idx) => (
+        <Fragment key={section.label}>
+          {idx > 0 && <hr />}
+          <strong>{section.label}</strong>
+          {section.content}
+        </Fragment>
+      ))}
+    </>
   )
 }
 
@@ -89,4 +85,21 @@ export function ContributorEditWordAudio(p: {
       <AvailableAudioSection word={p.word} />
     </div>
   )
+}
+
+export function ContributorUnpublishedWordAudio(p: {
+  word: Dailp.FormFieldsFragment
+}) {
+  const userId = useUserId()
+
+  const ownUnpublishedAudios = p.word.userContributedAudio.filter(
+    (audio) =>
+      audio.recordedBy?.id === userId && !audio.includeInEditedCollection
+  )
+
+  if (ownUnpublishedAudios.length === 0) {
+    return <div>You have no unpublished audios for this word.</div>
+  }
+
+  return <div>{ownUnpublishedAudios.map(renderTrack)}</div>
 }

--- a/website/src/components/edit-word-audio/editor.tsx
+++ b/website/src/components/edit-word-audio/editor.tsx
@@ -1,32 +1,163 @@
-import { FormEvent } from "react"
-import { useState } from "react"
+import { FormEvent, useState } from "react"
+import { useUserId } from "src/auth"
 import { AudioPlayer } from "../"
 import * as Dailp from "../../graphql/dailp"
 
-export function EditorEditWordAudio(p: { word: Dailp.FormFieldsFragment }) {
-  const allAudio = [
-    ...(p.word.ingestedAudioTrack ? [p.word.ingestedAudioTrack] : []),
-    ...p.word.userContributedAudio,
+type AudioTrack = Dailp.AudioSliceFieldsFragment
+
+// Return tuple array of audios filtering by published and unpublished
+function splitAudioByStatus(word: Dailp.FormFieldsFragment) {
+  const allAudio: AudioTrack[] = [
+    ...(word.ingestedAudioTrack ? [word.ingestedAudioTrack] : []),
+    ...word.userContributedAudio,
   ]
+
+  return {
+    published: allAudio.filter((a) => a.includeInEditedCollection),
+    unpublished: allAudio.filter((a) => !a.includeInEditedCollection),
+  }
+}
+
+// Warpper of an audio track to include a prop if editing to chose to display
+// the show to readers button
+function AudioTrackRow(p: {
+  wordId: string
+  audio: AudioTrack
+  editable: boolean
+}) {
+  const contributor = p.audio.recordedBy?.displayName
+  const recordedAt = p.audio.recordedAt
+    ? new Date(p.audio.recordedAt.formattedDate)
+    : undefined
+
+  if (p.editable)
+    return (
+      <WordAudioWithCurate
+        wordId={p.wordId}
+        audio={p.audio}
+        contributor={contributor}
+        recordedAt={recordedAt}
+      />
+    )
+
+  return (
+    <AudioPlayer
+      audioUrl={p.audio.resourceUrl}
+      contributor={contributor}
+      recordedAt={recordedAt}
+      slices={
+        p.audio.startTime && p.audio.endTime
+          ? { start: p.audio.startTime, end: p.audio.endTime }
+          : undefined
+      }
+      showProgress
+    />
+  )
+}
+
+// Displays published audios, separating by your contributions vs other contributions
+export function EditorPublishedWordAudio(p: {
+  word: Dailp.FormFieldsFragment
+  editable: boolean
+}) {
+  const userId = useUserId()
+  const { published } = splitAudioByStatus(p.word)
+
+  if (published.length === 0)
+    return <div>No audio available for this word.</div>
+
+  const ownPublishedAudios = published.filter(
+    (a) => a.recordedBy?.id === userId
+  )
+
+  const otherPublishedAudios = published.filter(
+    (a) => a.recordedBy?.id !== userId
+  )
 
   return (
     <div>
-      <ul style={{ margin: 0, padding: 0 }}>
-        {allAudio.length === 0
-          ? "No audio available for this word."
-          : allAudio.map((audio) => (
-              <WordAudioWithCurate
+      {ownPublishedAudios.length > 0 && (
+        <>
+          <strong>Your Published Audio</strong>
+          {ownPublishedAudios.map((audio) => (
+            <AudioTrackRow
+              key={audio.sliceId}
+              wordId={p.word.id}
+              audio={audio}
+              editable={p.editable}
+            />
+          ))}
+        </>
+      )}
+      {otherPublishedAudios.length > 0 && (
+        <>
+          {otherPublishedAudios.length > 0 && <hr />}
+          <strong>Other Published Contributions</strong>
+          {otherPublishedAudios.map((audio) => (
+            <AudioTrackRow
+              key={audio.sliceId}
+              wordId={p.word.id}
+              audio={audio}
+              editable={p.editable}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  )
+}
+
+// Displays unpublished audios, separating by your contributions vs other contributions
+export function EditorUnpublishedWordAudio(p: {
+  word: Dailp.FormFieldsFragment
+  editable: boolean
+}) {
+  const userId = useUserId()
+  const { unpublished } = splitAudioByStatus(p.word)
+
+  if (unpublished.length === 0)
+    return <div>No unpublished audio for this word.</div>
+
+  const ownUnpublishedAudios = unpublished.filter(
+    (a) => a.recordedBy?.id === userId
+  )
+  const otherUnpublishedAudios = unpublished.filter(
+    (a) => a.recordedBy?.id !== userId
+  )
+
+  return (
+    <div>
+      {ownUnpublishedAudios.length > 0 && (
+        <>
+          <strong>Your Unpublished Contributions</strong>
+          <ul style={{ margin: 0, padding: 0 }}>
+            {ownUnpublishedAudios.map((audio) => (
+              <AudioTrackRow
+                key={audio.sliceId}
                 wordId={p.word.id}
                 audio={audio}
-                contributor={audio.recordedBy?.displayName}
-                recordedAt={
-                  audio.recordedAt
-                    ? new Date(audio.recordedAt.formattedDate)
-                    : undefined
-                }
+                editable={p.editable}
               />
             ))}
-      </ul>
+          </ul>
+        </>
+      )}
+      {otherUnpublishedAudios.length > 0 && (
+        <>
+          {otherUnpublishedAudios.length > 0 && <hr />}
+          <strong>Other Unpublished Contributions</strong>
+          <ul style={{ margin: 0, padding: 0 }}>
+            {otherUnpublishedAudios.map((audio) => (
+              <AudioTrackRow
+                key={audio.sliceId}
+                wordId={p.word.id}
+                audio={audio}
+                editable={p.editable}
+              />
+            ))}
+          </ul>
+        </>
+      )}
     </div>
   )
 }
@@ -54,6 +185,7 @@ export function WordAudioWithCurate({
       },
     })
   }
+
   return (
     <div style={{ display: "flex" }}>
       <div style={{ flex: 1 }}>
@@ -63,10 +195,7 @@ export function WordAudioWithCurate({
           recordedAt={recordedAt}
           slices={
             audio.startTime && audio.endTime
-              ? {
-                  start: audio.startTime,
-                  end: audio.endTime,
-                }
+              ? { start: audio.startTime, end: audio.endTime }
               : undefined
           }
           showProgress
@@ -111,6 +240,7 @@ export function DocumentAudioWithCurate({
       },
     })
   }
+
   return (
     <div style={{ display: "flex", flex: 1 }}>
       <div style={{ flex: 1 }}>
@@ -120,10 +250,7 @@ export function DocumentAudioWithCurate({
           audioUrl={audio.resourceUrl}
           slices={
             audio.startTime && audio.endTime
-              ? {
-                  start: audio.startTime,
-                  end: audio.endTime,
-                }
+              ? { start: audio.startTime, end: audio.endTime }
               : undefined
           }
           showProgress

--- a/website/src/components/edit-word-audio/index.tsx
+++ b/website/src/components/edit-word-audio/index.tsx
@@ -1,25 +1,46 @@
 import { ReactElement } from "react"
 import { WordAudio } from "src/word-panel"
-import { UserRole, useCognitoUserGroups, useUserRole } from "../../auth"
+import { UserRole, useUserRole } from "../../auth"
 import * as Dailp from "../../graphql/dailp"
-import { ContributorEditWordAudio } from "./contributor"
-import { EditorEditWordAudio } from "./editor"
+import {
+  ContributorEditWordAudio,
+  ContributorUnpublishedWordAudio,
+} from "./contributor"
+import { EditorPublishedWordAudio, EditorUnpublishedWordAudio } from "./editor"
 
+// Displays auidos published to readers
 export const EditWordAudio = (p: {
   word: Dailp.FormFieldsFragment
+  editable: boolean
 }): ReactElement => {
   const role = useUserRole()
 
-  console.log("Branching based on", { role })
-
   switch (role) {
     case UserRole.Admin:
-      return <EditorEditWordAudio word={p.word} />
     case UserRole.Editor:
-      return <EditorEditWordAudio word={p.word} />
+      return <EditorPublishedWordAudio word={p.word} editable={p.editable} />
     case UserRole.Contributor:
       return <ContributorEditWordAudio word={p.word} />
     case UserRole.Reader:
+    default:
       return <WordAudio word={p.word} />
+  }
+}
+
+// Represents a panel that displays only unpublished audios not displayed to readers
+export const UnpublishedWordAudio = (p: {
+  word: Dailp.FormFieldsFragment
+  editable: boolean
+}): ReactElement | null => {
+  const role = useUserRole()
+
+  switch (role) {
+    case UserRole.Admin:
+    case UserRole.Editor:
+      return <EditorUnpublishedWordAudio word={p.word} editable={p.editable} />
+    case UserRole.Contributor:
+      return <ContributorUnpublishedWordAudio word={p.word} />
+    default:
+      return null
   }
 }

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -1701,7 +1701,7 @@ export type DocumentContentsQuery = { readonly __typename?: "Query" } & {
                                     readonly recordedBy: Maybe<
                                       { readonly __typename?: "User" } & Pick<
                                         User,
-                                        "displayName"
+                                        "id" | "displayName"
                                       >
                                     >
                                     readonly recordedAt: Maybe<
@@ -1820,7 +1820,7 @@ export type DocumentContentsQuery = { readonly __typename?: "Query" } & {
                     readonly recordedBy: Maybe<
                       { readonly __typename?: "User" } & Pick<
                         User,
-                        "displayName"
+                        "id" | "displayName"
                       >
                     >
                     readonly recordedAt: Maybe<
@@ -1903,7 +1903,7 @@ export type AudioSliceFieldsFragment = {
   | "includeInEditedCollection"
 > & {
     readonly recordedBy: Maybe<
-      { readonly __typename?: "User" } & Pick<User, "displayName">
+      { readonly __typename?: "User" } & Pick<User, "id" | "displayName">
     >
     readonly recordedAt: Maybe<
       { readonly __typename?: "Date" } & Pick<Date, "formattedDate">
@@ -2019,7 +2019,10 @@ export type ParagraphFormFieldsFragment = {
                 | "includeInEditedCollection"
               > & {
                   readonly recordedBy: Maybe<
-                    { readonly __typename?: "User" } & Pick<User, "displayName">
+                    { readonly __typename?: "User" } & Pick<
+                      User,
+                      "id" | "displayName"
+                    >
                   >
                   readonly recordedAt: Maybe<
                     { readonly __typename?: "Date" } & Pick<
@@ -2131,7 +2134,7 @@ export type FormFieldsFragment = {
         | "includeInEditedCollection"
       > & {
           readonly recordedBy: Maybe<
-            { readonly __typename?: "User" } & Pick<User, "displayName">
+            { readonly __typename?: "User" } & Pick<User, "id" | "displayName">
           >
           readonly recordedAt: Maybe<
             { readonly __typename?: "Date" } & Pick<Date, "formattedDate">
@@ -2529,7 +2532,7 @@ export type DocSliceQuery = { readonly __typename?: "Query" } & {
                     readonly recordedBy: Maybe<
                       { readonly __typename?: "User" } & Pick<
                         User,
-                        "displayName"
+                        "id" | "displayName"
                       >
                     >
                     readonly recordedAt: Maybe<
@@ -2914,7 +2917,10 @@ export type UpdateWordMutation = { readonly __typename?: "Mutation" } & {
           | "includeInEditedCollection"
         > & {
             readonly recordedBy: Maybe<
-              { readonly __typename?: "User" } & Pick<User, "displayName">
+              { readonly __typename?: "User" } & Pick<
+                User,
+                "id" | "displayName"
+              >
             >
             readonly recordedAt: Maybe<
               { readonly __typename?: "Date" } & Pick<Date, "formattedDate">
@@ -3028,7 +3034,10 @@ export type CurateDocumentAudioMutation = {
           | "includeInEditedCollection"
         > & {
             readonly recordedBy: Maybe<
-              { readonly __typename?: "User" } & Pick<User, "displayName">
+              { readonly __typename?: "User" } & Pick<
+                User,
+                "id" | "displayName"
+              >
             >
             readonly recordedAt: Maybe<
               { readonly __typename?: "Date" } & Pick<Date, "formattedDate">
@@ -3523,6 +3532,7 @@ export const AudioSliceFieldsFragmentDoc = gql`
     endTime
     includeInEditedCollection
     recordedBy {
+      id
       displayName
     }
     recordedAt {
@@ -3647,6 +3657,10 @@ export const FormFieldsFragmentDoc = gql`
     commentary
     ingestedAudioTrack {
       ...AudioSliceFields
+      recordedBy {
+        id
+        displayName
+      }
     }
     editedAudio {
       ...AudioSliceFields

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -108,6 +108,7 @@ fragment AudioSliceFields on AudioSlice {
   endTime
   includeInEditedCollection
   recordedBy {
+    id
     displayName
   }
   recordedAt {
@@ -219,6 +220,10 @@ fragment FormFields on AnnotatedForm {
   commentary
   ingestedAudioTrack {
     ...AudioSliceFields
+    recordedBy {
+      id
+      displayName
+    }
   }
   editedAudio {
     ...AudioSliceFields

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -1,17 +1,18 @@
 import { groupBy } from "lodash"
-import { set } from "lodash"
-import React, { ReactNode, useState } from "react"
+import React, { ReactNode } from "react"
 import {
   DragDropContext,
   Draggable,
   DropResult,
   Droppable,
 } from "react-beautiful-dnd"
+import { isMobile } from "react-device-detect"
 import {
   AiFillCaretDown,
   AiFillCaretUp,
   AiFillSound,
 } from "react-icons/ai/index"
+import { FiDownload } from "react-icons/fi/index"
 import { IoBookmarks, IoEllipsisHorizontalCircle } from "react-icons/io5/index"
 import {
   MdDragIndicator,
@@ -24,7 +25,8 @@ import { Disclosure, DisclosureContent, useDisclosureState } from "reakit"
 import { unstable_Form as Form, unstable_FormInput as FormInput } from "reakit"
 import { useMutation, useQuery } from "urql"
 import * as Dailp from "src/graphql/dailp"
-import { AudioPlayer } from "./components"
+import { UserRole, useUserRole } from "./auth"
+import { AudioPlayer, Button } from "./components"
 import { CommentSection } from "./components/comment-section"
 import { CustomCreatable } from "./components/creatable"
 import { EditWordAudio } from "./components/edit-word-audio"
@@ -76,13 +78,18 @@ export const WordPanel = (p: {
   } else {
     setRomanizedSource("")
   }
-  // what should be used to render word features? eg, syllabary, commentary, etc.
+
+  const role = useUserRole()
+
   const PanelFeatureComponent =
     p.panel === PanelType.EditWordPanel ? EditWordFeature : WordFeature
 
-  // what should be used to render word audio, if present?
-  const PanelAudioComponent =
-    p.panel === PanelType.EditWordPanel ? EditWordAudio : WordAudio
+  // Word audios now display for editors and contributors' own audios in view mode
+  const displayAudios =
+    p.panel === PanelType.EditWordPanel ||
+    role === UserRole.Editor ||
+    role === UserRole.Admin ||
+    role === UserRole.Contributor
 
   // Contains components rendering data of a word's phonetics.
   const phoneticsContent = (
@@ -157,17 +164,17 @@ export const WordPanel = (p: {
 
   return (
     <>
-      {(p.word.editedAudio.length || p.panel === PanelType.EditWordPanel) && (
-        <>
-          <CollapsiblePanel
-            title={"Audio"}
-            content={<PanelAudioComponent word={p.word} />}
-            icon={
-              <AiFillSound size={24} className={css.wordPanelButton.colpleft} />
-            }
-          />
-          <RecordWordAudioPanel word={p.word} />
-        </>
+      {(p.word.editedAudio.length > 0 || displayAudios) && (
+        <CollapsiblePanel
+          title={"Audio"}
+          content={<EditWordAudio word={p.word} />}
+          icon={
+            <AiFillSound size={24} className={css.wordPanelButton.colpleft} />
+          }
+        />
+      )}
+      {p.panel === PanelType.EditWordPanel && (
+        <RecordWordAudioPanel word={p.word} />
       )}
       <CollapsiblePanel
         title={"Phonetics"}
@@ -580,29 +587,29 @@ export const WordAudio = (p: { word: Dailp.FormFieldsFragment }) => {
   return (
     <>
       {p.word.editedAudio.map((audioTrack) => (
-        <AudioPlayer
-          contributor={
-            audioTrack.recordedBy?.displayName ?? "Unknown Contributor"
-          }
-          recordedAt={
-            audioTrack.recordedAt?.formattedDate
-              ? new Date(audioTrack.recordedAt.formattedDate)
-              : new Date()
-          }
-          audioUrl={audioTrack.resourceUrl}
-          slices={
-            audioTrack.startTime !== undefined &&
-            audioTrack.startTime !== null &&
-            audioTrack.endTime !== undefined &&
-            audioTrack.endTime !== null
-              ? {
-                  start: audioTrack.startTime,
-                  end: audioTrack.endTime,
-                }
-              : undefined
-          }
-          showProgress
-        />
+        <>
+          <AudioPlayer
+            contributor={audioTrack.recordedBy?.displayName}
+            recordedAt={
+              audioTrack.recordedAt?.formattedDate
+                ? new Date(audioTrack.recordedAt.formattedDate)
+                : new Date()
+            }
+            audioUrl={audioTrack.resourceUrl}
+            slices={
+              audioTrack.startTime !== undefined &&
+              audioTrack.startTime !== null &&
+              audioTrack.endTime !== undefined &&
+              audioTrack.endTime !== null
+                ? {
+                    start: audioTrack.startTime,
+                    end: audioTrack.endTime,
+                  }
+                : undefined
+            }
+            showProgress
+          />
+        </>
       ))}
     </>
   )

--- a/website/src/word-panel.tsx
+++ b/website/src/word-panel.tsx
@@ -13,7 +13,11 @@ import {
   AiFillSound,
 } from "react-icons/ai/index"
 import { FiDownload } from "react-icons/fi/index"
-import { IoBookmarks, IoEllipsisHorizontalCircle } from "react-icons/io5/index"
+import {
+  IoBookmarks,
+  IoEllipsisHorizontalCircle,
+  IoLockClosed,
+} from "react-icons/io5/index"
 import {
   MdDragIndicator,
   MdNotes,
@@ -29,7 +33,10 @@ import { UserRole, useUserRole } from "./auth"
 import { AudioPlayer, Button } from "./components"
 import { CommentSection } from "./components/comment-section"
 import { CustomCreatable } from "./components/creatable"
-import { EditWordAudio } from "./components/edit-word-audio"
+import {
+  EditWordAudio,
+  UnpublishedWordAudio,
+} from "./components/edit-word-audio"
 import { RecordWordAudioPanel } from "./components/edit-word-audio/record"
 import { useEditWordCheckContext } from "./edit-word-check-context"
 import { EditWordFeature } from "./edit-word-feature"
@@ -85,8 +92,7 @@ export const WordPanel = (p: {
     p.panel === PanelType.EditWordPanel ? EditWordFeature : WordFeature
 
   // Word audios now display for editors and contributors' own audios in view mode
-  const displayAudios =
-    p.panel === PanelType.EditWordPanel ||
+  const canSeeUnpublishedAudio =
     role === UserRole.Editor ||
     role === UserRole.Admin ||
     role === UserRole.Contributor
@@ -164,12 +170,31 @@ export const WordPanel = (p: {
 
   return (
     <>
-      {(p.word.editedAudio.length > 0 || displayAudios) && (
+      {p.word.editedAudio.length > 0 && (
         <CollapsiblePanel
           title={"Audio"}
-          content={<EditWordAudio word={p.word} />}
+          content={
+            <EditWordAudio
+              word={p.word}
+              editable={p.panel === PanelType.EditWordPanel}
+            />
+          }
           icon={
             <AiFillSound size={24} className={css.wordPanelButton.colpleft} />
+          }
+        />
+      )}
+      {canSeeUnpublishedAudio && (
+        <CollapsiblePanel
+          title={"Unpublished Audios"}
+          content={
+            <UnpublishedWordAudio
+              word={p.word}
+              editable={p.panel === PanelType.EditWordPanel}
+            />
+          }
+          icon={
+            <IoLockClosed size={24} className={css.wordPanelButton.colpleft} />
           }
         />
       )}
@@ -186,6 +211,7 @@ export const WordPanel = (p: {
           />
         }
       />
+
       {/* Always show Word Parts panel in edit mode, otherwise only if there are segments */}
       {(p.word.englishGloss.length > 0 ||
         p.panel === PanelType.EditWordPanel) && (


### PR DESCRIPTION
Now, when an audio is recorded by a contributor, it will display their own recorded audios in the view page to show that it was saved. Similarly, from an editor perspective, the word panel does not need to be in edit mode to view and toggle recorded audios, including contributor audios, just as the overall document audio works currently. 

**EDIT**
The following changes have been made:
1. As an editor, the view word panel has been changed to add published audios and unpublished audios. Here, audios recorded by the current user are separated by the audios recorded by other editors or  contributors. Only upon clicking the edit button are editors able  to toggle the  visibility of an audio track.
2. As a contributor, the same unpublished and published audio dropdowns are visible but only display their own contributions in the  unpublished section. Upon editing, they are unable to make any changes.
3. As a viewer, the experience is the same and all published audios are grouped.
