### PR TITLE
Import invoke lambda policy

### DIFF
--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -7,6 +7,7 @@ in {
       name = prefixName "lambda-execution";
       managed_policy_arns = [
         "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+        "\${aws_iam_policy.invoke_outbound_turnstile.arn}"
       ];
       
       assume_role_policy = ''

--- a/terraform/import.nix
+++ b/terraform/import.nix
@@ -15,5 +15,9 @@ in {
       to = "module.bastion_host.aws_instance.default[0]";
       id = builtins.getEnv "BASTION_ID";
     }
+    {
+      to = "aws_iam_policy.invoke_outbound_turnstile";
+      id = arn:aws:iam::783177801354:policy/invoke-outbound-turnstile;
+    }
   ];
 }

--- a/terraform/outbound-lambda.nix
+++ b/terraform/outbound-lambda.nix
@@ -23,7 +23,25 @@ in {
     };
     tags = config.setup.global_tags // config.functions.tags;
   };
+
   resource.aws_iam_policy.invoke_outbound_turnstile = {
+    policy = ''
+      {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+            "Sid": "invokeoutboundturnstile",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:InvokeFunction"
+            ],
+            "Resource": [
+                "arn:aws:lambda:*:783177801354:function:dailp-*-outbound-turnstile*"
+            ]
+        }
+      ]
+    }
+    '';
     tags = config.setup.global_tags;
   };
 }

--- a/terraform/outbound-lambda.nix
+++ b/terraform/outbound-lambda.nix
@@ -25,8 +25,7 @@ in {
   };
 
   resource.aws_iam_policy.invoke_outbound_turnstile = {
-    policy = ''
-      {
+    policy = ''{
       "Version": "2012-10-17",
       "Statement": [
         {

--- a/terraform/outbound-lambda.nix
+++ b/terraform/outbound-lambda.nix
@@ -41,7 +41,6 @@ in {
       ]
     }
     '';
-    tags = config.setup.global_tags;
   };
 }
 

--- a/terraform/outbound-lambda.nix
+++ b/terraform/outbound-lambda.nix
@@ -25,6 +25,8 @@ in {
   };
 
   resource.aws_iam_policy.invoke_outbound_turnstile = {
+    name = "invoke-outbound-turnstile";
+    description = "Allows our graphQL lambda function to invoke a lambda function that can integrate with services outside the VPC";
     policy = ''{
       "Version": "2012-10-17",
       "Statement": [

--- a/terraform/outbound-lambda.nix
+++ b/terraform/outbound-lambda.nix
@@ -23,5 +23,8 @@ in {
     };
     tags = config.setup.global_tags // config.functions.tags;
   };
+  resource.aws_iam_policy.invoke_outbound_turnstile = {
+    tags = config.setup.global_tags;
+  };
 }
 


### PR DESCRIPTION
Binds existing `invoke-outbound-turnstile` IAM policy and its references to our Terraform config. Needed to allow our GQL lambda to invoke our outbound lambda.