### PR TITLE
enable `create_before_destroy` on functions api gateway

### DIFF
--- a/terraform/functions-base.nix
+++ b/terraform/functions-base.nix
@@ -46,11 +46,13 @@ in {
     };
 
     aws_api_gateway_deployment.functions_api = {
+      lifecycle.create_before_destroy = true;
       # Redeploy the API if this file changes, or any functions config changes.
       triggers = let
         inherit (builtins) toJSON hashString removeAttrs mapAttrs;
         removeFunctorFromMembers = set: mapAttrs (memberName: memberValue: removeAttrs memberValue [ "__functor" ]) set;
         hashJSON = x: hashString "sha1" (toJSON x);
+      
       in {
         functions = hashJSON (removeFunctorFromMembers config.resource.aws_lambda_function);
         gateway_integrations =


### PR DESCRIPTION
A routine deploy to our development environment on August 19 failed with the following error message:
```
 Error: deleting API Gateway Deployment (lyuqd9): operation error API Gateway: DeleteDeployment, https response error StatusCode: 400, RequestID: 70f5a8e3-5200-40db-ada2-cbf877857542, BadRequestException: Active stages pointing to this deployment must be moved or deleted
```

This error follows recent updates to our terraform AWS provider, which required refactoring our API gateway from a coupled stage and deployment definition to a decoupled definition using the `aws_api_gateway_stage` resource. Deployments run with the updated terraform configuration seem to encounter a race condition when building the API gateway where the deployment tries to update before the stage. The expected behavior is that the stage is rebuilt first, allowing the original deployment to disconnect from the stage, enabling the rebuild of our api gateway deployment.

To fix this issue, I have added `lifecycle.create_before_destroy` to our API gatewy deployment, allowing the stage to be rewired before attempting to replace the API gateway. This should resolve the race condition described above.