### PR TITLE
Expose ETag Header for multi-part uploads

### DIFF
--- a/terraform/media-storage.nix
+++ b/terraform/media-storage.nix
@@ -16,6 +16,7 @@
         allowed_headers = ["*"];
         allowed_methods = ["GET" "PUT" "POST"];
         allowed_origins = ["*"];
+        expose_headers   = ["ETag"]; # Required for multipart uploads
         max_age_seconds = 3600;
       };
       


### PR DESCRIPTION
After merging into main, the terraform can run which updates the CORS configuration. I can then start testing multi-part uploads on my other branch.