### PR TITLE
#803 Asset Library back-end work with avoidOptionals conflict unsolved

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -886,6 +886,61 @@ type EditedCollection {
 	chapters: [CollectionChapter!]
 }
 
+"""
+A file in the shared asset library, pointing at an object in S3.
+"""
+type File {
+	"""
+	UUID for the file
+	"""
+	id: UUID!
+	"""
+	Folder holding this file, or null at the root of the library
+	"""
+	folderId: UUID
+	"""
+	URL that the file's bytes are served from
+	"""
+	s3Url: String!
+	"""
+	Display name of the file
+	"""
+	name: String!
+}
+
+
+"""
+A folder in the shared asset library. Folders form a tree; a folder with no
+parent sits at the root of the library.
+"""
+type Folder {
+	"""
+	UUID for the folder
+	"""
+	id: UUID!
+	"""
+	Folder this one sits inside, or null at the root of the library
+	"""
+	parentId: UUID
+	"""
+	Display name of the folder
+	"""
+	name: String!
+}
+
+"""
+Everything directly inside a single folder (one level) like the unix `ls` command.
+"""
+type FolderContents {
+	"""
+	Subfolders directly inside this folder
+	"""
+	folders: [Folder!]!
+	"""
+	Files directly inside this folder
+	"""
+	files: [File!]!
+}
 
 """
 Stores the physical or digital medium associated with a document
@@ -1324,6 +1379,32 @@ type Mutation {
 	Inverts associated collection's visiblity
 	"""
 	toggleCollectionVisibility(collectionId: UUID!): EditedCollection!
+	"""
+	Create an asset-library folder. A null `parentId` places it at the root.
+	"""
+	createFolder(parentId: UUID, name: String!): Folder!
+	"""
+	Record a file that has already been uploaded to S3. A null `folderId`
+	places it at the root.
+	"""
+	createFile(folderId: UUID, name: String!, s3Url: String!): File!
+	"""
+	Rename a folder.
+	"""
+	renameFolder(id: UUID!, name: String!): Folder!
+	"""
+	Rename a file.
+	"""
+	renameFile(id: UUID!, name: String!): File!
+	"""
+	Move a folder under a new parent. A null `parentId` moves it to the root.
+	Descendants follow automatically since they reference the folder's id.
+	"""
+	moveFolder(id: UUID!, parentId: UUID): Folder!
+	"""
+	Move a file into another folder. A null `folderId` moves it to the root.
+	"""
+	moveFile(id: UUID!, folderId: UUID): File!
 }
 
 """
@@ -1541,6 +1622,11 @@ type Query {
 	Fetch all available subject headings.
 	"""
 	allSubjectHeadings: [SubjectHeading!]!
