### PR TITLE
comment out old amplify webhook

### DIFF
--- a/terraform/website.nix
+++ b/terraform/website.nix
@@ -124,14 +124,14 @@ in {
       wait_for_verification = false;
     };
 
-    aws_amplify_webhook.current_stage = {
-      app_id = "\${aws_amplify_app.dailp.id}";
-      branch_name = "\${aws_amplify_branch.current_stage.branch_name}";
-      description = "Build front-end environment";
-    };
+    # aws_amplify_webhook.current_stage = {
+    #   app_id = "\${aws_amplify_app.dailp.id}";
+    #   branch_name = "\${aws_amplify_branch.current_stage.branch_name}";
+    #   description = "Build front-end environment";
+    # };
   };
 
-  config.output.amplify_webhook = {
-    value = "\${aws_amplify_webhook.current_stage.url}";
-  };
+  # config.output.amplify_webhook = {
+  #   value = "\${aws_amplify_webhook.current_stage.url}";
+  # };
 }


### PR DESCRIPTION
Earlier this year, we replaced our hand-spun webhook with Amplify's unifying webhook as prompted by the AWS console. This PR removes the terraform code for the old webhook model in an attempt to fix a terraform build issue impacting all GitHub Actions flows (see below). For more information about the unifying webhook, see https://aws.amazon.com/blogs/mobile/simplifying-multi-app-management-in-aws-amplify-hosting/

GitHub Actions Error:
```
Error: unexpected format for ARN resource (webhooks/0de9ce00-121d-4584-823f-ec6a979b910a)
with aws_amplify_webhook.current_stage,
on config.tf.json line 365, in resource.aws_amplify_webhook.current_stage:
  365:       }
```