### PR TITLE
#811 Comment Deletion Flag

### DIFF
--- a/doc/database/comments.md
+++ b/doc/database/comments.md
@@ -13,6 +13,8 @@ A single comment left by a user on some piece of DAILP content.
 | `comment_type` | `comment_type_enum`     | A tag specifying the "kind" of comment, ie. a "Story" as opposed to a "Correction"        |
 | `parent_id`    | `uuid -> [parent_type]` | The _uuid of_ the object that this comment is regarding, ie. a specific word or paragraph |
 | `parent_type`  | `comment_parent_type`   | The _kind of_ object that this comment is regarding, ie. a word or paragraph              |
+| `edited`       | `boolean`               | Whether the comment has been edited since it was posted                                   |
+| `deleted_at`   | `timestamp?`            | When the comment was soft-deleted, or `null` if it is still live                          |
 
 - Because polymorphism and foreign key constraints are hard, _there is no fkey constraint on `parent_id`_.
 - Deleting a `dailp_user` deletes all comments made by that user!

--- a/types/migrations/20260805200150_add_comment_deletion_flags.sql
+++ b/types/migrations/20260805200150_add_comment_deletion_flags.sql
@@ -1,0 +1,4 @@
+-- Add column for soft deletion of comments.
+
+alter table comment
+  add column deleted_at timestamp;


### PR DESCRIPTION
Added `deleted_at` as a column for `comment`.
The table already has `posted_at` to track creation, and `posted_by` to tie each row to a user.