+	"""
+	Everything directly inside an asset-library folder - subfolders and files
+	One level deep. Pass a null `folderId` to list the root.
+	"""
+	folderContents(folderId: UUID): FolderContents!
 }
 
 """

--- a/graphql/src/query.rs
+++ b/graphql/src/query.rs
@@ -1,6 +1,7 @@
 //! This piece of the project exposes a GraphQL endpoint that allows one to access DAILP data in a federated manner with specific queries.
 
 use dailp::{
+    asset_library::{File, Folder, FolderContents},
     async_graphql::InputType,
     auth::{AuthGuard, GroupGuard, NotGroupGuard, UserGroup, UserInfo},
     collection,
@@ -418,6 +419,21 @@ impl Query {
         let db = context.data::<DataLoader<Database>>()?.loader();
 
         Ok(db.all_subject_headings().await?)
+    }
+
+    /// Everything directly inside an asset-library folder - subfolders and files
+    /// One level deep. Pass a null `folderId` to list the root.
+    #[graphql(guard = "GroupGuard::new(UserGroup::Editors)")]
+    async fn folder_contents(
+        &self,
+        context: &Context<'_>,
+        folder_id: Option<Uuid>,
+    ) -> FieldResult<FolderContents> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .list_folder_contents(folder_id)
+            .await?)
     }
 }
 
@@ -1046,6 +1062,99 @@ impl Mutation {
             .data::<DataLoader<Database>>()?
             .loader()
             .toggle_collection_visibility(collection_id)
+            .await?)
+    }
+
+    /// Create an asset-library folder. A null `parentId` places it at the root.
+    #[graphql(guard = "GroupGuard::new(UserGroup::Editors)")]
+    async fn create_folder(
+        &self,
+        context: &Context<'_>,
+        parent_id: Option<Uuid>,
+        name: String,
+    ) -> FieldResult<Folder> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .insert_folder(parent_id, &name)
+            .await?)
+    }
+
+    /// Record a file that has already been uploaded to S3. A null `folderId`
+    /// places it at the root.
+    #[graphql(guard = "GroupGuard::new(UserGroup::Editors)")]
+    async fn create_file(
+        &self,
+        context: &Context<'_>,
+        folder_id: Option<Uuid>,
+        name: String,
+        s3_url: String,
+    ) -> FieldResult<File> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .insert_file(folder_id, &name, &s3_url)
+            .await?)
+    }
+
+    /// Rename a folder.
+    #[graphql(guard = "GroupGuard::new(UserGroup::Editors)")]
+    async fn rename_folder(
+        &self,
+        context: &Context<'_>,
+        id: Uuid,
+        name: String,
+    ) -> FieldResult<Folder> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .rename_folder(id, &name)
+            .await?)
+    }
+
+    /// Rename a file.
+    #[graphql(guard = "GroupGuard::new(UserGroup::Editors)")]
+    async fn rename_file(
+        &self,
+        context: &Context<'_>,
+        id: Uuid,
+        name: String,
+    ) -> FieldResult<File> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .rename_file(id, &name)
+            .await?)
+    }
+
+    /// Move a folder under a new parent. A null `parentId` moves it to the root.
+    /// Descendants follow automatically since they reference the folder's id.
+    #[graphql(guard = "GroupGuard::new(UserGroup::Editors)")]
+    async fn move_folder(
+        &self,
+        context: &Context<'_>,
+        id: Uuid,
+        parent_id: Option<Uuid>,
+    ) -> FieldResult<Folder> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .move_folder(id, parent_id)
+            .await?)
+    }
+
+    /// Move a file into another folder. A null `folderId` moves it to the root.
+    #[graphql(guard = "GroupGuard::new(UserGroup::Editors)")]
+    async fn move_file(
+        &self,
+        context: &Context<'_>,
+        id: Uuid,
+        folder_id: Option<Uuid>,
+    ) -> FieldResult<File> {
+        Ok(context
+            .data::<DataLoader<Database>>()?
+            .loader()
+            .move_file(id, folder_id)
             .await?)
     }
 }

--- a/types/migrations/20260708112029_add-asset-library.sql
+++ b/types/migrations/20260708112029_add-asset-library.sql
@@ -1,0 +1,14 @@
+create table folders (
+  id uuid primary key,
+  parent_id uuid references folders(id),
+  name text not null,
+  unique (parent_id, name)
+);
+
+create table files (
+  id uuid primary key,
+  folder_id uuid references folders(id),
+  s3_url text not null,
+  name text not null,
+  unique (folder_id, name)
+);

--- a/types/queries/delete_file.sql
+++ b/types/queries/delete_file.sql
@@ -1,0 +1,4 @@
+-- Delete a file. $1 id
+delete from files
+where id = $1
+returning id, folder_id, s3_url, name;

--- a/types/queries/delete_folder.sql
+++ b/types/queries/delete_folder.sql
@@ -1,0 +1,6 @@
+-- Delete a folder. $1 id
+-- Fails if the folder still holds subfolders or files: both foreign keys restrict
+-- by default, so contents must be moved or deleted first.
+delete from folders
+where id = $1
+returning id, parent_id, name;

--- a/types/queries/folder_subtree_contains.sql
+++ b/types/queries/folder_subtree_contains.sql
@@ -1,0 +1,12 @@
+-- True if folder $2 is $1 itself or one of $1's descendants.
+-- Used to reject folder moves that would create a cycle.
+-- Collects $1 and everything beneath it, then checks whether the proposed new
+-- parent ($2) falls inside that subtree.
+with recursive subtree as (
+  select id from folders where id = $1
+  union all
+  select f.id
+  from folders f
+  join subtree s on f.parent_id = s.id
+)
+select exists (select 1 from subtree where id = $2) as "contained!";

--- a/types/queries/insert_file.sql
+++ b/types/queries/insert_file.sql
@@ -1,0 +1,4 @@
+-- Create a file. $1 folder_id, $2 name, $3 s3_url
+insert into files (id, folder_id, name, s3_url)
+values (uuid_generate_v4(), $1, $2, $3)
+returning id, folder_id, s3_url, name;

--- a/types/queries/insert_folder.sql
+++ b/types/queries/insert_folder.sql
@@ -1,0 +1,4 @@
+-- Create a folder. $1 parent_id (null = root), $2 name
+insert into folders (id, parent_id, name)
+values (uuid_generate_v4(), $1, $2)
+returning id, parent_id, name;

--- a/types/queries/list_files.sql
+++ b/types/queries/list_files.sql
@@ -1,0 +1,7 @@
+-- Files directly inside folder $1. Pass null to list the root.
+-- `is not distinct from` is used so a null $1 matches the root's null parent_id,
+-- which a plain `=` never would.
+select id, folder_id, s3_url, name
+from files
+where folder_id is not distinct from $1
+order by name;

--- a/types/queries/list_folders.sql
+++ b/types/queries/list_folders.sql
@@ -1,0 +1,7 @@
+-- Immediate subfolders of $1. Pass null to list the root.
+-- `is not distinct from` is used so a null $1 matches the root's null parent_id,
+-- which a plain `=` never would.
+select id, parent_id, name
+from folders
+where parent_id is not distinct from $1
+order by name;

--- a/types/queries/move_file.sql
+++ b/types/queries/move_file.sql
@@ -1,0 +1,5 @@
+-- Move a file into another folder. $1 id, $2 new folder_id
+update files
+set folder_id = $2
+where id = $1
+returning id, folder_id, s3_url, name;

--- a/types/queries/move_folder.sql
+++ b/types/queries/move_folder.sql
@@ -1,0 +1,6 @@
+-- Move a folder under a new parent. $1 id, $2 new parent_id (null = root).
+-- Descendants need no update: they point at this folder's id, which does not change.
+update folders
+set parent_id = $2
+where id = $1
+returning id, parent_id, name;

--- a/types/queries/rename_file.sql
+++ b/types/queries/rename_file.sql
@@ -1,0 +1,5 @@
+-- Rename a file. $1 id, $2 new name
+update files
+set name = $2
+where id = $1
+returning id, folder_id, s3_url, name;

--- a/types/queries/rename_folder.sql
+++ b/types/queries/rename_folder.sql
@@ -1,0 +1,5 @@
+-- Rename a folder. $1 id, $2 new name
+update folders
+set name = $2
+where id = $1
+returning id, parent_id, name;

--- a/types/src/asset_library.rs
+++ b/types/src/asset_library.rs
@@ -1,0 +1,35 @@
+use uuid::Uuid;
+
+/// A folder in the shared asset library. Folders form a tree; a folder with no
+/// parent sits at the root of the library.
+#[derive(Debug, Clone, async_graphql::SimpleObject)]
+pub struct Folder {
+    /// UUID for the folder
+    pub id: Uuid,
+    /// Folder this one sits inside, or null at the root of the library
+    pub parent_id: Option<Uuid>,
+    /// Display name of the folder
+    pub name: String,
+}
+
+/// A file in the shared asset library, pointing at an object in S3.
+#[derive(Debug, Clone, async_graphql::SimpleObject)]
+pub struct File {
+    /// UUID for the file
+    pub id: Uuid,
+    /// Folder holding this file, or null at the root of the library
+    pub folder_id: Option<Uuid>,
+    /// URL that the file's bytes are served from
+    pub s3_url: String,
+    /// Display name of the file
+    pub name: String,
+}
+
+/// Everything directly inside a single folder (one level) like the unix `ls` command.
+#[derive(Debug, Clone, async_graphql::SimpleObject)]
+pub struct FolderContents {
+    /// Subfolders directly inside this folder
+    pub folders: Vec<Folder>,
+    /// Files directly inside this folder
+    pub files: Vec<File>,
+}

--- a/types/src/database_sql.rs
+++ b/types/src/database_sql.rs
@@ -10,6 +10,7 @@ use std::ptr::null;
 use std::str::FromStr;
 use user::UserUpdate;
 
+use crate::asset_library::{File, Folder, FolderContents};
 use crate::collection::CollectionChapter;
 use crate::collection::EditedCollection;
 use crate::comment::{Comment, CommentParentType, CommentType, CommentUpdate};
@@ -696,6 +697,120 @@ impl Database {
                 .fetch_all(&self.client)
                 .await?,
         )
+    }
+
+    // --- Asset library: folders ---
+
+    /// Create a folder. `parent_id` of `None` places it at the root.
+    pub async fn insert_folder(&self, parent_id: Option<Uuid>, name: &str) -> Result<Folder> {
+        Ok(
+            query_file_as!(Folder, "queries/insert_folder.sql", parent_id, name)
+                .fetch_one(&self.client)
+                .await?,
+        )
+    }
+
+    /// Rename a folder.
+    pub async fn rename_folder(&self, id: Uuid, name: &str) -> Result<Folder> {
+        Ok(
+            query_file_as!(Folder, "queries/rename_folder.sql", id, name)
+                .fetch_one(&self.client)
+                .await?,
+        )
+    }
+
+    /// Move a folder under a new parent (`None` = root). Descendants ride along
+    /// unchanged since they reference this folder's unchanged id.
+    ///
+    /// Rejects moving a folder into itself or one of its own descendants, which
+    /// would detach that subtree from the root and create a cycle.
+    pub async fn move_folder(&self, id: Uuid, parent_id: Option<Uuid>) -> Result<Folder> {
+        if let Some(new_parent) = parent_id {
+            let would_cycle =
+                query_file_scalar!("queries/folder_subtree_contains.sql", id, new_parent)
+                    .fetch_one(&self.client)
+                    .await?;
+            if would_cycle {
+                return Err(anyhow::anyhow!(
+                    "Cannot move a folder into itself or one of its descendants"
+                ));
+            }
+        }
+        Ok(
+            query_file_as!(Folder, "queries/move_folder.sql", id, parent_id)
+                .fetch_one(&self.client)
+                .await?,
+        )
+    }
+
+    /// Delete a folder. Errors if it still holds subfolders or files.
+    pub async fn delete_folder(&self, id: Uuid) -> Result<Folder> {
+        Ok(query_file_as!(Folder, "queries/delete_folder.sql", id)
+            .fetch_one(&self.client)
+            .await?)
+    }
+
+    /// Immediate subfolders of `parent_id` (`None` lists the root).
+    pub async fn list_folders(&self, parent_id: Option<Uuid>) -> Result<Vec<Folder>> {
+        Ok(
+            query_file_as!(Folder, "queries/list_folders.sql", parent_id)
+                .fetch_all(&self.client)
+                .await?,
+        )
+    }
+
+    // --- Asset library: files ---
+
+    /// Record a file that has already been uploaded to S3. `folder_id` of `None`
+    /// places it at the root.
+    pub async fn insert_file(
+        &self,
+        folder_id: Option<Uuid>,
+        name: &str,
+        s3_url: &str,
+    ) -> Result<File> {
+        Ok(
+            query_file_as!(File, "queries/insert_file.sql", folder_id, name, s3_url)
+                .fetch_one(&self.client)
+                .await?,
+        )
+    }
+
+    /// Rename a file.
+    pub async fn rename_file(&self, id: Uuid, name: &str) -> Result<File> {
+        Ok(query_file_as!(File, "queries/rename_file.sql", id, name)
+            .fetch_one(&self.client)
+            .await?)
+    }
+
+    /// Move a file into another folder (`None` = root).
+    pub async fn move_file(&self, id: Uuid, folder_id: Option<Uuid>) -> Result<File> {
+        Ok(query_file_as!(File, "queries/move_file.sql", id, folder_id)
+            .fetch_one(&self.client)
+            .await?)
+    }
+
+    /// Delete a file.
+    pub async fn delete_file(&self, id: Uuid) -> Result<File> {
+        Ok(query_file_as!(File, "queries/delete_file.sql", id)
+            .fetch_one(&self.client)
+            .await?)
+    }
+
+    /// Files directly inside `folder_id` (`None` lists the root).
+    pub async fn list_files(&self, folder_id: Option<Uuid>) -> Result<Vec<File>> {
+        Ok(query_file_as!(File, "queries/list_files.sql", folder_id)
+            .fetch_all(&self.client)
+            .await?)
+    }
+
+    /// Everything directly inside a folder (`None` = root) - the library's `ls`.
+    /// Combines the subfolder and file listings into one `FolderContents`.
+    pub async fn list_folder_contents(&self, folder_id: Option<Uuid>) -> Result<FolderContents> {
+        Ok(FolderContents {
+            folders: self.list_folders(folder_id).await?,
+            files: self.list_files(folder_id).await?,
+        })
     }
 
     /// Ensure that a user exists in the database

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -28,6 +28,7 @@ mod audio;
 /// based on the user making the request.
 pub mod auth;
 
+pub mod asset_library;
 mod cherokee;
 pub mod collection;
 pub mod comment;

--- a/website/src/graphql/dailp/index.ts
+++ b/website/src/graphql/dailp/index.ts
@@ -669,6 +669,42 @@ export type EditedCollection = {
   readonly wordpressMenuId: Maybe<Scalars["Int"]>
 }
 
+/** A file in the shared asset library, pointing at an object in S3. */
+export type File = {
+  readonly __typename?: "File"
+  /** Folder holding this file, or null at the root of the library */
+  readonly folderId: Maybe<Scalars["UUID"]>
+  /** UUID for the file */
+  readonly id: Scalars["UUID"]
+  /** Display name of the file */
+  readonly name: Scalars["String"]
+  /** URL that the file's bytes are served from */
+  readonly s3Url: Scalars["String"]
+}
+
+/**
+ * A folder in the shared asset library. Folders form a tree; a folder with no
+ * parent sits at the root of the library.
+ */
+export type Folder = {
+  readonly __typename?: "Folder"
+  /** UUID for the folder */
+  readonly id: Scalars["UUID"]
+  /** Display name of the folder */
+  readonly name: Scalars["String"]
+  /** Folder this one sits inside, or null at the root of the library */
+  readonly parentId: Maybe<Scalars["UUID"]>
+}
+
+/** Everything directly inside a single folder (one level) like the unix `ls` command. */
+export type FolderContents = {
+  readonly __typename?: "FolderContents"
+  /** Files directly inside this folder */
+  readonly files: ReadonlyArray<File>
+  /** Subfolders directly inside this folder */
+  readonly folders: ReadonlyArray<Folder>
+}
+
 /** Stores the physical or digital medium associated with a document */
 export type Format = {
   readonly __typename?: "Format"
@@ -932,6 +968,13 @@ export type Mutation = {
    */
   readonly attachAudioToWord: AnnotatedForm
   readonly createEditedCollection: Scalars["String"]
+  /**
+   * Record a file that has already been uploaded to S3. A null `folderId`
+   * places it at the root.
+   */
+  readonly createFile: File
+  /** Create an asset-library folder. A null `parentId` places it at the root. */
+  readonly createFolder: Folder
   /** Adds a new subject heading to the global list. */
   readonly createSubjectHeading: SubjectHeading
   /** Decide if a piece of document audio should be included in edited collection */
@@ -946,10 +989,21 @@ export type Mutation = {
   /** Mutation for deleting contributor attributions */
   readonly deleteContributorAttribution: Scalars["UUID"]
   readonly insertCustomMorphemeTag: Scalars["Boolean"]
+  /** Move a file into another folder. A null `folderId` moves it to the root. */
+  readonly moveFile: File
+  /**
+   * Move a folder under a new parent. A null `parentId` moves it to the root.
+   * Descendants follow automatically since they reference the folder's id.
+   */
+  readonly moveFolder: Folder
   /** Post a new comment on a given object */
   readonly postComment: CommentParent
   /** Removes a bookmark from a user's list of bookmarks */
   readonly removeBookmark: AnnotatedDoc
+  /** Rename a file. */
+  readonly renameFile: File
+  /** Rename a folder. */
+  readonly renameFolder: Folder
   /** Inverts associated collection's visiblity */
   readonly toggleCollectionVisibility: EditedCollection
   readonly updateAnnotation: Scalars["Boolean"]
@@ -989,6 +1043,17 @@ export type MutationCreateEditedCollectionArgs = {
   input: CreateEditedCollectionInput
 }
 
+export type MutationCreateFileArgs = {
+  folderId: InputMaybe<Scalars["UUID"]>
+  name: Scalars["String"]
+  s3Url: Scalars["String"]
+}
+
+export type MutationCreateFolderArgs = {
+  name: Scalars["String"]
+  parentId: InputMaybe<Scalars["UUID"]>
+}
+
 export type MutationCreateSubjectHeadingArgs = {
   name: Scalars["String"]
   status: ApprovalStatus
@@ -1016,12 +1081,32 @@ export type MutationInsertCustomMorphemeTagArgs = {
   title: Scalars["String"]
 }
 
+export type MutationMoveFileArgs = {
+  folderId: InputMaybe<Scalars["UUID"]>
+  id: Scalars["UUID"]
+}
+
+export type MutationMoveFolderArgs = {
+  id: Scalars["UUID"]
+  parentId: InputMaybe<Scalars["UUID"]>
+}
+
 export type MutationPostCommentArgs = {
   input: PostCommentInput
 }
 
 export type MutationRemoveBookmarkArgs = {
   documentId: Scalars["UUID"]
+}
+
+export type MutationRenameFileArgs = {
+  id: Scalars["UUID"]
+  name: Scalars["String"]
+}
+
+export type MutationRenameFolderArgs = {
+  id: Scalars["UUID"]
+  name: Scalars["String"]
 }
 
 export type MutationToggleCollectionVisibilityArgs = {
@@ -1183,6 +1268,11 @@ export type Query = {
   /** Retrieves a full document from its unique identifier. */
   readonly documentByUuid: Maybe<AnnotatedDoc>
   readonly editedCollection: Maybe<EditedCollection>
+  /**
+   * Everything directly inside an asset-library folder - subfolders and files
+   * One level deep. Pass a null `folderId` to list the root.
+   */
+  readonly folderContents: FolderContents
   /** Gets all dailp_user with their id, username, and role for now */
   readonly listUsers: ReadonlyArray<User>
   readonly menuBySlug: Menu
@@ -1256,6 +1346,10 @@ export type QueryDocumentByUuidArgs = {
 
 export type QueryEditedCollectionArgs = {
   slug: Scalars["String"]
+}
+
+export type QueryFolderContentsArgs = {
+  folderId: InputMaybe<Scalars["UUID"]>
 }
 
 export type QueryMenuBySlugArgs = {
@@ -3514,6 +3608,110 @@ export type ValidateTurnstileTokenMutation = {
   readonly __typename?: "Mutation"
 } & Pick<Mutation, "validateTurnstileToken">
 
+export type FolderFieldsFragment = { readonly __typename?: "Folder" } & Pick<
+  Folder,
+  "id" | "parentId" | "name"
+>
+
+export type FileFieldsFragment = { readonly __typename?: "File" } & Pick<
+  File,
+  "id" | "folderId" | "s3Url" | "name"
+>
+
+export type FolderContentsQueryVariables = Exact<{
+  folderId: InputMaybe<Scalars["UUID"]>
+}>
+
+export type FolderContentsQuery = { readonly __typename?: "Query" } & {
+  readonly folderContents: { readonly __typename?: "FolderContents" } & {
+    readonly folders: ReadonlyArray<
+      { readonly __typename?: "Folder" } & Pick<
+        Folder,
+        "id" | "parentId" | "name"
+      >
+    >
+    readonly files: ReadonlyArray<
+      { readonly __typename?: "File" } & Pick<
+        File,
+        "id" | "folderId" | "s3Url" | "name"
+      >
+    >
+  }
+}
+
+export type CreateFolderMutationVariables = Exact<{
+  parentId: InputMaybe<Scalars["UUID"]>
+  name: Scalars["String"]
+}>
+
+export type CreateFolderMutation = { readonly __typename?: "Mutation" } & {
+  readonly createFolder: { readonly __typename?: "Folder" } & Pick<
+    Folder,
+    "id" | "parentId" | "name"
+  >
+}
+
+export type CreateFileMutationVariables = Exact<{
+  folderId: InputMaybe<Scalars["UUID"]>
+  name: Scalars["String"]
+  s3Url: Scalars["String"]
+}>
+
+export type CreateFileMutation = { readonly __typename?: "Mutation" } & {
+  readonly createFile: { readonly __typename?: "File" } & Pick<
+    File,
+    "id" | "folderId" | "s3Url" | "name"
+  >
+}
+
+export type RenameFolderMutationVariables = Exact<{
+  id: Scalars["UUID"]
+  name: Scalars["String"]
+}>
+
+export type RenameFolderMutation = { readonly __typename?: "Mutation" } & {
+  readonly renameFolder: { readonly __typename?: "Folder" } & Pick<
+    Folder,
+    "id" | "parentId" | "name"
+  >
+}
+
+export type RenameFileMutationVariables = Exact<{
+  id: Scalars["UUID"]
+  name: Scalars["String"]
+}>
+
+export type RenameFileMutation = { readonly __typename?: "Mutation" } & {
+  readonly renameFile: { readonly __typename?: "File" } & Pick<
+    File,
+    "id" | "folderId" | "s3Url" | "name"
+  >
+}
+
+export type MoveFolderMutationVariables = Exact<{
+  id: Scalars["UUID"]
+  parentId: InputMaybe<Scalars["UUID"]>
+}>
+
+export type MoveFolderMutation = { readonly __typename?: "Mutation" } & {
+  readonly moveFolder: { readonly __typename?: "Folder" } & Pick<
+    Folder,
+    "id" | "parentId" | "name"
+  >
+}
+
+export type MoveFileMutationVariables = Exact<{
+  id: Scalars["UUID"]
+  folderId: InputMaybe<Scalars["UUID"]>
+}>
+
+export type MoveFileMutation = { readonly __typename?: "Mutation" } & {
+  readonly moveFile: { readonly __typename?: "File" } & Pick<
+    File,
+    "id" | "folderId" | "s3Url" | "name"
+  >
+}
+
 export const AudioSliceFieldsFragmentDoc = gql`
   fragment AudioSliceFields on AudioSlice {
     sliceId
@@ -3728,6 +3926,21 @@ export const BookmarkedDocumentFragmentDoc = gql`
     bookmarkedOn {
       formattedDate
     }
+  }
+`
+export const FolderFieldsFragmentDoc = gql`
+  fragment FolderFields on Folder {
+    id
+    parentId
+    name
+  }
+`
+export const FileFieldsFragmentDoc = gql`
+  fragment FileFields on File {
+    id
+    folderId
+    s3Url
+    name
   }
 `
 export const CollectionsListingDocument = gql`
@@ -4811,4 +5024,111 @@ export function useValidateTurnstileTokenMutation() {
     ValidateTurnstileTokenMutation,
     ValidateTurnstileTokenMutationVariables
   >(ValidateTurnstileTokenDocument)
+}
+export const FolderContentsDocument = gql`
+  query FolderContents($folderId: UUID) {
+    folderContents(folderId: $folderId) {
+      folders {
+        ...FolderFields
+      }
+      files {
+        ...FileFields
+      }
+    }
+  }
+  ${FolderFieldsFragmentDoc}
+  ${FileFieldsFragmentDoc}
+`
+
+export function useFolderContentsQuery(
+  options?: Omit<Urql.UseQueryArgs<FolderContentsQueryVariables>, "query">
+) {
+  return Urql.useQuery<FolderContentsQuery, FolderContentsQueryVariables>({
+    query: FolderContentsDocument,
+    ...options,
+  })
+}
+export const CreateFolderDocument = gql`
+  mutation CreateFolder($parentId: UUID, $name: String!) {
+    createFolder(parentId: $parentId, name: $name) {
+      ...FolderFields
+    }
+  }
+  ${FolderFieldsFragmentDoc}
+`
+
+export function useCreateFolderMutation() {
+  return Urql.useMutation<CreateFolderMutation, CreateFolderMutationVariables>(
+    CreateFolderDocument
+  )
+}
+export const CreateFileDocument = gql`
+  mutation CreateFile($folderId: UUID, $name: String!, $s3Url: String!) {
+    createFile(folderId: $folderId, name: $name, s3Url: $s3Url) {
+      ...FileFields
+    }
+  }
+  ${FileFieldsFragmentDoc}
+`
+
+export function useCreateFileMutation() {
+  return Urql.useMutation<CreateFileMutation, CreateFileMutationVariables>(
+    CreateFileDocument
+  )
+}
+export const RenameFolderDocument = gql`
+  mutation RenameFolder($id: UUID!, $name: String!) {
+    renameFolder(id: $id, name: $name) {
+      ...FolderFields
+    }
+  }
+  ${FolderFieldsFragmentDoc}
+`
+
+export function useRenameFolderMutation() {
+  return Urql.useMutation<RenameFolderMutation, RenameFolderMutationVariables>(
+    RenameFolderDocument
+  )
+}
+export const RenameFileDocument = gql`
+  mutation RenameFile($id: UUID!, $name: String!) {
+    renameFile(id: $id, name: $name) {
+      ...FileFields
+    }
+  }
+  ${FileFieldsFragmentDoc}
+`
+
+export function useRenameFileMutation() {
+  return Urql.useMutation<RenameFileMutation, RenameFileMutationVariables>(
+    RenameFileDocument
+  )
+}
+export const MoveFolderDocument = gql`
+  mutation MoveFolder($id: UUID!, $parentId: UUID) {
+    moveFolder(id: $id, parentId: $parentId) {
+      ...FolderFields
+    }
+  }
+  ${FolderFieldsFragmentDoc}
+`
+
+export function useMoveFolderMutation() {
+  return Urql.useMutation<MoveFolderMutation, MoveFolderMutationVariables>(
+    MoveFolderDocument
+  )
+}
+export const MoveFileDocument = gql`
+  mutation MoveFile($id: UUID!, $folderId: UUID) {
+    moveFile(id: $id, folderId: $folderId) {
+      ...FileFields
+    }
+  }
+  ${FileFieldsFragmentDoc}
+`
+
+export function useMoveFileMutation() {
+  return Urql.useMutation<MoveFileMutation, MoveFileMutationVariables>(
+    MoveFileDocument
+  )
 }

--- a/website/src/graphql/dailp/queries.graphql
+++ b/website/src/graphql/dailp/queries.graphql
@@ -824,3 +824,63 @@ mutation UpdateMenu($menu: MenuUpdate!) {
 mutation ValidateTurnstileToken($token: String!) {
   validateTurnstileToken(token: $token)
 }
+
+fragment FolderFields on Folder {
+  id
+  parentId
+  name
+}
+
+fragment FileFields on File {
+  id
+  folderId
+  s3Url
+  name
+}
+
+query FolderContents($folderId: UUID) {
+  folderContents(folderId: $folderId) {
+    folders {
+      ...FolderFields
+    }
+    files {
+      ...FileFields
+    }
+  }
+}
+
+mutation CreateFolder($parentId: UUID, $name: String!) {
+  createFolder(parentId: $parentId, name: $name) {
+    ...FolderFields
+  }
+}
+
+mutation CreateFile($folderId: UUID, $name: String!, $s3Url: String!) {
+  createFile(folderId: $folderId, name: $name, s3Url: $s3Url) {
+    ...FileFields
+  }
+}
+
+mutation RenameFolder($id: UUID!, $name: String!) {
+  renameFolder(id: $id, name: $name) {
+    ...FolderFields
+  }
+}
+
+mutation RenameFile($id: UUID!, $name: String!) {
+  renameFile(id: $id, name: $name) {
+    ...FileFields
+  }
+}
+
+mutation MoveFolder($id: UUID!, $parentId: UUID) {
+  moveFolder(id: $id, parentId: $parentId) {
+    ...FolderFields
+  }
+}
+
+mutation MoveFile($id: UUID!, $folderId: UUID) {
+  moveFile(id: $id, folderId: $folderId) {
+    ...FileFields
+  }
+}


### PR DESCRIPTION
Currently in drafting phase due to outstanding conflicts with the `FolderContents` urql hook.

- Implemented Create, Rename, Move, Delete for both files and folders.
- Implemented `list_folder_contents` which combines the results of `list_files` and `list_folders`
- Linked all operations to GraphQL front end except delete due to undecided design for deleting folders with items in them.